### PR TITLE
Don't double-count pageviews.

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -6,17 +6,8 @@ import ExplorerLayout from "./pages/layout";
 import TransactionPage from "./pages/Transactions/Transaction";
 import AccountPage from "./pages/Accounts/Account";
 import { TransactionsPage } from "./pages/Transactions/Transactions";
-import { useLocation } from "react-router-dom";
-import ReactGA from "react-ga4";
-
 
 export default function ExplorerRoutes() {
-  let location = useLocation();
-
-  React.useEffect(() => {
-    ReactGA.send({hitType: "pageview", page: `${location.pathname}${location.search}`});
-  }, [location]);
-
   return (
     <ExplorerLayout>
       <Routes>


### PR DESCRIPTION
GA4 automatically sends a pageview event when the history state changes:
https://support.google.com/analytics/answer/11403294?hl=en