### PR TITLE
update networks on explorer

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -4,7 +4,7 @@ export const devnetUrl =
 export const networks: Record<string, string> = {
   local: "http://localhost:8080",
   devnet: devnetUrl,
-  "nft-nyc": "https://fullnode.nft-nyc.aptoslabs.com/",
+  "AIT2": "https://ait2.aptosdev.com/",
 };
 
 // Remove trailing slashes


### PR DESCRIPTION
we will be using https://ait2.aptosdev.com as AIT2 public fullnode url. 
The chain is not live yet, but fullnodes already running.

```
curl https://ait2.aptosdev.com
{"chain_id":41,"epoch":0,"ledger_version":"0","ledger_timestamp":"0","node_role":"full_node"}
```