### PR TITLE
fix item might be null error on pagination item

### DIFF
--- a/src/pages/Transactions/Transactions.tsx
+++ b/src/pages/Transactions/Transactions.tsx
@@ -44,7 +44,7 @@ function RenderPagination({
       boundaryCount={0}
       shape="rounded"
       renderItem={(item) => {
-        const delta = (currentPage - item.page) * limit;
+        const delta = (currentPage - (item.page ? item.page : 0)) * limit;
         const newStart = Math.max(
           0,
           Math.min(maxStart(maxVersion, limit), start + delta),


### PR DESCRIPTION
Was getting an `object might be null` error on `yarn start`, this PR is to fix that error.