### PR TITLE
adjust wallet button to light and dark mode

### DIFF
--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -51,7 +51,7 @@ const OldWalletVersionWarning = (): JSX.Element => {
       target="_blank"
     >
       You are using an old wallet version, please install the latest Aptos
-      Wallet extension for a better support
+      Wallet extension.
     </Link>
   );
   return (

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import {
-  Box,
   Button,
   ButtonBaseProps,
   ButtonProps,
@@ -9,6 +8,7 @@ import {
   Stack,
   Tooltip,
   Typography,
+  useTheme,
 } from "@mui/material";
 import {useWalletContext} from "../context/wallet/context";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
@@ -17,19 +17,28 @@ import {truncateAddress} from "../pages/utils";
 import {isUpdatedVersion} from "../api/wallet";
 
 type WalletButtonWrapperProps = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  icon?: JSX.Element;
+  text: string | null;
 };
 
 const WalletButtonWrapper = ({
   children,
+  text,
+  icon,
   ...props
 }: WalletButtonWrapperProps & ButtonBaseProps & ButtonProps): JSX.Element => {
+  const theme = useTheme();
   return (
     <Button
       variant="outlined"
-      sx={{padding: "10px 25px", backgroundColor: "#1B1F1E"}}
+      sx={{padding: "10px 25px", backgroundColor: theme.palette.mode === "dark" ? "#1B1F1E" : "white",color: theme.palette.mode === "dark" ? "#2ED8A7" : "#121615"}}
       {...props}
     >
+      {icon}
+      <Typography variant="body2" color={theme.palette.mode === "dark" ? "white" : "121615"} ml={2}>
+        {text}
+      </Typography>
       {children}
     </Button>
   );
@@ -42,7 +51,7 @@ const OldWalletVersionWarning = (): JSX.Element => {
       target="_blank"
     >
       You are using an old wallet version, please install the latest Aptos
-      Wallet extension for better support
+      Wallet extension for a better support
     </Link>
   );
   return (
@@ -71,11 +80,7 @@ export const WalletButton = (): JSX.Element => {
         }
       >
         <span>
-          <WalletButtonWrapper disabled>
-            <Typography variant="body2" color="white">
-              Connect Wallet
-            </Typography>
-          </WalletButtonWrapper>
+          <WalletButtonWrapper disabled text="Connect Wallet"/>
         </span>
       </Tooltip>
     );
@@ -86,20 +91,12 @@ export const WalletButton = (): JSX.Element => {
   return (
     <>
       {isInstalled && !isConnected && (
-        <WalletButtonWrapper onClick={connect}>
-          <CreditCardIcon />
-          <Typography variant="body2" color="white" ml={2}>
-            Connect Wallet
-          </Typography>
+        <WalletButtonWrapper onClick={connect} text="Connect Wallet" icon={<CreditCardIcon />}>
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}
       {isInstalled && isConnected && (
-        <WalletButtonWrapper>
-          <CreditCardIcon />
-          <Typography variant="body2" color="white" ml={2}>
-            {accountAddress && truncateAddress(accountAddress)}
-          </Typography>
+        <WalletButtonWrapper text={accountAddress && truncateAddress(accountAddress)} icon={<CreditCardIcon />}>
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}


### PR DESCRIPTION
This PR modifies the wallet button to match dark and light mode

Dark mode
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/29798064/183466982-a870e23e-db61-4c3b-8bc5-f8749a770028.png">


Light mode
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/29798064/183467013-60f9abda-7cbc-42ac-90e0-2dc96ae4441f.png">
