### PR TITLE
[Governance] unify table UI for Transactions and Proposals

### DIFF
--- a/src/components/GeneralTableHeaderCell.tsx
+++ b/src/components/GeneralTableHeaderCell.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {Typography, TableCell, useTheme} from "@mui/material";
+import {SxProps} from "@mui/system";
+import {Theme} from "@mui/material/styles";
+
+interface GeneralTableHeaderCellProps {
+  header: React.ReactNode;
+  textAlignRight?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+export default function GeneralTableHeaderCell({
+  header,
+  textAlignRight,
+  sx = [],
+}: GeneralTableHeaderCellProps) {
+  const theme = useTheme();
+  const tableCellBackgroundColor = "transparent";
+  const tableCellTextColor = theme.palette.text.secondary;
+
+  return (
+    <TableCell
+      sx={[
+        {
+          textAlign: textAlignRight ? "right" : "left",
+          background: `${tableCellBackgroundColor}`,
+          color: `${tableCellTextColor}`,
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      <Typography variant="subtitle1">{header}</Typography>
+    </TableCell>
+  );
+}

--- a/src/components/GeneralTableRow.tsx
+++ b/src/components/GeneralTableRow.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {TableRow, useTheme} from "@mui/material";
+import {grey} from "../themes/colors/aptosColorPalette";
+
+interface TableRowProps {
+  children?: React.ReactNode;
+  onClick: () => void;
+}
+
+export default function GeneralTableRow({children, onClick}: TableRowProps) {
+  const theme = useTheme();
+  return (
+    <TableRow
+      onClick={onClick}
+      sx={{
+        cursor: "pointer",
+        userSelect: "none",
+        backgroundColor: `${
+          theme.palette.mode === "dark" ? grey[800] : grey[50]
+        }`,
+        "&:hover:not(:active)": {
+          filter: `${
+            theme.palette.mode === "dark"
+              ? "brightness(0.9)"
+              : "brightness(0.99)"
+          }`,
+        },
+        "&:active": {
+          background: theme.palette.neutralShade.main,
+          transform: "translate(0,0.1rem)",
+        },
+      }}
+    >
+      {children}
+    </TableRow>
+  );
+}

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  Popover,
+  IconButton,
+  useTheme,
+} from "@mui/material";
+import {grey} from "../themes/colors/aptosColorPalette";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
+import {truncateAddress} from "../pages/utils";
+
+interface HashButtonProps {
+  hash: string;
+}
+
+export default function HashButton({hash}: HashButtonProps) {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  const hashExpand = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+
+  const hashCollapse = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+  const theme = useTheme();
+
+  return (
+    <Box>
+      <Button
+        sx={{
+          textTransform: "none",
+          backgroundColor: `${
+            theme.palette.mode === "dark" ? grey[700] : grey[100]
+          }`,
+          display: "flex",
+          borderRadius: 1,
+          color: "inherit",
+          padding: "0.15rem 0.5rem 0.15rem 1rem",
+          "&:hover": {
+            backgroundColor: `${
+              theme.palette.mode === "dark" ? grey[700] : grey[100]
+            }`,
+          },
+        }}
+        aria-describedby={id}
+        onClick={hashExpand}
+        variant="contained"
+        endIcon={<ChevronRightRoundedIcon sx={{opacity: "0.75", m: 0}} />}
+      >
+        {truncateAddress(hash)}
+      </Button>
+
+      <Popover
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        sx={{
+          overflow: "scroll",
+          ".MuiPaper-root": {boxShadow: "none"},
+          "&.MuiModal-root .MuiBackdrop-root": {
+            transition: "none!important",
+            backgroundColor: `${
+              theme.palette.mode === "dark"
+                ? "rgba(18,22,21,0.5)"
+                : "rgba(255,255,255,0.5)"
+            }`,
+          },
+        }}
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={hashCollapse}
+        anchorOrigin={{
+          vertical: "center",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "center",
+          horizontal: "left",
+        }}
+      >
+        <Typography
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            backgroundColor: `${
+              theme.palette.mode === "dark" ? grey[700] : grey[100]
+            }`,
+            px: 2,
+            py: "0.15rem",
+            fontSize: "14px",
+            overflow: "scroll",
+            scrollbarWidth: "none",
+            "&::-webkit-scrollbar": {
+              display: "none",
+            },
+          }}
+        >
+          {hash}
+          <IconButton
+            aria-label="collapse hash"
+            onClick={hashCollapse}
+            sx={{
+              ml: 1,
+              mr: 0,
+              p: 0,
+              "&.MuiButtonBase-root:hover": {
+                bgcolor: "transparent",
+              },
+            }}
+          >
+            <ChevronLeftRoundedIcon sx={{opacity: "0.5"}} />
+          </IconButton>
+        </Typography>
+      </Popover>
+    </Box>
+  );
+}

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -7,16 +7,11 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import {useNavigate} from "react-router-dom";
-import Popover from "@mui/material/Popover";
-import {IconButton} from "@mui/material";
-import {grey} from "../themes/colors/aptosColorPalette";
-import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
-import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
-
-import Button from "@mui/material/Button";
+import GeneralTableRow from "../components/GeneralTableRow";
+import GeneralTableHeaderCell from "../components/GeneralTableHeaderCell";
+import HashButton from "./HashButton";
 
 import {Types} from "aptos";
 import {
@@ -26,7 +21,6 @@ import {
   renderTransactionType,
 } from "../pages/Transactions/helpers";
 import {assertNever} from "../utils";
-import {truncateAddress} from "../pages/utils";
 
 type TransactionCellProps = {
   transaction: Types.OnChainTransaction;
@@ -82,115 +76,9 @@ function TransactionGasCell({transaction}: TransactionCellProps) {
 }
 
 function TransactionHashCell({transaction}: TransactionCellProps) {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
-    null,
-  );
-
-  const hashExpand = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    setAnchorEl(event.currentTarget);
-  };
-
-  const hashCollapse = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    setAnchorEl(null);
-  };
-
-  const open = Boolean(anchorEl);
-  const id = open ? "simple-popover" : undefined;
-  const theme = useTheme();
-
   return (
     <TableCell>
-      <Box>
-        <Button
-          sx={{
-            textTransform: "none",
-            backgroundColor: `${
-              theme.palette.mode === "dark" ? grey[700] : grey[100]
-            }`,
-            display: "flex",
-            borderRadius: 1,
-            color: "inherit",
-            padding: "0.15rem 0.5rem 0.15rem 1rem",
-            "&:hover": {
-              backgroundColor: `${
-                theme.palette.mode === "dark" ? grey[700] : grey[100]
-              }`,
-            },
-          }}
-          aria-describedby={id}
-          onClick={hashExpand}
-          variant="contained"
-          endIcon={<ChevronRightRoundedIcon sx={{opacity: "0.75", m: 0}} />}
-        >
-          {truncateAddress(transaction.hash)}
-        </Button>
-
-        <Popover
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-          sx={{
-            overflow: "scroll",
-            ".MuiPaper-root": {boxShadow: "none"},
-            "&.MuiModal-root .MuiBackdrop-root": {
-              transition: "none!important",
-              backgroundColor: `${
-                theme.palette.mode === "dark"
-                  ? "rgba(18,22,21,0.5)"
-                  : "rgba(255,255,255,0.5)"
-              }`,
-            },
-          }}
-          id={id}
-          open={open}
-          anchorEl={anchorEl}
-          onClose={hashCollapse}
-          anchorOrigin={{
-            vertical: "center",
-            horizontal: "left",
-          }}
-          transformOrigin={{
-            vertical: "center",
-            horizontal: "left",
-          }}
-        >
-          <Typography
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              backgroundColor: `${
-                theme.palette.mode === "dark" ? grey[700] : grey[100]
-              }`,
-              px: 2,
-              py: "0.15rem",
-              fontSize: "14px",
-              overflow: "scroll",
-              scrollbarWidth: "none",
-              "&::-webkit-scrollbar": {
-                display: "none",
-              },
-            }}
-          >
-            {transaction.hash}
-            <IconButton
-              aria-label="collapse hash"
-              onClick={hashCollapse}
-              sx={{
-                ml: 1,
-                mr: 0,
-                p: 0,
-                "&.MuiButtonBase-root:hover": {
-                  bgcolor: "transparent",
-                },
-              }}
-            >
-              <ChevronLeftRoundedIcon sx={{opacity: "0.5"}} />
-            </IconButton>
-          </Typography>
-        </Popover>
-      </Box>
+      <HashButton hash={transaction.hash} />
     </TableCell>
   );
 }
@@ -223,39 +111,17 @@ type TransactionRowProps = {
 function TransactionRow({transaction, columns}: TransactionRowProps) {
   const navigate = useNavigate();
 
-  const rowClick = (event: React.MouseEvent<unknown>) => {
+  const rowClick = () => {
     navigate(`/txn/${transaction.version}`);
   };
 
-  const theme = useTheme();
-
   return (
-    <TableRow
-      onClick={(event) => rowClick(event)}
-      sx={{
-        cursor: "pointer",
-        userSelect: "none",
-        backgroundColor: `${
-          theme.palette.mode === "dark" ? grey[800] : grey[50]
-        }`,
-        "&:hover:not(:active)": {
-          filter: `${
-            theme.palette.mode === "dark"
-              ? "brightness(0.9)"
-              : "brightness(0.99)"
-          }`,
-        },
-        "&:active": {
-          background: theme.palette.neutralShade.main,
-          transform: "translate(0,0.1rem)",
-        },
-      }}
-    >
+    <GeneralTableRow onClick={rowClick}>
       {columns.map((column) => {
         const Cell = TransactionCells[column];
         return <Cell key={column} transaction={transaction} />;
       })}
-    </TableRow>
+    </GeneralTableRow>
   );
 }
 
@@ -265,83 +131,36 @@ type TransactionHeaderCellProps = {
 
 function TransactionHeaderCell({column}: TransactionHeaderCellProps) {
   const theme = useTheme();
-  const tableCellBackgroundColor = "transparent";
-  const tableCellTextColor = theme.palette.text.secondary;
 
   switch (column) {
     case "version":
-      return (
-        <TableCell
-          sx={{
-            textAlign: "left",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
-          }}
-        >
-          <Typography variant="subtitle1">Version</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Version" />;
     case "type":
-      return (
-        <TableCell
-          sx={{
-            textAlign: "left",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
-          }}
-        >
-          <Typography variant="subtitle1">Type</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Type" />;
     case "hash":
-      return (
-        <TableCell
-          sx={{
-            textAlign: "left",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
-          }}
-        >
-          <Typography variant="subtitle1">Hash</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Hash" />;
     case "status":
       return (
-        <TableCell
+        <GeneralTableHeaderCell
+          header="Status"
           sx={{
-            textAlign: "left",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
             borderRadius: `${theme.shape.borderRadius}px 0 0 ${theme.shape.borderRadius}px`,
           }}
-        >
-          <Typography variant="subtitle1">Status</Typography>
-        </TableCell>
+        />
       );
     case "gas":
       return (
-        <TableCell
+        <GeneralTableHeaderCell
+          header="Gas"
+          textAlignRight={true}
           sx={{
-            textAlign: "right",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
             borderRadius: `0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0`,
           }}
-        >
-          <Typography variant="subtitle1">Gas</Typography>
-        </TableCell>
+        />
       );
     case "timestamp":
       return (
-        <TableCell
-          sx={{
-            textAlign: "right",
-            background: `${tableCellBackgroundColor}`,
-            color: `${tableCellTextColor}`,
-          }}
-        >
-          <Typography variant="subtitle1">Timestamp</Typography>
-        </TableCell>
+        <GeneralTableHeaderCell header="Timestamp" textAlignRight={true} />
       );
     default:
       return assertNever(column);

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -32,19 +32,11 @@ const WalletButtonWrapper = ({
   return (
     <Button
       variant="outlined"
-      sx={{
-        padding: "10px 25px",
-        backgroundColor: theme.palette.mode === "dark" ? "#1B1F1E" : "white",
-        color: theme.palette.mode === "dark" ? "#2ED8A7" : "#121615",
-      }}
+      sx={{padding: "10px 25px", backgroundColor: theme.palette.mode === "dark" ? "#1B1F1E" : "white",color: theme.palette.mode === "dark" ? "#2ED8A7" : "#121615"}}
       {...props}
     >
       {icon}
-      <Typography
-        variant="body2"
-        color={theme.palette.mode === "dark" ? "white" : "121615"}
-        ml={2}
-      >
+      <Typography variant="body2" color={theme.palette.mode === "dark" ? "white" : "121615"} ml={2}>
         {text}
       </Typography>
       {children}
@@ -88,7 +80,7 @@ export const WalletButton = (): JSX.Element => {
         }
       >
         <span>
-          <WalletButtonWrapper disabled text="Connect Wallet" />
+          <WalletButtonWrapper disabled text="Connect Wallet"/>
         </span>
       </Tooltip>
     );
@@ -99,19 +91,12 @@ export const WalletButton = (): JSX.Element => {
   return (
     <>
       {isInstalled && !isConnected && (
-        <WalletButtonWrapper
-          onClick={connect}
-          text="Connect Wallet"
-          icon={<CreditCardIcon />}
-        >
+        <WalletButtonWrapper onClick={connect} text="Connect Wallet" icon={<CreditCardIcon />}>
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}
       {isInstalled && isConnected && (
-        <WalletButtonWrapper
-          text={accountAddress && truncateAddress(accountAddress)}
-          icon={<CreditCardIcon />}
-        >
+        <WalletButtonWrapper text={accountAddress && truncateAddress(accountAddress)} icon={<CreditCardIcon />}>
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -32,11 +32,19 @@ const WalletButtonWrapper = ({
   return (
     <Button
       variant="outlined"
-      sx={{padding: "10px 25px", backgroundColor: theme.palette.mode === "dark" ? "#1B1F1E" : "white",color: theme.palette.mode === "dark" ? "#2ED8A7" : "#121615"}}
+      sx={{
+        padding: "10px 25px",
+        backgroundColor: theme.palette.mode === "dark" ? "#1B1F1E" : "white",
+        color: theme.palette.mode === "dark" ? "#2ED8A7" : "#121615",
+      }}
       {...props}
     >
       {icon}
-      <Typography variant="body2" color={theme.palette.mode === "dark" ? "white" : "121615"} ml={2}>
+      <Typography
+        variant="body2"
+        color={theme.palette.mode === "dark" ? "white" : "121615"}
+        ml={2}
+      >
         {text}
       </Typography>
       {children}
@@ -80,7 +88,7 @@ export const WalletButton = (): JSX.Element => {
         }
       >
         <span>
-          <WalletButtonWrapper disabled text="Connect Wallet"/>
+          <WalletButtonWrapper disabled text="Connect Wallet" />
         </span>
       </Tooltip>
     );
@@ -91,12 +99,19 @@ export const WalletButton = (): JSX.Element => {
   return (
     <>
       {isInstalled && !isConnected && (
-        <WalletButtonWrapper onClick={connect} text="Connect Wallet" icon={<CreditCardIcon />}>
+        <WalletButtonWrapper
+          onClick={connect}
+          text="Connect Wallet"
+          icon={<CreditCardIcon />}
+        >
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}
       {isInstalled && isConnected && (
-        <WalletButtonWrapper text={accountAddress && truncateAddress(accountAddress)} icon={<CreditCardIcon />}>
+        <WalletButtonWrapper
+          text={accountAddress && truncateAddress(accountAddress)}
+          icon={<CreditCardIcon />}
+        >
           {!isWalletLatestVersion && <OldWalletVersionWarning />}
         </WalletButtonWrapper>
       )}

--- a/src/pages/Governance/Proposals/Table.tsx
+++ b/src/pages/Governance/Proposals/Table.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as RRD from "react-router-dom";
-import {Grid, useTheme} from "@mui/material";
 import Title from "../../../components/Title";
 import {
   Stack,
@@ -11,14 +10,19 @@ import {
   TableHead,
   TableRow,
   Typography,
+  Grid,
+  useTheme,
 } from "@mui/material";
 import {renderTimestamp} from "../../Transactions/helpers";
 import {assertNever} from "../../../utils";
 import {Proposal} from "../Types";
 import {useGetProposal} from "../hooks/useGetProposal";
+import GeneralTableRow from "../../../components/GeneralTableRow";
+import GeneralTableHeaderCell from "../../../components/GeneralTableHeaderCell";
+import HashButton from "../../../components/HashButton";
+import {teal} from "../../../themes/colors/aptosColorPalette";
 
 const TITLE_WIDTH = 400;
-const HASH_WIDTH = 300;
 
 type ProposalCellProps = {
   proposal: Proposal;
@@ -31,6 +35,7 @@ function TitleCell({proposal}: ProposalCellProps) {
         component="div"
         sx={{
           width: TITLE_WIDTH,
+          color: teal[500],
           overflow: "hidden",
           textOverflow: "ellipsis",
         }}
@@ -50,16 +55,7 @@ function StatusCell({proposal}: ProposalCellProps) {
 function ProposerCell({proposal}: ProposalCellProps) {
   return (
     <TableCell sx={{textAlign: "left"}}>
-      <Box
-        component="div"
-        sx={{
-          width: HASH_WIDTH,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-        }}
-      >
-        {proposal.proposer}
-      </Box>
+      <HashButton hash={proposal.proposer} />
     </TableCell>
   );
 }
@@ -75,7 +71,7 @@ function TimestampCell({proposal}: ProposalCellProps) {
       </Typography>
     );
 
-  return <TableCell sx={{textAlign: "left"}}>{timestamp}</TableCell>;
+  return <TableCell sx={{textAlign: "right"}}>{timestamp}</TableCell>;
 }
 
 const ProposalCells = Object.freeze({
@@ -109,17 +105,17 @@ function ProposalRow({proposal_id, handle, columns}: ProposalRowProps) {
   };
 
   if (!proposalData) {
-    // returns null as we dont need to generate a TableRow if there is no proposal data
+    // returns null as we don't need to generate a TableRow if there is no proposal data
     return null;
   }
 
   return (
-    <TableRow hover onClick={onTableRowClick}>
+    <GeneralTableRow onClick={onTableRowClick}>
       {columns.map((column) => {
         const Cell = ProposalCells[column];
         return <Cell key={column} proposal={proposalData} />;
       })}
-    </TableRow>
+    </GeneralTableRow>
   );
 }
 
@@ -128,50 +124,16 @@ type ProposalHeaderCellProps = {
 };
 
 function ProposalHeaderCell({column}: ProposalHeaderCellProps) {
-  const theme = useTheme();
-  const tableCellBackgroundColor = theme.palette.background.paper;
-
   switch (column) {
     case "title":
-      return (
-        <TableCell
-          sx={{
-            textAlign: "left",
-            width: "2%",
-            background: `${tableCellBackgroundColor}`,
-            borderRadius: "8px 0 0 8px",
-          }}
-        >
-          <Typography variant="subtitle1">Title</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Title" />;
     case "status":
-      return (
-        <TableCell
-          sx={{textAlign: "left", background: `${tableCellBackgroundColor}`}}
-        >
-          <Typography variant="subtitle1">Status</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Status" />;
     case "proposer":
-      return (
-        <TableCell
-          sx={{textAlign: "left", background: `${tableCellBackgroundColor}`}}
-        >
-          <Typography variant="subtitle1">Proposer</Typography>
-        </TableCell>
-      );
+      return <GeneralTableHeaderCell header="Proposer" />;
     case "timestamp":
       return (
-        <TableCell
-          sx={{
-            textAlign: "left",
-            background: `${tableCellBackgroundColor}`,
-            borderRadius: "0 8px 8px 0",
-          }}
-        >
-          <Typography variant="subtitle1">Timestamp</Typography>
-        </TableCell>
+        <GeneralTableHeaderCell header="Timestamp" textAlignRight={true} />
       );
     default:
       return assertNever(column);


### PR DESCRIPTION
## Nothing changed for Transactions table:
<img width="1558" alt="Screen Shot 2022-08-08 at 5 56 27 PM" src="https://user-images.githubusercontent.com/109111707/183539693-e15299b1-1310-4b38-8853-5f4d892776ae.png">
## Apply same UI design for Proposals table:
<img width="1231" alt="Screen Shot 2022-08-08 at 5 56 43 PM" src="https://user-images.githubusercontent.com/109111707/183539783-660fa804-1e6a-4cc7-8d4a-6428fd26016c.png">

