### PR TITLE
[GOVERNANCE] handle create account event

### DIFF
--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -19,6 +19,19 @@ export const isWalletConnected = async (): Promise<boolean> => {
   return false;
 };
 
+export const isAccountCreated = async (): Promise<boolean> => {
+  try {
+    if (window.aptos) {
+      const res = await window.aptos.isConnected();
+      // if there is an account we are getting a true/false response else we are getting an object type response
+      return typeof res === "boolean";
+    }
+  } catch (error: any) {
+    console.log(error);
+  }
+  return false;
+};
+
 export const connectToWallet = async (): Promise<boolean> => {
   try {
     const result = await window.aptos.connect();

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import {useWalletContext} from "../context/wallet/context";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
+import AddCardIcon from "@mui/icons-material/AddCard";
 import ErrorIcon from "@mui/icons-material/Error";
 import {truncateAddress} from "../pages/utils";
 import {isUpdatedVersion} from "../api/wallet";
@@ -73,7 +74,7 @@ const OldWalletVersionWarning = (): JSX.Element => {
 };
 
 export const WalletButton = (): JSX.Element => {
-  const {isInstalled, isConnected, connect, accountAddress} =
+  const {isInstalled, isConnected, isAccountSet, connect, accountAddress} =
     useWalletContext();
 
   if (!isInstalled) {
@@ -89,7 +90,7 @@ export const WalletButton = (): JSX.Element => {
         }
       >
         <span>
-          <WalletButtonWrapper disabled text="Connect Wallet" />
+          <WalletButtonWrapper disabled text="install Wallet" />
         </span>
       </Tooltip>
     );
@@ -99,7 +100,20 @@ export const WalletButton = (): JSX.Element => {
 
   return (
     <>
-      {isInstalled && !isConnected && (
+      {isInstalled && !isAccountSet && (
+        <Tooltip title="Use the Wallet extension to create an account">
+          <span>
+            <WalletButtonWrapper
+              text="create an account"
+              icon={<AddCardIcon />}
+              sx={{cursor: "default"}}
+            >
+              {!isWalletLatestVersion && <OldWalletVersionWarning />}
+            </WalletButtonWrapper>
+          </span>
+        </Tooltip>
+      )}
+      {isInstalled && isAccountSet && !isConnected && (
         <WalletButtonWrapper
           onClick={connect}
           text="Connect Wallet"

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -3,6 +3,7 @@ import {createContext, useContext} from "react";
 export interface walletContext {
   isInstalled: boolean;
   isConnected: boolean;
+  isAccountSet: boolean;
   accountAddress: string | null;
   connect: () => Promise<void>;
 }

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -4,11 +4,13 @@ import {
   getAccountAddress,
   getAptosWallet,
   isUpdatedVersion,
+  isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
 
 export function useWallet() {
   const [isInstalled, setAptosWallet] = React.useState<boolean>(false);
+  const [isAccountSet, setIsAccountSet] = React.useState<boolean>(false);
   const [isConnected, setIsConnected] = React.useState<boolean>(false);
   const [accountAddress, setAccountAddress] = React.useState<string | null>(
     null,
@@ -19,8 +21,9 @@ export function useWallet() {
   }, []);
 
   useEffect(() => {
+    isAccountCreated().then(setIsAccountSet);
     isWalletConnected().then(setIsConnected);
-  }, [isInstalled, accountAddress]);
+  }, [isInstalled, accountAddress, isAccountSet]);
 
   useEffect(() => {
     // add this check to support older wallet versions
@@ -30,6 +33,8 @@ export function useWallet() {
           setAccountAddress(account.address);
         } else {
           setAccountAddress(null);
+          // this means an account was created but is not connected yet
+          setIsAccountSet(true);
         }
       });
     }
@@ -43,7 +48,8 @@ export function useWallet() {
 
   const connect = async () => {
     connectToWallet().then(setIsConnected);
+    isAccountCreated().then(setIsAccountSet);
   };
 
-  return {isInstalled, isConnected, accountAddress, connect};
+  return {isInstalled, isAccountSet, isConnected, accountAddress, connect};
 }

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -48,7 +48,6 @@ export function useWallet() {
 
   const connect = async () => {
     connectToWallet().then(setIsConnected);
-    isAccountCreated().then(setIsAccountSet);
   };
 
   return {isInstalled, isAccountSet, isConnected, accountAddress, connect};

--- a/src/pages/Governance/Proposals/Instructions.tsx
+++ b/src/pages/Governance/Proposals/Instructions.tsx
@@ -4,6 +4,7 @@ import {
   Divider,
   Grid,
   Link,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -23,9 +24,9 @@ type CardBoxProps = {
 
 export function Instructions({onVoteProposalButtonClick}: InstructionsProps) {
   const theme = useTheme();
-  const {isInstalled, isConnected, connect} = useWalletContext();
+  const {isInstalled, isConnected, isAccountSet, connect} = useWalletContext();
 
-  const CardBox = ({children, title, content}: CardBoxProps) => {
+  const CardBox = ({children, title, content}: CardBoxProps): JSX.Element => {
     return (
       <Box
         minHeight={400}
@@ -44,6 +45,35 @@ export function Instructions({onVoteProposalButtonClick}: InstructionsProps) {
         <Typography variant="body1">{content}</Typography>
         {children}
       </Box>
+    );
+  };
+
+  const ConnectWalletButton = (): JSX.Element => {
+    return (
+      <Button
+        variant="primary"
+        disabled={!isInstalled || isConnected}
+        onClick={connect}
+      >
+        Connect
+      </Button>
+    );
+  };
+
+  const CreateAnAccountButton = (): JSX.Element => {
+    return (
+      <Tooltip title="Use the Wallet extension to create an account">
+        <span>
+          <Button
+            fullWidth={true}
+            variant="primary"
+            sx={{cursor: "default"}}
+            disabled={!isInstalled}
+          >
+            create an account
+          </Button>
+        </span>
+      </Tooltip>
     );
   };
 
@@ -77,13 +107,11 @@ export function Instructions({onVoteProposalButtonClick}: InstructionsProps) {
               title="02/ Connect"
               content="Connect your Aptos wallet to enable voting"
             >
-              <Button
-                variant="primary"
-                disabled={!isInstalled || isConnected}
-                onClick={connect}
-              >
-                Connect
-              </Button>
+              {isAccountSet ? (
+                <ConnectWalletButton />
+              ) : (
+                <CreateAnAccountButton />
+              )}
             </CardBox>
           </Card>
         </Grid>


### PR DESCRIPTION
This PR sets the account created state and lets the user know if they need to create an account by displaying it on the wallet button or the connect step in the instructions section on the proposals page


https://user-images.githubusercontent.com/29798064/183765092-b7d2f965-26a8-4792-bee9-63c4d06c153c.mov

