### PR TITLE
[GOVERNANCE] check wallet and explorer use the same network

### DIFF
--- a/src/GlobalState.tsx
+++ b/src/GlobalState.tsx
@@ -1,21 +1,21 @@
 import React from "react";
-import {networks, defaultNetworkName, ExplorerNetworks} from "./constants";
+import {networks, defaultNetworkName, NetworkName} from "./constants";
 
-const selected_network = safeGetSelectedNetworkName() as ExplorerNetworks;
+const selected_network = safeGetSelectedNetworkName() as NetworkName;
 
-function safeGetSelectedNetworkName(): string {
+function safeGetSelectedNetworkName(): NetworkName {
   let selected_network = localStorage.getItem("selected_network");
   if (selected_network) {
     selected_network = selected_network.toLowerCase();
     if (selected_network in networks) {
-      return selected_network;
+      return selected_network as NetworkName;
     }
   }
-  return defaultNetworkName.toLowerCase();
+  return defaultNetworkName.toLowerCase() as NetworkName;
 }
 
 export type GlobalState = {
-  network_name: ExplorerNetworks;
+  network_name: NetworkName;
   network_value: string;
 };
 

--- a/src/GlobalState.tsx
+++ b/src/GlobalState.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {networks, defaultNetworkName} from "./constants";
+import {networks, defaultNetworkName, ExplorerNetworks} from "./constants";
 
-const selected_network = safeGetSelectedNetworkName();
+const selected_network = safeGetSelectedNetworkName() as ExplorerNetworks;
 
 function safeGetSelectedNetworkName(): string {
   let selected_network = localStorage.getItem("selected_network");
@@ -15,7 +15,7 @@ function safeGetSelectedNetworkName(): string {
 }
 
 export type GlobalState = {
-  network_name: string;
+  network_name: ExplorerNetworks;
   network_value: string;
 };
 

--- a/src/GlobalState.tsx
+++ b/src/GlobalState.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {networks, defaultNetworkName, NetworkName} from "./constants";
 
-const selected_network = safeGetSelectedNetworkName() as NetworkName;
+const selected_network = safeGetSelectedNetworkName();
 
 function safeGetSelectedNetworkName(): NetworkName {
   let selected_network = localStorage.getItem("selected_network");
@@ -11,7 +11,7 @@ function safeGetSelectedNetworkName(): NetworkName {
       return selected_network as NetworkName;
     }
   }
-  return defaultNetworkName.toLowerCase() as NetworkName;
+  return defaultNetworkName;
 }
 
 export type GlobalState = {

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,7 +1,10 @@
 import {TxnBuilderTypes} from "aptos";
 import {useState} from "react";
-import {walleExplorertNetworkMap} from "../../constants";
-import {useWalletContext} from "../../context/wallet/context";
+
+import {
+  useWalletContext,
+  walletExplorertNetworkMap,
+} from "../../context/wallet/context";
 import {useGlobalState} from "../../GlobalState";
 import {signAndSubmitTransaction} from "../wallet";
 
@@ -29,7 +32,7 @@ const useSubmitTransaction = () => {
     payload: TxnBuilderTypes.TransactionPayloadScriptFunction,
   ) {
     // if dApp network !== wallet network => return error
-    if (walleExplorertNetworkMap(walletNetwork) !== state.network_name) {
+    if (walletExplorertNetworkMap(walletNetwork) !== state.network_name) {
       setTransactionResponse({
         succeeded: false,
         message:

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,5 +1,7 @@
 import {TxnBuilderTypes} from "aptos";
 import {useState} from "react";
+import {useWalletContext} from "../../context/wallet/context";
+import {useGlobalState} from "../../GlobalState";
 import {signAndSubmitTransaction} from "../wallet";
 
 export type TransactionResponse =
@@ -19,10 +21,21 @@ export type TransactionResponseOnFailure = {
 const useSubmitTransaction = () => {
   const [transactionResponse, setTransactionResponse] =
     useState<TransactionResponse | null>(null);
+  const [state, _] = useGlobalState();
+  const {walletNetwork} = useWalletContext();
 
   async function submitTransaction(
     payload: TxnBuilderTypes.TransactionPayloadScriptFunction,
   ) {
+    // if dApp network !== wallet network => return error
+    if (walletNetwork !== state.network_name) {
+      setTransactionResponse({
+        succeeded: false,
+        message:
+          "Wallet and Explorer should use the same network to submit a transaction",
+      });
+      return;
+    }
     await signAndSubmitTransaction(payload).then(setTransactionResponse);
   }
 

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,5 +1,6 @@
 import {TxnBuilderTypes} from "aptos";
 import {useState} from "react";
+import {walleExplorertNetworkMap} from "../../constants";
 import {useWalletContext} from "../../context/wallet/context";
 import {useGlobalState} from "../../GlobalState";
 import {signAndSubmitTransaction} from "../wallet";
@@ -28,7 +29,7 @@ const useSubmitTransaction = () => {
     payload: TxnBuilderTypes.TransactionPayloadScriptFunction,
   ) {
     // if dApp network !== wallet network => return error
-    if (walletNetwork !== state.network_name) {
+    if (walleExplorertNetworkMap(walletNetwork) !== state.network_name) {
       setTransactionResponse({
         succeeded: false,
         message:

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -3,7 +3,7 @@ import {useState} from "react";
 
 import {
   useWalletContext,
-  walletExplorertNetworkMap,
+  walletExplorerNetworkMap,
 } from "../../context/wallet/context";
 import {useGlobalState} from "../../GlobalState";
 import {signAndSubmitTransaction} from "../wallet";
@@ -32,7 +32,7 @@ const useSubmitTransaction = () => {
     payload: TxnBuilderTypes.TransactionPayloadScriptFunction,
   ) {
     // if dApp network !== wallet network => return error
-    if (walletExplorertNetworkMap(walletNetwork) !== state.network_name) {
+    if (walletExplorerNetworkMap(walletNetwork) !== state.network_name) {
       setTransactionResponse({
         succeeded: false,
         message:

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -1,5 +1,6 @@
 import {TxnBuilderTypes} from "aptos";
-import {WalletNetworks} from "../constants";
+import {WalletNetworks} from "../context/wallet/context";
+
 import {
   TransactionResponse,
   TransactionResponseOnFailure,

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -50,6 +50,15 @@ export const getAccountAddress: () => Promise<string | null> = async () => {
   return null;
 };
 
+export const getWalletNetwork: () => Promise<string> = async () => {
+  try {
+    return await window.aptos?.network?.();
+  } catch (error) {
+    console.log(error);
+  }
+  return "Devnet"; // default wallet network
+};
+
 export const isUpdatedVersion = (): boolean =>
   window.aptos?.on instanceof Function;
 

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -1,4 +1,5 @@
 import {TxnBuilderTypes} from "aptos";
+import {WalletNetworks} from "../constants";
 import {
   TransactionResponse,
   TransactionResponseOnFailure,
@@ -50,7 +51,7 @@ export const getAccountAddress: () => Promise<string | null> = async () => {
   return null;
 };
 
-export const getWalletNetwork: () => Promise<string> = async () => {
+export const getWalletNetwork: () => Promise<WalletNetworks> = async () => {
   try {
     return await window.aptos?.network?.();
   } catch (error) {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,27 +1,39 @@
+import { assertNever } from "./utils";
+
 export const devnetUrl =
   process.env.APTOS_DEVNET_URL || "https://fullnode.devnet.aptoslabs.com/";
 
-export const networks: Record<string, string> = {
+export const networks = {
   local: "http://localhost:8080",
   devnet: devnetUrl,
   test: "https://rosetta.aptosdev.com/",
-  //governance: "https://ait2.aptosdev.com/", // TODO - use the proposals url
 };
 
-export const walletNetworkMap: Record<string, string> = {
-  Devnet: "devnet",
-  Localhost: "local",
-  Testnet: "test",
-};
-
-// Remove trailing slashes
-for (let key of Object.keys(networks)) {
-  if (networks[key].endsWith("/")) {
-    networks[key] = networks[key].slice(0, -1);
+export const walleExplorertNetworkMap = (walletNetwork: WalletNetworks):ExplorerNetworks => {
+  switch(walletNetwork){
+    case "Devnet":
+      return "devnet";
+    case "Localhost":
+      return "local";
+    case "Testnet":
+      return "test";
+    default:
+      return assertNever(walletNetwork);
   }
 }
 
-export const defaultNetworkName: string = "devnet";
+export type ExplorerNetworks = keyof typeof networks;
+
+export type WalletNetworks = "Devnet" | "Localhost" | "Testnet";
+
+// Remove trailing slashes
+for (let value of Object.values(networks)) {  
+  if (value.endsWith("/")) {
+    value = value.slice(0, -1);
+  }
+}
+
+export const defaultNetworkName = "devnet" as const;
 
 if (!(defaultNetworkName in networks)) {
   throw `defaultNetworkName '${defaultNetworkName}' not in Networks!`;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -8,6 +8,12 @@ export const networks: Record<string, string> = {
   //governance: "https://ait2.aptosdev.com/", // TODO - use the proposals url
 };
 
+export const walletNetworkMap: Record<string,string> = {
+  Devnet:"devnet",
+  Localhost:"local",
+  Testnet:"test"
+}
+
 // Remove trailing slashes
 for (let key of Object.keys(networks)) {
   if (networks[key].endsWith("/")) {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -12,7 +12,9 @@ export type NetworkName = keyof typeof networks;
 // Remove trailing slashes
 for (let key of Object.keys(networks)) {
   if (networks[key as keyof typeof networks].endsWith("/")) {
-    networks[key as keyof typeof networks] = networks[key as keyof typeof networks].slice(0, -1);
+    networks[key as keyof typeof networks] = networks[
+      key as keyof typeof networks
+    ].slice(0, -1);
   }
 }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -10,15 +10,14 @@ export const networks = {
 export type NetworkName = keyof typeof networks;
 
 // Remove trailing slashes
-for (let key of Object.keys(networks)) {
-  if (networks[key as keyof typeof networks].endsWith("/")) {
-    networks[key as keyof typeof networks] = networks[
-      key as keyof typeof networks
-    ].slice(0, -1);
+for (const key of Object.keys(networks)) {
+  const networkName = key as NetworkName;
+  if (networks[networkName].endsWith("/")) {
+    networks[networkName] = networks[networkName].slice(0, -1);
   }
 }
 
-export const defaultNetworkName = "devnet" as const;
+export const defaultNetworkName: NetworkName = "devnet" as const;
 
 if (!(defaultNetworkName in networks)) {
   throw `defaultNetworkName '${defaultNetworkName}' not in Networks!`;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -8,11 +8,11 @@ export const networks: Record<string, string> = {
   //governance: "https://ait2.aptosdev.com/", // TODO - use the proposals url
 };
 
-export const walletNetworkMap: Record<string,string> = {
-  Devnet:"devnet",
-  Localhost:"local",
-  Testnet:"test"
-}
+export const walletNetworkMap: Record<string, string> = {
+  Devnet: "devnet",
+  Localhost: "local",
+  Testnet: "test",
+};
 
 // Remove trailing slashes
 for (let key of Object.keys(networks)) {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,4 +1,4 @@
-import { assertNever } from "./utils";
+import {assertNever} from "./utils";
 
 export const devnetUrl =
   process.env.APTOS_DEVNET_URL || "https://fullnode.devnet.aptoslabs.com/";
@@ -9,8 +9,10 @@ export const networks = {
   test: "https://rosetta.aptosdev.com/",
 };
 
-export const walleExplorertNetworkMap = (walletNetwork: WalletNetworks):ExplorerNetworks => {
-  switch(walletNetwork){
+export const walleExplorertNetworkMap = (
+  walletNetwork: WalletNetworks,
+): ExplorerNetworks => {
+  switch (walletNetwork) {
     case "Devnet":
       return "devnet";
     case "Localhost":
@@ -20,14 +22,14 @@ export const walleExplorertNetworkMap = (walletNetwork: WalletNetworks):Explorer
     default:
       return assertNever(walletNetwork);
   }
-}
+};
 
 export type ExplorerNetworks = keyof typeof networks;
 
 export type WalletNetworks = "Devnet" | "Localhost" | "Testnet";
 
 // Remove trailing slashes
-for (let value of Object.values(networks)) {  
+for (let value of Object.values(networks)) {
   if (value.endsWith("/")) {
     value = value.slice(0, -1);
   }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,5 +1,3 @@
-import {assertNever} from "./utils";
-
 export const devnetUrl =
   process.env.APTOS_DEVNET_URL || "https://fullnode.devnet.aptoslabs.com/";
 
@@ -9,29 +7,12 @@ export const networks = {
   test: "https://rosetta.aptosdev.com/",
 };
 
-export const walleExplorertNetworkMap = (
-  walletNetwork: WalletNetworks,
-): ExplorerNetworks => {
-  switch (walletNetwork) {
-    case "Devnet":
-      return "devnet";
-    case "Localhost":
-      return "local";
-    case "Testnet":
-      return "test";
-    default:
-      return assertNever(walletNetwork);
-  }
-};
-
-export type ExplorerNetworks = keyof typeof networks;
-
-export type WalletNetworks = "Devnet" | "Localhost" | "Testnet";
+export type NetworkName = keyof typeof networks;
 
 // Remove trailing slashes
-for (let value of Object.values(networks)) {
-  if (value.endsWith("/")) {
-    value = value.slice(0, -1);
+for (let key of Object.keys(networks)) {
+  if (networks[key as keyof typeof networks].endsWith("/")) {
+    networks[key as keyof typeof networks] = networks[key as keyof typeof networks].slice(0, -1);
   }
 }
 

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -1,5 +1,5 @@
 import {createContext, useContext} from "react";
-import { WalletNetworks } from "../../constants";
+import {WalletNetworks} from "../../constants";
 
 export interface walletContext {
   isInstalled: boolean;

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -1,10 +1,11 @@
 import {createContext, useContext} from "react";
+import { WalletNetworks } from "../../constants";
 
 export interface walletContext {
   isInstalled: boolean;
   isConnected: boolean;
   isAccountSet: boolean;
-  walletNetwork: string;
+  walletNetwork: WalletNetworks;
   accountAddress: string | null;
   connect: () => Promise<void>;
 }

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -24,7 +24,7 @@ export const useWalletContext = () => {
 
 export type WalletNetworks = "Devnet" | "Localhost" | "Testnet";
 
-export const walletExplorertNetworkMap = (
+export const walletExplorerNetworkMap = (
   walletNetwork: WalletNetworks,
 ): NetworkName => {
   switch (walletNetwork) {

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -4,6 +4,7 @@ export interface walletContext {
   isInstalled: boolean;
   isConnected: boolean;
   isAccountSet: boolean;
+  walletNetwork: string;
   accountAddress: string | null;
   connect: () => Promise<void>;
 }

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -1,5 +1,6 @@
 import {createContext, useContext} from "react";
-import {WalletNetworks} from "../../constants";
+import {NetworkName} from "../../constants";
+import { assertNever } from "../../utils";
 
 export interface walletContext {
   isInstalled: boolean;
@@ -19,4 +20,21 @@ export const useWalletContext = () => {
     throw new Error("useWalletContext must be used within a walletContext");
   }
   return context;
+};
+
+export type WalletNetworks = "Devnet" | "Localhost" | "Testnet";
+
+export const walletExplorertNetworkMap = (
+  walletNetwork: WalletNetworks,
+): NetworkName => {
+  switch (walletNetwork) {
+    case "Devnet":
+      return "devnet";
+    case "Localhost":
+      return "local";
+    case "Testnet":
+      return "test";
+    default:
+      return assertNever(walletNetwork);
+  }
 };

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext} from "react";
 import {NetworkName} from "../../constants";
-import { assertNever } from "../../utils";
+import {assertNever} from "../../utils";
 
 export interface walletContext {
   isInstalled: boolean;

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect} from "react";
-import {getWalletNetworkFromNetworkMap} from '../../utils'
+import {getWalletNetworkFromNetworkMap} from "../../utils";
 import {
   connectToWallet,
   getAccountAddress,
@@ -48,7 +48,9 @@ export function useWallet() {
   useEffect(() => {
     if (isConnected) {
       getAccountAddress().then(setAccountAddress);
-      getWalletNetwork().then((network) => setWalletNetwork(getWalletNetworkFromNetworkMap(network)))
+      getWalletNetwork().then((network) =>
+        setWalletNetwork(getWalletNetworkFromNetworkMap(network)),
+      );
     }
   }, [isConnected]);
 

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -1,8 +1,10 @@
 import {useState, useEffect} from "react";
+import {getWalletNetworkFromNetworkMap} from '../../utils'
 import {
   connectToWallet,
   getAccountAddress,
   getAptosWallet,
+  getWalletNetwork,
   isUpdatedVersion,
   isAccountCreated,
   isWalletConnected,
@@ -14,7 +16,7 @@ export function useWallet() {
   const [isAccountSet, setIsAccountSet] = useState<boolean>(false);
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [accountAddress, setAccountAddress] = useState<string | null>(null);
-  const [walletNetwork, setWalletNetwork] = useState<string>("Devnet");
+  const [walletNetwork, setWalletNetwork] = useState<string>("");
 
   useEffect(() => {
     setAptosWallet(getAptosWallet());
@@ -38,7 +40,7 @@ export function useWallet() {
         }
       });
       window.aptos?.on?.("networkChanged", (newNetwork: string) => {
-        setWalletNetwork(walletNetworkMap[newNetwork]);
+        setWalletNetwork(getWalletNetworkFromNetworkMap(newNetwork));
       });
     }
   }, []);
@@ -46,6 +48,7 @@ export function useWallet() {
   useEffect(() => {
     if (isConnected) {
       getAccountAddress().then(setAccountAddress);
+      getWalletNetwork().then((network) => setWalletNetwork(getWalletNetworkFromNetworkMap(network)))
     }
   }, [isConnected]);
 

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -28,7 +28,7 @@ export function useWallet() {
   useEffect(() => {
     // add this check to support older wallet versions
     if (isUpdatedVersion()) {
-      window.aptos.on("accountChanged", (account: any) => {
+      window.aptos?.on?.("accountChanged", (account: any) => {
         if (account.address) {
           setAccountAddress(account.address);
         } else {
@@ -37,7 +37,7 @@ export function useWallet() {
           setIsAccountSet(true);
         }
       });
-      window.aptos.on("networkChanged", (newNetwork: string) => {
+      window.aptos?.on?.("networkChanged", (newNetwork: string) => {
         setWalletNetwork(walletNetworkMap[newNetwork]);
       });
     }

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -1,5 +1,4 @@
 import {useState, useEffect} from "react";
-import {getWalletNetworkFromNetworkMap} from "../../utils";
 import {
   connectToWallet,
   getAccountAddress,
@@ -9,14 +8,14 @@ import {
   isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
-import {walletNetworkMap} from "../../constants";
+import {WalletNetworks} from "../../constants";
 
 export function useWallet() {
   const [isInstalled, setAptosWallet] = useState<boolean>(false);
   const [isAccountSet, setIsAccountSet] = useState<boolean>(false);
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [accountAddress, setAccountAddress] = useState<string | null>(null);
-  const [walletNetwork, setWalletNetwork] = useState<string>("");
+  const [walletNetwork, setWalletNetwork] = useState<WalletNetworks>("Devnet");
 
   useEffect(() => {
     setAptosWallet(getAptosWallet());
@@ -39,8 +38,8 @@ export function useWallet() {
           setIsAccountSet(true);
         }
       });
-      window.aptos?.on?.("networkChanged", (newNetwork: string) => {
-        setWalletNetwork(getWalletNetworkFromNetworkMap(newNetwork));
+      window.aptos?.on?.("networkChanged", (newNetwork: WalletNetworks) => {
+        setWalletNetwork(newNetwork);
       });
     }
   }, []);
@@ -49,7 +48,7 @@ export function useWallet() {
     if (isConnected) {
       getAccountAddress().then(setAccountAddress);
       getWalletNetwork().then((network) =>
-        setWalletNetwork(getWalletNetworkFromNetworkMap(network)),
+        setWalletNetwork(network),
       );
     }
   }, [isConnected]);

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -8,7 +8,7 @@ import {
   isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
-import { WalletNetworks } from "./context";
+import {WalletNetworks} from "./context";
 
 export function useWallet() {
   const [isInstalled, setAptosWallet] = useState<boolean>(false);

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -7,15 +7,13 @@ import {
   isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
-import { walletNetworkMap } from "../../constants";
+import {walletNetworkMap} from "../../constants";
 
 export function useWallet() {
   const [isInstalled, setAptosWallet] = useState<boolean>(false);
   const [isAccountSet, setIsAccountSet] = useState<boolean>(false);
   const [isConnected, setIsConnected] = useState<boolean>(false);
-  const [accountAddress, setAccountAddress] = useState<string | null>(
-    null,
-  );
+  const [accountAddress, setAccountAddress] = useState<string | null>(null);
   const [walletNetwork, setWalletNetwork] = useState<string>("Devnet");
 
   useEffect(() => {
@@ -40,7 +38,7 @@ export function useWallet() {
         }
       });
       window.aptos.on("networkChanged", (newNetwork: string) => {
-        setWalletNetwork(walletNetworkMap[newNetwork])
+        setWalletNetwork(walletNetworkMap[newNetwork]);
       });
     }
   }, []);
@@ -55,5 +53,12 @@ export function useWallet() {
     connectToWallet().then(setIsConnected);
   };
 
-  return {isInstalled, isAccountSet, isConnected, accountAddress, walletNetwork, connect};
+  return {
+    isInstalled,
+    isAccountSet,
+    isConnected,
+    accountAddress,
+    walletNetwork,
+    connect,
+  };
 }

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -47,9 +47,7 @@ export function useWallet() {
   useEffect(() => {
     if (isConnected) {
       getAccountAddress().then(setAccountAddress);
-      getWalletNetwork().then((network) =>
-        setWalletNetwork(network),
-      );
+      getWalletNetwork().then((network) => setWalletNetwork(network));
     }
   }, [isConnected]);
 

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import {useState, useEffect} from "react";
 import {
   connectToWallet,
   getAccountAddress,
@@ -7,14 +7,16 @@ import {
   isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
+import { walletNetworkMap } from "../../constants";
 
 export function useWallet() {
-  const [isInstalled, setAptosWallet] = React.useState<boolean>(false);
-  const [isAccountSet, setIsAccountSet] = React.useState<boolean>(false);
-  const [isConnected, setIsConnected] = React.useState<boolean>(false);
-  const [accountAddress, setAccountAddress] = React.useState<string | null>(
+  const [isInstalled, setAptosWallet] = useState<boolean>(false);
+  const [isAccountSet, setIsAccountSet] = useState<boolean>(false);
+  const [isConnected, setIsConnected] = useState<boolean>(false);
+  const [accountAddress, setAccountAddress] = useState<string | null>(
     null,
   );
+  const [walletNetwork, setWalletNetwork] = useState<string>("Devnet");
 
   useEffect(() => {
     setAptosWallet(getAptosWallet());
@@ -33,9 +35,12 @@ export function useWallet() {
           setAccountAddress(account.address);
         } else {
           setAccountAddress(null);
-          // this means an account was created but is not connected yet
+          // this means an account was created but wallet is not connected yet
           setIsAccountSet(true);
         }
+      });
+      window.aptos.on("networkChanged", (newNetwork: string) => {
+        setWalletNetwork(walletNetworkMap[newNetwork])
       });
     }
   }, []);
@@ -50,5 +55,5 @@ export function useWallet() {
     connectToWallet().then(setIsConnected);
   };
 
-  return {isInstalled, isAccountSet, isConnected, accountAddress, connect};
+  return {isInstalled, isAccountSet, isConnected, accountAddress, walletNetwork, connect};
 }

--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -8,7 +8,7 @@ import {
   isAccountCreated,
   isWalletConnected,
 } from "../../api/wallet";
-import {WalletNetworks} from "../../constants";
+import { WalletNetworks } from "./context";
 
 export function useWallet() {
   const [isInstalled, setAptosWallet] = useState<boolean>(false);

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect} from "react";
 import {FormControl, Select, SelectChangeEvent} from "@mui/material";
-import {networks} from "../../constants";
+import {ExplorerNetworks, networks} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useTheme} from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";
@@ -13,7 +13,7 @@ export default function NetworkSelect() {
   const [state, dispatch] = useGlobalState();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  function maybeSetNetwork(network_name: string | null) {
+  function maybeSetNetwork(network_name: ExplorerNetworks | null) {
     if (!network_name || state.network_name === network_name) return;
     const network_value = networks[network_name];
     if (network_value) {
@@ -23,13 +23,17 @@ export default function NetworkSelect() {
   }
 
   const handleChange = (event: SelectChangeEvent) => {
-    const network_name = event.target.value as string;
-    maybeSetNetwork(network_name && network_name.toLowerCase());
+    const selectedNetwork = event.target.value as string;
+    if(!selectedNetwork) return;
+    const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
+    maybeSetNetwork(network_name);
   };
 
   useEffect(() => {
-    const network_name = searchParams.get("network");
-    maybeSetNetwork(network_name && network_name.toLowerCase());
+    const selectedNetwork = searchParams.get("network");
+    if(!selectedNetwork) return;
+    const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
+    maybeSetNetwork(network_name);
   });
 
   function DropdownIcon(props: SvgIconProps) {

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect} from "react";
 import {FormControl, Select, SelectChangeEvent} from "@mui/material";
-import {ExplorerNetworks, networks} from "../../constants";
+import {NetworkName, networks} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useTheme} from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";
@@ -13,7 +13,7 @@ export default function NetworkSelect() {
   const [state, dispatch] = useGlobalState();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  function maybeSetNetwork(network_name: ExplorerNetworks | null) {
+  function maybeSetNetwork(network_name: NetworkName | null) {
     if (!network_name || state.network_name === network_name) return;
     const network_value = networks[network_name];
     if (network_value) {
@@ -25,14 +25,14 @@ export default function NetworkSelect() {
   const handleChange = (event: SelectChangeEvent) => {
     const selectedNetwork = event.target.value as string;
     if (!selectedNetwork) return;
-    const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
+    const network_name = selectedNetwork.toLowerCase() as NetworkName;
     maybeSetNetwork(network_name);
   };
 
   useEffect(() => {
     const selectedNetwork = searchParams.get("network");
     if (!selectedNetwork) return;
-    const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
+    const network_name = selectedNetwork.toLowerCase() as NetworkName;
     maybeSetNetwork(network_name);
   });
 

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -13,8 +13,10 @@ export default function NetworkSelect() {
   const [state, dispatch] = useGlobalState();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  function maybeSetNetwork(network_name: NetworkName | null) {
-    if (!network_name || state.network_name === network_name) return;
+  function maybeSetNetwork(networkNameString: string | null) {
+    if (!networkNameString || state.network_name === networkNameString) return;
+    if (!(networkNameString in networks)) return;
+    const network_name = networkNameString as NetworkName;
     const network_value = networks[network_name];
     if (network_value) {
       setSearchParams({network: network_name});
@@ -22,18 +24,14 @@ export default function NetworkSelect() {
     }
   }
 
-  const handleChange = (event: SelectChangeEvent) => {
-    const selectedNetwork = event.target.value as string;
-    if (!selectedNetwork) return;
-    const network_name = selectedNetwork.toLowerCase() as NetworkName;
-    maybeSetNetwork(network_name);
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    const network_name = event.target.value;
+    maybeSetNetwork(network_name && network_name.toLowerCase());
   };
 
   useEffect(() => {
-    const selectedNetwork = searchParams.get("network");
-    if (!selectedNetwork) return;
-    const network_name = selectedNetwork.toLowerCase() as NetworkName;
-    maybeSetNetwork(network_name);
+    const network_name = searchParams.get("network");
+    maybeSetNetwork(network_name && network_name.toLowerCase());
   });
 
   function DropdownIcon(props: SvgIconProps) {

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -24,14 +24,14 @@ export default function NetworkSelect() {
 
   const handleChange = (event: SelectChangeEvent) => {
     const selectedNetwork = event.target.value as string;
-    if(!selectedNetwork) return;
+    if (!selectedNetwork) return;
     const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
     maybeSetNetwork(network_name);
   };
 
   useEffect(() => {
     const selectedNetwork = searchParams.get("network");
-    if(!selectedNetwork) return;
+    if (!selectedNetwork) return;
     const network_name = selectedNetwork.toLowerCase() as ExplorerNetworks;
     maybeSetNetwork(network_name);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import {walletNetworkMap} from "./constants";
-
 /**
  * Helper function for exhaustiveness checks.
  *
@@ -9,10 +7,3 @@ import {walletNetworkMap} from "./constants";
 export function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }
-
-export const getWalletNetworkFromNetworkMap = (network: string) => {
-  if (!(network in walletNetworkMap)) {
-    throw `network '${network}' not in Wallet Network Map!`;
-  }
-  return walletNetworkMap[network];
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import {walletNetworkMap} from "./constants";
+
 /**
  * Helper function for exhaustiveness checks.
  *
@@ -7,3 +9,10 @@
 export function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }
+
+export const getWalletNetworkFromNetworkMap = (network: string) => {
+  if (!(network in walletNetworkMap)) {
+    throw `network '${network}' not in Wallet Network Map!`;
+  }
+  return walletNetworkMap[network];
+};


### PR DESCRIPTION
Before sign and submit a transaction, we want to make sure the explorer and the wallet are set to the same network. 

This PR blocks and returns an error when users try to sign and submit a transaction if the explorer an wallet are not set to the same network