### PR TITLE
[GOVERNANCE] fix wallet network bug

### DIFF
--- a/src/context/wallet/useWallet.tsx
+++ b/src/context/wallet/useWallet.tsx
@@ -19,6 +19,7 @@ export function useWallet() {
 
   useEffect(() => {
     setAptosWallet(getAptosWallet());
+    getWalletNetwork().then(setWalletNetwork);
   }, []);
 
   useEffect(() => {
@@ -47,7 +48,6 @@ export function useWallet() {
   useEffect(() => {
     if (isConnected) {
       getAccountAddress().then(setAccountAddress);
-      getWalletNetwork().then((network) => setWalletNetwork(network));
     }
   }, [isConnected]);
 


### PR DESCRIPTION
we were setting the wallet network only when a wallet is connected, we should set it on first load and then listen to any network changed event