### PR TITLE
[Governance] add execution status to proposals table

### DIFF
--- a/src/pages/Governance/Proposal/Header.tsx
+++ b/src/pages/Governance/Proposal/Header.tsx
@@ -3,14 +3,18 @@ import {Grid, Typography, Stack, Divider, Box} from "@mui/material";
 import {renderTimestamp} from "../../../pages/Transactions/helpers";
 import {getTimeRemaining} from "../../utils";
 import {Proposal, ProposalExecutionState, ProposalVotingState} from "../Types";
-import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
-import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import {primaryColor, warningColor} from "../constants";
 import PersonIcon from "@mui/icons-material/Person";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import {useTheme} from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import {getVotingStatusColor, renderStatusIcon, isVotingClosed} from "../utils";
+import {
+  getVotingStatusColor,
+  renderVotingStatusIcon,
+  getExecutionStatusColor,
+  renderExecutionStatusIcon,
+  isVotingClosed,
+} from "../utils";
 import HashButton from "../../../components/HashButton";
 
 const SECONDARY_TEXT_COLOR = "#A3A3A3";
@@ -23,7 +27,7 @@ function StatusComponent({proposal}: {proposal: Proposal}): JSX.Element {
   return (
     <Box sx={{display: "flex", alignItems: "center", gap: 3}}>
       <Box sx={{display: "flex", alignItems: "center", gap: 1}}>
-        {renderStatusIcon(proposal.proposal_state)}
+        {renderVotingStatusIcon(proposal.proposal_state)}
         <Typography
           variant="subtitle1"
           color={getVotingStatusColor(proposal.proposal_state)}
@@ -45,31 +49,16 @@ function ExecutionStatusComponent({
 }: {
   proposal: Proposal;
 }): JSX.Element {
-  if (proposal.is_resolved) {
-    return (
-      <>
-        <CheckCircleOutlinedIcon
-          fontSize="small"
-          sx={{
-            color: primaryColor,
-          }}
-        />
-        <Typography variant="subtitle1" color={primaryColor}>
-          {ProposalExecutionState.EXECUTED}
-        </Typography>
-      </>
-    );
-  }
   return (
     <>
-      <RadioButtonUncheckedIcon
-        fontSize="small"
-        sx={{
-          color: warningColor,
-        }}
-      />
-      <Typography variant="subtitle1" color={warningColor}>
-        {ProposalExecutionState.WAITING_TO_BE_EXECUTED}
+      {renderExecutionStatusIcon(proposal.is_resolved)}
+      <Typography
+        variant="subtitle1"
+        color={getExecutionStatusColor(proposal.is_resolved)}
+      >
+        {proposal.is_resolved
+          ? ProposalExecutionState.EXECUTED
+          : ProposalExecutionState.WAITING_TO_BE_EXECUTED}
       </Typography>
     </>
   );

--- a/src/pages/Governance/Proposal/Header.tsx
+++ b/src/pages/Governance/Proposal/Header.tsx
@@ -3,19 +3,19 @@ import {Grid, Typography, Stack, Divider, Box} from "@mui/material";
 import {renderTimestamp} from "../../../pages/Transactions/helpers";
 import {getTimeRemaining} from "../../utils";
 import {Proposal, ProposalExecutionState, ProposalVotingState} from "../Types";
-import {primaryColor, warningColor} from "../constants";
+import {primaryColor} from "../constants";
 import PersonIcon from "@mui/icons-material/Person";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import {useTheme} from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {
   getVotingStatusColor,
-  renderVotingStatusIcon,
   getExecutionStatusColor,
-  renderExecutionStatusIcon,
   isVotingClosed,
 } from "../utils";
 import HashButton from "../../../components/HashButton";
+import VotingStatusIcon from "../components/VotingStatusIcon";
+import ExecutionStatusIcon from "../components/ExecutionStatusIcon";
 
 const SECONDARY_TEXT_COLOR = "#A3A3A3";
 
@@ -27,7 +27,7 @@ function StatusComponent({proposal}: {proposal: Proposal}): JSX.Element {
   return (
     <Box sx={{display: "flex", alignItems: "center", gap: 3}}>
       <Box sx={{display: "flex", alignItems: "center", gap: 1}}>
-        {renderVotingStatusIcon(proposal.proposal_state)}
+        <VotingStatusIcon proposalState={proposal.proposal_state} />
         <Typography
           variant="subtitle1"
           color={getVotingStatusColor(proposal.proposal_state)}
@@ -51,7 +51,7 @@ function ExecutionStatusComponent({
 }): JSX.Element {
   return (
     <>
-      {renderExecutionStatusIcon(proposal.is_resolved)}
+      <ExecutionStatusIcon isResolved={proposal.is_resolved} />
       <Typography
         variant="subtitle1"
         color={getExecutionStatusColor(proposal.is_resolved)}

--- a/src/pages/Governance/Proposals/Table.tsx
+++ b/src/pages/Governance/Proposals/Table.tsx
@@ -20,7 +20,8 @@ import GeneralTableRow from "../../../components/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/GeneralTableHeaderCell";
 import HashButton from "../../../components/HashButton";
 import {teal} from "../../../themes/colors/aptosColorPalette";
-import {renderVotingStatusIcon, renderExecutionStatusIcon} from "../utils";
+import VotingStatusIcon from "../components/VotingStatusIcon";
+import ExecutionStatusIcon from "../components/ExecutionStatusIcon";
 
 const MAX_TITLE_WIDTH = 400;
 const CELL_HEIGHT = 72;
@@ -51,12 +52,12 @@ function StatusCell({proposal}: ProposalCellProps) {
   return (
     <TableCell sx={{textAlign: "left"}} height={CELL_HEIGHT}>
       <Box sx={{display: "flex", alignItems: "center", gap: 0.7}}>
-        {renderVotingStatusIcon(proposal.proposal_state)}
+        <VotingStatusIcon proposalState={proposal.proposal_state} />
         {proposal.proposal_state}
       </Box>
       {proposal.proposal_state === ProposalVotingState.PASSED && (
         <Box sx={{display: "flex", alignItems: "center", gap: 0.7, mt: 1}}>
-          {renderExecutionStatusIcon(proposal.is_resolved)}
+          <ExecutionStatusIcon isResolved={proposal.is_resolved} />
           {proposal.is_resolved
             ? ProposalExecutionState.EXECUTED
             : ProposalExecutionState.WAITING_TO_BE_EXECUTED}

--- a/src/pages/Governance/Proposals/Table.tsx
+++ b/src/pages/Governance/Proposals/Table.tsx
@@ -14,15 +14,16 @@ import {
 } from "@mui/material";
 import {renderTimestamp} from "../../Transactions/helpers";
 import {assertNever} from "../../../utils";
-import {Proposal} from "../Types";
+import {Proposal, ProposalVotingState, ProposalExecutionState} from "../Types";
 import {useGetProposal} from "../hooks/useGetProposal";
 import GeneralTableRow from "../../../components/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/GeneralTableHeaderCell";
 import HashButton from "../../../components/HashButton";
 import {teal} from "../../../themes/colors/aptosColorPalette";
-import {renderStatusIcon} from "../utils";
+import {renderVotingStatusIcon, renderExecutionStatusIcon} from "../utils";
 
-const TITLE_WIDTH = 400;
+const MAX_TITLE_WIDTH = 400;
+const CELL_HEIGHT = 72;
 
 type ProposalCellProps = {
   proposal: Proposal;
@@ -30,11 +31,11 @@ type ProposalCellProps = {
 
 function TitleCell({proposal}: ProposalCellProps) {
   return (
-    <TableCell sx={{textAlign: "left"}}>
+    <TableCell sx={{textAlign: "left"}} height={CELL_HEIGHT}>
       <Box
         component="div"
         sx={{
-          width: TITLE_WIDTH,
+          maxWidth: MAX_TITLE_WIDTH,
           color: teal[500],
           overflow: "hidden",
           textOverflow: "ellipsis",
@@ -48,18 +49,26 @@ function TitleCell({proposal}: ProposalCellProps) {
 
 function StatusCell({proposal}: ProposalCellProps) {
   return (
-    <TableCell sx={{textAlign: "left"}}>
-      <Box sx={{display: "flex", alignItems: "center", gap: 1}}>
-        {renderStatusIcon(proposal.proposal_state)}
+    <TableCell sx={{textAlign: "left"}} height={CELL_HEIGHT}>
+      <Box sx={{display: "flex", alignItems: "center", gap: 0.7}}>
+        {renderVotingStatusIcon(proposal.proposal_state)}
         {proposal.proposal_state}
       </Box>
+      {proposal.proposal_state === ProposalVotingState.PASSED && (
+        <Box sx={{display: "flex", alignItems: "center", gap: 0.7, mt: 1}}>
+          {renderExecutionStatusIcon(proposal.is_resolved)}
+          {proposal.is_resolved
+            ? ProposalExecutionState.EXECUTED
+            : ProposalExecutionState.WAITING_TO_BE_EXECUTED}
+        </Box>
+      )}
     </TableCell>
   );
 }
 
 function ProposerCell({proposal}: ProposalCellProps) {
   return (
-    <TableCell sx={{textAlign: "left"}}>
+    <TableCell sx={{textAlign: "left"}} height={CELL_HEIGHT}>
       <HashButton hash={proposal.proposer} />
     </TableCell>
   );
@@ -76,7 +85,11 @@ function TimestampCell({proposal}: ProposalCellProps) {
       </Typography>
     );
 
-  return <TableCell sx={{textAlign: "right"}}>{timestamp}</TableCell>;
+  return (
+    <TableCell sx={{textAlign: "right"}} height={CELL_HEIGHT}>
+      {timestamp}
+    </TableCell>
+  );
 }
 
 const ProposalCells = Object.freeze({

--- a/src/pages/Governance/components/ExecutionStatusIcon.tsx
+++ b/src/pages/Governance/components/ExecutionStatusIcon.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import {getExecutionStatusColor} from "../utils";
+
+type ExecutionStatusIconProps = {
+  isResolved: boolean;
+};
+
+export default function ExecutionStatusIcon({
+  isResolved,
+}: ExecutionStatusIconProps): JSX.Element {
+  return isResolved ? (
+    <CheckCircleOutlinedIcon
+      fontSize="small"
+      sx={{
+        color: getExecutionStatusColor(isResolved),
+      }}
+    />
+  ) : (
+    <RadioButtonUncheckedIcon
+      fontSize="small"
+      sx={{
+        color: getExecutionStatusColor(isResolved),
+      }}
+    />
+  );
+}

--- a/src/pages/Governance/components/VotingStatusIcon.tsx
+++ b/src/pages/Governance/components/VotingStatusIcon.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import {ProposalVotingState} from "../Types";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import PendingOutlinedIcon from "@mui/icons-material/PendingOutlined";
+import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+import {getVotingStatusColor} from "../utils";
+import {assertNever} from "../../../utils";
+
+type VotingStatusIconProps = {
+  proposalState: ProposalVotingState;
+};
+
+export default function VotingStatusIcon({
+  proposalState,
+}: VotingStatusIconProps): JSX.Element {
+  switch (proposalState) {
+    case ProposalVotingState.PASSED:
+      return (
+        <CheckCircleOutlinedIcon
+          fontSize="small"
+          sx={{
+            color: getVotingStatusColor(ProposalVotingState.PASSED),
+          }}
+        />
+      );
+    case ProposalVotingState.FAILED:
+      return (
+        <ErrorOutlineOutlinedIcon
+          fontSize="small"
+          sx={{
+            color: getVotingStatusColor(ProposalVotingState.FAILED),
+          }}
+        />
+      );
+    case ProposalVotingState.REJECTED:
+      return (
+        <HighlightOffIcon
+          fontSize="small"
+          sx={{
+            color: getVotingStatusColor(ProposalVotingState.REJECTED),
+          }}
+        />
+      );
+    case ProposalVotingState.PENDING:
+      return (
+        <PendingOutlinedIcon
+          fontSize="small"
+          sx={{
+            color: getVotingStatusColor(ProposalVotingState.PENDING),
+          }}
+        />
+      );
+    default:
+      return assertNever(proposalState);
+  }
+}

--- a/src/pages/Governance/utils.tsx
+++ b/src/pages/Governance/utils.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import {ensureMillisecondTimestamp} from "../utils";
-import {Proposal, ProposalVotingState} from "./Types";
+import {Proposal, ProposalVotingState, ProposalExecutionState} from "./Types";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
 import PendingOutlinedIcon from "@mui/icons-material/PendingOutlined";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import {primaryColor, negativeColor, warningColor} from "./constants";
 import {assertNever} from "../../utils";
 
@@ -78,7 +79,7 @@ export function getVotingStatusColor(
   }
 }
 
-export function renderStatusIcon(
+export function renderVotingStatusIcon(
   proposalState: ProposalVotingState,
 ): JSX.Element {
   switch (proposalState) {
@@ -121,4 +122,26 @@ export function renderStatusIcon(
     default:
       return assertNever(proposalState);
   }
+}
+
+export function getExecutionStatusColor(isResolved: boolean): string {
+  return isResolved ? primaryColor : warningColor;
+}
+
+export function renderExecutionStatusIcon(isResolved: boolean): JSX.Element {
+  return isResolved ? (
+    <CheckCircleOutlinedIcon
+      fontSize="small"
+      sx={{
+        color: getExecutionStatusColor(isResolved),
+      }}
+    />
+  ) : (
+    <RadioButtonUncheckedIcon
+      fontSize="small"
+      sx={{
+        color: getExecutionStatusColor(isResolved),
+      }}
+    />
+  );
 }

--- a/src/pages/Governance/utils.tsx
+++ b/src/pages/Governance/utils.tsx
@@ -1,11 +1,5 @@
-import React from "react";
 import {ensureMillisecondTimestamp} from "../utils";
-import {Proposal, ProposalVotingState, ProposalExecutionState} from "./Types";
-import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
-import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import PendingOutlinedIcon from "@mui/icons-material/PendingOutlined";
-import HighlightOffIcon from "@mui/icons-material/HighlightOff";
-import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import {Proposal, ProposalVotingState} from "./Types";
 import {primaryColor, negativeColor, warningColor} from "./constants";
 import {assertNever} from "../../utils";
 
@@ -79,69 +73,6 @@ export function getVotingStatusColor(
   }
 }
 
-export function renderVotingStatusIcon(
-  proposalState: ProposalVotingState,
-): JSX.Element {
-  switch (proposalState) {
-    case ProposalVotingState.PASSED:
-      return (
-        <CheckCircleOutlinedIcon
-          fontSize="small"
-          sx={{
-            color: getVotingStatusColor(ProposalVotingState.PASSED),
-          }}
-        />
-      );
-    case ProposalVotingState.FAILED:
-      return (
-        <ErrorOutlineOutlinedIcon
-          fontSize="small"
-          sx={{
-            color: getVotingStatusColor(ProposalVotingState.FAILED),
-          }}
-        />
-      );
-    case ProposalVotingState.REJECTED:
-      return (
-        <HighlightOffIcon
-          fontSize="small"
-          sx={{
-            color: getVotingStatusColor(ProposalVotingState.REJECTED),
-          }}
-        />
-      );
-    case ProposalVotingState.PENDING:
-      return (
-        <PendingOutlinedIcon
-          fontSize="small"
-          sx={{
-            color: getVotingStatusColor(ProposalVotingState.PENDING),
-          }}
-        />
-      );
-    default:
-      return assertNever(proposalState);
-  }
-}
-
 export function getExecutionStatusColor(isResolved: boolean): string {
   return isResolved ? primaryColor : warningColor;
-}
-
-export function renderExecutionStatusIcon(isResolved: boolean): JSX.Element {
-  return isResolved ? (
-    <CheckCircleOutlinedIcon
-      fontSize="small"
-      sx={{
-        color: getExecutionStatusColor(isResolved),
-      }}
-    />
-  ) : (
-    <RadioButtonUncheckedIcon
-      fontSize="small"
-      sx={{
-        color: getExecutionStatusColor(isResolved),
-      }}
-    />
-  );
 }


### PR DESCRIPTION
* make execution status helper functions and reuse them in the proposal header and proposals table
* add execution status to proposals table
<img width="1553" alt="Screen Shot 2022-08-18 at 12 21 18 PM" src="https://user-images.githubusercontent.com/109111707/185477408-e8fd719d-3ce8-4751-b7f7-6dfc6cb06780.png">
