### PR TITLE
show proposal time remaining countdown

### DIFF
--- a/src/pages/Governance/Proposal/Header.tsx
+++ b/src/pages/Governance/Proposal/Header.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import {Grid, Typography, Stack, Divider, Box} from "@mui/material";
 import {renderTimestamp} from "../../../pages/Transactions/helpers";
-import {getTimeRemaining} from "../../utils";
+import {getProposalTimeRemaining, ProposalTimeRemaining} from "../../utils";
 import {Proposal, ProposalExecutionState, ProposalVotingState} from "../Types";
 import {primaryColor} from "../constants";
 import PersonIcon from "@mui/icons-material/Person";
@@ -75,8 +75,20 @@ function TimeRemainingComponent({
   if (isVotingClosed(proposal)) {
     return null;
   }
+  const [remainingTime, setRemainingTime] = useState<ProposalTimeRemaining>(
+    getProposalTimeRemaining(proposal.expiration_secs),
+  );
 
-  const remainingTime = getTimeRemaining(proposal.expiration_secs);
+  useEffect(() => {
+    const intervalID = setInterval(() => {
+      setRemainingTime(getProposalTimeRemaining(proposal.expiration_secs));
+    }, 60000); // 1 minute interval
+    if (remainingTime.minutes === 0) {
+      clearInterval(intervalID);
+    }
+    return () => clearInterval(intervalID);
+  }, [remainingTime.minutes]);
+
   return (
     <Stack
       direction="column"

--- a/src/pages/utils.tsx
+++ b/src/pages/utils.tsx
@@ -57,14 +57,21 @@ export function timestampDisplay(timestamp: moment.Moment): TimestampDisplay {
   };
 }
 
-export function getTimeRemaining(endtime: string) {
+export interface ProposalTimeRemaining {
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
+export function getProposalTimeRemaining(
+  endtime: string,
+): ProposalTimeRemaining {
   const total = ensureMillisecondTimestamp(endtime) - Date.now();
   const minutes = Math.floor((total / 1000 / 60) % 60);
   const hours = Math.floor((total / (1000 * 60 * 60)) % 24);
   const days = Math.floor(total / (1000 * 60 * 60 * 24));
 
   return {
-    total,
     days,
     hours,
     minutes,


### PR DESCRIPTION
Set 1 minute interval to show proposal time remaining countdown.

Potential follow-up PR: when time ends, update the proposal status, the time remaining, voting card, etc - needs refactoring