### PR TITLE
handle new proposal metadata property

### DIFF
--- a/src/pages/Governance/Proposal/Content.tsx
+++ b/src/pages/Governance/Proposal/Content.tsx
@@ -20,13 +20,16 @@ export function ProposalContent({proposal}: ProposalContentProps): JSX.Element {
       <ContentRow
         title="Source Code"
         text="LINK TO SOURCE CODE"
-        link={proposal.metadata.source_code_url}
+        link={proposal.proposal_metadata.source_code_url}
       />
-      <ContentRow title="Description" text={proposal.metadata.description} />
+      <ContentRow
+        title="Description"
+        text={proposal.proposal_metadata.description}
+      />
       <ContentRow
         title="Discussion"
         text="LINK TO DISCUSSION"
-        link={proposal.metadata.discussion_url}
+        link={proposal.proposal_metadata.discussion_url}
       />
     </Stack>
   );

--- a/src/pages/Governance/Proposal/Header.tsx
+++ b/src/pages/Governance/Proposal/Header.tsx
@@ -20,7 +20,9 @@ import ExecutionStatusIcon from "../components/ExecutionStatusIcon";
 const SECONDARY_TEXT_COLOR = "#A3A3A3";
 
 function TitleComponent({proposal}: {proposal: Proposal}): JSX.Element {
-  return <Typography variant="h5">{proposal.metadata.title}</Typography>;
+  return (
+    <Typography variant="h5">{proposal.proposal_metadata.title}</Typography>
+  );
 }
 
 function StatusComponent({proposal}: {proposal: Proposal}): JSX.Element {

--- a/src/pages/Governance/Proposals/Table.tsx
+++ b/src/pages/Governance/Proposals/Table.tsx
@@ -41,7 +41,7 @@ function TitleCell({proposal}: ProposalCellProps) {
           textOverflow: "ellipsis",
         }}
       >
-        {proposal.metadata.title}
+        {proposal.proposal_metadata.title}
       </Box>
     </TableCell>
   );

--- a/src/pages/Governance/Types.ts
+++ b/src/pages/Governance/Types.ts
@@ -4,10 +4,7 @@ export type Proposal = {
   proposer: string;
   creation_time_secs: string;
   execution_content: {
-    vec: Array<{
-      metadata_location: string;
-      metadata_hash: string;
-    }>;
+    vec: [];
   };
   execution_hash: string;
   min_vote_threshold: number;
@@ -18,7 +15,19 @@ export type Proposal = {
   yes_votes: string;
   no_votes: string;
   is_resolved: boolean;
-  metadata: ProposalMetadata;
+  metadata: {
+    data: [
+      {
+        key: "metadata_hash";
+        value: string;
+      },
+      {
+        key: "metadata_location";
+        value: string;
+      },
+    ];
+  };
+  proposal_metadata: ProposalMetadata;
   is_voting_closed: boolean;
   proposal_state: ProposalVotingState;
 };

--- a/src/pages/Governance/hooks/useGetProposal.tsx
+++ b/src/pages/Governance/hooks/useGetProposal.tsx
@@ -5,7 +5,7 @@ import {getTableItem} from "../../../api";
 import {GlobalState, useGlobalState} from "../../../GlobalState";
 import {Proposal, ProposalMetadata} from "../Types";
 import {getProposalState, isVotingClosed} from "../utils";
-import {hex_to_ascii} from "../../../utils";
+import {hex_to_string} from "../../../utils";
 
 const fetchTableItem = async (
   proposal_id: string,
@@ -33,7 +33,7 @@ const fetchProposalMetadata = async (
   proposalData: Proposal,
 ): Promise<ProposalMetadata | null> => {
   // fetch proposal metadata from metadata_location property
-  const metadata_location = hex_to_ascii(proposalData.metadata.data[1].value);
+  const metadata_location = hex_to_string(proposalData.metadata.data[1].value);
   const response = await fetch(metadata_location);
   // validate response status
   if (response.status !== 200) return null;
@@ -44,7 +44,7 @@ const fetchProposalMetadata = async (
   const metadata_hash = proposalData.metadata.data[0].value;
 
   const hash = sha3_256(metadataText);
-  if (hex_to_ascii(metadata_hash) !== hash) return null;
+  if (hex_to_string(metadata_hash) !== hash) return null;
 
   const proposal_metadata = JSON.parse(metadataText);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,3 +23,17 @@ export function sortTransactions(
   const second = "version" in b ? parseInt(b.version) : Infinity;
   return first < second ? 1 : -1;
 }
+
+/*
+Converts a utf8 string encoded as hex back to string
+if hex starts with 0x - ignore this part and start from the 3rd char (at index 2).
+*/
+export function hex_to_ascii(hex: string): string {
+  var hexString = hex.toString();
+  var str = "";
+  let n = hex.startsWith("0x") ? 2 : 0;
+  for (n; n < hexString.length; n += 2) {
+    str += String.fromCharCode(parseInt(hexString.substring(n, n + 2), 16));
+  }
+  return str;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function sortTransactions(
 Converts a utf8 string encoded as hex back to string
 if hex starts with 0x - ignore this part and start from the 3rd char (at index 2).
 */
-export function hex_to_ascii(hex: string): string {
+export function hex_to_string(hex: string): string {
   var hexString = hex.toString();
   var str = "";
   let n = hex.startsWith("0x") ? 2 : 0;


### PR DESCRIPTION
We were missing executed proposals from the UI because the metadata property is gone from the proposal object once the proposal has been executed. 
A new property was introduced to keep the metadata alive https://github.com/aptos-labs/aptos-core/pull/3140/files 

We now get the metadata values as a utf8 string encoded as hex, we need to convert it back to string.