### PR TITLE
Re-enable Nav (desktop & mobile), match Marketing spacing

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -7,17 +7,21 @@ export default function Nav() {
   return (
     <Box
       sx={{
-        display: {xs: "none", md: "flex"},
+        display: {xs: "none", sm: "flex"},
         alignItems: "center",
-        gap: 2,
-        marginRight: "1.5rem",
+        gap: {sm: 2, md: 4, lg: 8},
+        marginRight: {sm: "1rem", md: "2rem", lg: "3.5rem"},
       }}
     >
       <Button
         variant="nav"
         component={NavLink}
         to="/transactions"
-        sx={{color: "inherit"}}
+        title="View all Transactions"
+        sx={{
+          color: "inherit",
+          fontSize: {sm: ".875rem", md: "1rem"},
+        }}
       >
         Transactions
       </Button>
@@ -26,7 +30,11 @@ export default function Nav() {
         variant="nav"
         component={NavLink}
         to="/proposals"
-        sx={{color: "inherit"}}
+        title="Aptos Governance"
+        sx={{
+          color: "inherit",
+          fontSize: {sm: ".875rem", md: "1rem"},
+        }}
       >
         Governance
       </Button>

--- a/src/pages/layout/Header.tsx
+++ b/src/pages/layout/Header.tsx
@@ -95,7 +95,7 @@ export default function Header() {
               <LogoIcon />
             </Link>
 
-            {/* <Nav /> */}
+            <Nav />
             <NetworkSelect />
             <Button
               onClick={toggleColorMode}
@@ -114,7 +114,7 @@ export default function Header() {
             >
               {theme.palette.mode === "light" ? <IconLight /> : <IconDark />}
             </Button>
-            {/* <NavMobile /> */}
+            <NavMobile />
           </Toolbar>
         </Container>
       </MuiAppBar>


### PR DESCRIPTION
- Bring back Navigation for Desktop & Mobile
- Adjust spacing of items / breakpoints to better match Marketing site