### PR TITLE
fix to match with Petra's custom network feature

### DIFF
--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,12 +1,10 @@
 import {TxnBuilderTypes, AptosClient} from "aptos";
 import {useEffect, useState} from "react";
 
-import {
-  useWalletContext,
-  walletExplorerNetworkMap,
-} from "../../context/wallet/context";
+import {useWalletContext} from "../../context/wallet/context";
 import {signAndSubmitTransaction} from "../wallet";
 import {useGlobalState} from "../../GlobalState";
+import {networks} from "../../constants";
 
 export type TransactionResponse =
   | TransactionResponseOnSubmission
@@ -42,8 +40,8 @@ const useSubmitTransaction = () => {
   async function submitTransaction(
     payload: TxnBuilderTypes.TransactionPayloadEntryFunction,
   ) {
-    // if dApp network !== wallet network => return error
-    if (walletExplorerNetworkMap(walletNetwork) !== state.network_name) {
+    // if wallet network in dApp networks && dApp network !== wallet network => return error
+    if (walletNetwork in networks && walletNetwork !== state.network_name) {
       setTransactionResponse({
         transactionSubmitted: false,
         message:

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -3,8 +3,8 @@ export const devnetUrl =
 
 export const networks = {
   local: "http://localhost:8080",
-  devnet: devnetUrl,
-  test: "https://rosetta.aptosdev.com/",
+  Devnet: devnetUrl,
+  Testnet: "https://rosetta.aptosdev.com/",
   test2: "https://sherryx.aptosdev.com/",
 };
 
@@ -18,7 +18,7 @@ for (const key of Object.keys(networks)) {
   }
 }
 
-export const defaultNetworkName: NetworkName = "devnet" as const;
+export const defaultNetworkName: NetworkName = "Devnet" as const;
 
 if (!(defaultNetworkName in networks)) {
   throw `defaultNetworkName '${defaultNetworkName}' not in Networks!`;

--- a/src/context/wallet/context.tsx
+++ b/src/context/wallet/context.tsx
@@ -1,6 +1,4 @@
 import {createContext, useContext} from "react";
-import {NetworkName} from "../../constants";
-import {assertNever} from "../../utils";
 
 export interface walletContext {
   isInstalled: boolean;
@@ -22,21 +20,4 @@ export const useWalletContext = () => {
   return context;
 };
 
-export type WalletNetworks = "Devnet" | "Localhost" | "Testnet" | "Sherry";
-
-export const walletExplorerNetworkMap = (
-  walletNetwork: WalletNetworks,
-): NetworkName => {
-  switch (walletNetwork) {
-    case "Devnet":
-      return "devnet";
-    case "Localhost":
-      return "local";
-    case "Testnet":
-      return "test";
-    case "Sherry":
-      return "test2";
-    default:
-      return assertNever(walletNetwork);
-  }
-};
+export type WalletNetworks = "Devnet" | "Testnet";

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -26,12 +26,12 @@ export default function NetworkSelect() {
 
   const handleChange = (event: SelectChangeEvent<string>) => {
     const network_name = event.target.value;
-    maybeSetNetwork(network_name && network_name.toLowerCase());
+    maybeSetNetwork(network_name);
   };
 
   useEffect(() => {
     const network_name = searchParams.get("network");
-    maybeSetNetwork(network_name && network_name.toLowerCase());
+    maybeSetNetwork(network_name);
   });
 
   function DropdownIcon(props: SvgIconProps) {


### PR DESCRIPTION
Petra introduced a "custom networks" where the uncustomized networks are Devnet and Testnet (and in the future probably also "Mainnet"). Explorer does a check (by network name) if the dApp network is same as Petra network before submitting a transaction, to make it work with Petra's custom url feature, it should do this check only for the uncustomized networks.