### PR TITLE
Use Petra 1.6 version

### DIFF
--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,4 +1,4 @@
-import {TxnBuilderTypes, AptosClient} from "aptos";
+import {TxnBuilderTypes, AptosClient, Types} from "aptos";
 import {useEffect, useState} from "react";
 
 import {useWalletContext} from "../../context/wallet/context";
@@ -38,7 +38,7 @@ const useSubmitTransaction = () => {
   }, [transactionResponse]);
 
   async function submitTransaction(
-    payload: TxnBuilderTypes.TransactionPayloadEntryFunction,
+    payload: TxnBuilderTypes.TransactionPayload,
   ) {
     // if wallet network in dApp networks && dApp network !== wallet network => return error
     if (walletNetwork in networks && walletNetwork !== state.network_name) {

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,4 +1,4 @@
-import {TxnBuilderTypes, AptosClient, Types} from "aptos";
+import {AptosClient, Types} from "aptos";
 import {useEffect, useState} from "react";
 
 import {useWalletContext} from "../../context/wallet/context";
@@ -37,9 +37,7 @@ const useSubmitTransaction = () => {
     }
   }, [transactionResponse]);
 
-  async function submitTransaction(
-    payload: TxnBuilderTypes.TransactionPayload,
-  ) {
+  async function submitTransaction(payload: Types.TransactionPayload) {
     // if wallet network in dApp networks && dApp network !== wallet network => return error
     if (walletNetwork in networks && walletNetwork !== state.network_name) {
       setTransactionResponse({

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -71,11 +71,11 @@ export const signAndSubmitTransaction = async (
     transactionSubmitted: false,
     message: "Unknown Error",
   };
-  console.log("here");
   try {
     const response = await window.aptos?.signAndSubmitTransaction?.(
       transactionPayload,
     );
+    // transaction succeed
     if ("hash" in response) {
       await client.waitForTransaction(response["hash"]);
       return {
@@ -83,9 +83,9 @@ export const signAndSubmitTransaction = async (
         transactionHash: response["hash"],
       };
     }
+    // transaction failed
     return {...responseOnError, message: response.message};
   } catch (error: any) {
-    console.log(error);
     if (typeof error == "object" && "message" in error) {
       responseOnError.message = error.message;
     }

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -1,4 +1,4 @@
-import {TxnBuilderTypes, AptosClient} from "aptos";
+import {TxnBuilderTypes, AptosClient, Types} from "aptos";
 import {WalletNetworks} from "../context/wallet/context";
 import {
   TransactionResponse,
@@ -64,14 +64,14 @@ export const isUpdatedVersion = (): boolean =>
   window.aptos?.on instanceof Function;
 
 export const signAndSubmitTransaction = async (
-  transactionPayload: TxnBuilderTypes.TransactionPayloadEntryFunction,
+  transactionPayload: Types.TransactionPayload,
   client: AptosClient,
 ): Promise<TransactionResponse> => {
   const responseOnError: TransactionResponseOnError = {
     transactionSubmitted: false,
     message: "Unknown Error",
   };
-
+  console.log("here");
   try {
     const response = await window.aptos?.signAndSubmitTransaction?.(
       transactionPayload,
@@ -83,7 +83,9 @@ export const signAndSubmitTransaction = async (
         transactionHash: response["hash"],
       };
     }
+    return {...responseOnError, message: response.message};
   } catch (error: any) {
+    console.log(error);
     if (typeof error == "object" && "message" in error) {
       responseOnError.message = error.message;
     }

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -76,6 +76,7 @@ const OldWalletVersionWarning = (): JSX.Element => {
 export const WalletButton = (): JSX.Element => {
   const {isInstalled, isConnected, isAccountSet, connect, accountAddress} =
     useWalletContext();
+  // console.log(isAccountSet)
 
   if (!isInstalled) {
     return (

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -76,7 +76,6 @@ const OldWalletVersionWarning = (): JSX.Element => {
 export const WalletButton = (): JSX.Element => {
   const {isInstalled, isConnected, isAccountSet, connect, accountAddress} =
     useWalletContext();
-  // console.log(isAccountSet)
 
   if (!isInstalled) {
     return (

--- a/src/pages/Governance/Proposal/card/VoteButtons.tsx
+++ b/src/pages/Governance/Proposal/card/VoteButtons.tsx
@@ -62,7 +62,7 @@ export default function VoteButtons({proposalId}: VoteButtonsProps) {
   };
 
   const onVote = (shouldPass: boolean) => {
-    submitVote(parseInt(proposalId), shouldPass, accountAddr);
+    submitVote(proposalId, shouldPass, accountAddr);
     closeVoteForModal();
     closeVoteAgainstModal();
   };

--- a/src/pages/Governance/Stake/Index.tsx
+++ b/src/pages/Governance/Stake/Index.tsx
@@ -45,7 +45,7 @@ export function StakePage() {
     const isVoterAddrValid = validateVoterAddressInput();
 
     if (isStakingAmountValid && isOperatorAddrValid && isVoterAddrValid) {
-      await submitStake(parseInt(stakingAmount), operatorAddr, voterAddr);
+      await submitStake(stakingAmount, operatorAddr, voterAddr);
     }
   };
 

--- a/src/pages/Governance/hooks/useSubmitStake.ts
+++ b/src/pages/Governance/hooks/useSubmitStake.ts
@@ -1,4 +1,4 @@
-import {BCS, TxnBuilderTypes} from "aptos";
+import {Types} from "aptos";
 import useSubmitTransaction from "../../../api/hooks/useSubmitTransaction";
 
 const useSubmitStake = () => {
@@ -10,22 +10,16 @@ const useSubmitStake = () => {
   } = useSubmitTransaction();
 
   async function submitStake(
-    stakingAmount: number,
+    stakingAmount: string,
     operatorAddr: string,
     voterAddr: string,
   ) {
-    const payload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
-      TxnBuilderTypes.EntryFunction.natural(
-        "0x1::stake",
-        "initialize_stake_owner",
-        [],
-        [
-          BCS.bcsSerializeUint64(stakingAmount),
-          BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(operatorAddr)),
-          BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(voterAddr)),
-        ],
-      ),
-    );
+    const payload: Types.TransactionPayload = {
+      type: "entry_function_payload",
+      function: "0x1::stake::initialize_stake_owner",
+      type_arguments: [],
+      arguments: [stakingAmount, operatorAddr, voterAddr],
+    };
 
     await submitTransaction(payload);
   }

--- a/src/pages/Governance/hooks/useSubmitVote.ts
+++ b/src/pages/Governance/hooks/useSubmitVote.ts
@@ -10,7 +10,7 @@ const useSubmitVote = () => {
   } = useSubmitTransaction();
 
   async function submitVote(
-    proposalId: number,
+    proposalId: string,
     shouldPass: boolean,
     ownerAccountAddr: string,
   ) {
@@ -18,7 +18,7 @@ const useSubmitVote = () => {
       type: "entry_function_payload",
       function: "0x1::aptos_governance::vote",
       type_arguments: [],
-      arguments: [ownerAccountAddr, proposalId + "", shouldPass],
+      arguments: [ownerAccountAddr, proposalId, shouldPass],
     };
 
     await submitTransaction(payload);

--- a/src/pages/Governance/hooks/useSubmitVote.ts
+++ b/src/pages/Governance/hooks/useSubmitVote.ts
@@ -1,4 +1,4 @@
-import {BCS, TxnBuilderTypes} from "aptos";
+import {Types} from "aptos";
 import useSubmitTransaction from "../../../api/hooks/useSubmitTransaction";
 
 const useSubmitVote = () => {
@@ -14,22 +14,12 @@ const useSubmitVote = () => {
     shouldPass: boolean,
     ownerAccountAddr: string,
   ) {
-    const serializer = new BCS.Serializer();
-    serializer.serializeBool(shouldPass);
-    const payload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
-      TxnBuilderTypes.EntryFunction.natural(
-        "0x1::aptos_governance",
-        "vote",
-        [],
-        [
-          BCS.bcsToBytes(
-            TxnBuilderTypes.AccountAddress.fromHex(ownerAccountAddr),
-          ),
-          BCS.bcsSerializeUint64(proposalId),
-          serializer.getBytes(),
-        ],
-      ),
-    );
+    const payload: Types.TransactionPayload = {
+      type: "entry_function_payload",
+      function: "0x1::aptos_governance::vote",
+      type_arguments: [],
+      arguments: [ownerAccountAddr, proposalId + "", shouldPass],
+    };
 
     await submitTransaction(payload);
   }


### PR DESCRIPTION
Updates to use Petra 0.1.6 version

1. Pass transactions as JSON object to Petra
2. Display Petra's transactions errors