### PR TITLE
[Governance] go back from proposal page

### DIFF
--- a/src/components/GoBack.tsx
+++ b/src/components/GoBack.tsx
@@ -3,34 +3,46 @@ import {useNavigate} from "react-router-dom";
 import Button from "@mui/material/Button";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 
-export default function GoBack() {
+function BackButton(handleClick: () => void) {
+  return (
+    <>
+      <Button
+        color="primary"
+        variant="text"
+        onClick={handleClick}
+        sx={{
+          mb: 4,
+          p: 0,
+          "&:hover": {
+            background: "transparent",
+          },
+        }}
+        startIcon={<ArrowBackRoundedIcon />}
+      >
+        Back
+      </Button>
+    </>
+  );
+}
+
+type GoBackProps = {
+  to?: string;
+};
+
+export default function GoBack({to}: GoBackProps) {
   const navigate = useNavigate();
 
-  const handleClick = () => {
-    navigate(-1);
-  };
-
   if (window.history.state && window.history.state.idx > 0) {
-    return (
-      <>
-        <Button
-          color="primary"
-          variant="text"
-          onClick={handleClick}
-          sx={{
-            mb: 4,
-            p: 0,
-            "&:hover": {
-              background: "transparent",
-            },
-          }}
-          startIcon={<ArrowBackRoundedIcon />}
-        >
-          Back
-        </Button>
-      </>
-    );
+    return BackButton(() => {
+      navigate(-1);
+    });
   } else {
-    return null;
+    if (to != null) {
+      return BackButton(() => {
+        navigate(to);
+      });
+    } else {
+      return null;
+    }
   }
 }

--- a/src/components/GoBack.tsx
+++ b/src/components/GoBack.tsx
@@ -29,7 +29,7 @@ type GoBackProps = {
   to?: string;
 };
 
-export default function GoBack({to}: GoBackProps) {
+export default function GoBack({to}: GoBackProps): JSX.Element | null {
   const navigate = useNavigate();
 
   if (window.history.state && window.history.state.idx > 0) {

--- a/src/pages/Governance/CreateProposal/Create.tsx
+++ b/src/pages/Governance/CreateProposal/Create.tsx
@@ -6,7 +6,7 @@ import {useGlobalState} from "../../../GlobalState";
 import {doTransaction} from "../../utils";
 
 /* REQUIRED: Please replace the following with your own local network urls */
-const FAUCET_URL = "http://127.0.0.1:8000";
+const FAUCET_URL = "http://127.0.0.1:80";
 
 /* OPTIONAL: Please replace the following with your own test data */
 const TEST_EXECUTION_HASH =

--- a/src/pages/Governance/Proposal/Index.tsx
+++ b/src/pages/Governance/Proposal/Index.tsx
@@ -26,7 +26,7 @@ export const ProposalPage = () => {
   return (
     <Grid container>
       <Header />
-      <GoBack />
+      <GoBack to={"/proposals"} />
       <Grid item md={12} xs={12} sx={{mb: 6}}>
         <ProposalHeader proposal={proposal} />
       </Grid>


### PR DESCRIPTION
To address feedback from internal test: https://www.notion.so/aptoslabs/WIP-Governance-AIT3-Dogfooding-Instruction-01743af243d44794911aeb46b53cf9d1#82eb7c17671f4e6d9efbe73624be24cb

This PR:
* when a user visits a proposal page by opening url `/proposals/<handle_id>/<proposal_id>`, show go back button and go back to the proposals page on click.