### PR TITLE
[Governance] show votes on hover

### DIFF
--- a/src/pages/Governance/Proposal/card/ResultBar.tsx
+++ b/src/pages/Governance/Proposal/card/ResultBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Stack, Box, Typography} from "@mui/material";
+import {Stack, Box, Typography, Tooltip} from "@mui/material";
 import {
   primaryColor,
   negativeColor,
@@ -11,12 +11,21 @@ import {grey} from "../../../../themes/colors/aptosColorPalette";
 
 const RADIUS = "0.7em";
 
+function getFormattedVotesStr(votes: string): string {
+  return parseInt(votes).toLocaleString("en-US");
+}
+
 type ResultBarProps = {
   shouldPass: boolean;
+  votes: string;
   percentage: number;
 };
 
-export default function ResultBar({shouldPass, percentage}: ResultBarProps) {
+export default function ResultBar({
+  shouldPass,
+  votes,
+  percentage,
+}: ResultBarProps) {
   const theme = useTheme();
 
   const barColor = shouldPass ? primaryColor : negativeColor;
@@ -25,40 +34,43 @@ export default function ResultBar({shouldPass, percentage}: ResultBarProps) {
   const remainingPercentageStr = `${(100 - percentage).toFixed(0)}%`;
 
   return (
-    <Stack>
-      <Stack direction="row" justifyContent="space-between" paddingX={0.2}>
-        <Typography variant="subtitle2" color={barColor}>
-          {shouldPass ? voteFor : voteAgainst}
-        </Typography>
-        <Typography variant="subtitle2">{percentageStr}</Typography>
+    <Tooltip title={`${getFormattedVotesStr(votes)} votes`} placement="left">
+      <Stack>
+        <Stack direction="row" justifyContent="space-between" paddingX={0.2}>
+          <Typography variant="subtitle2" color={barColor}>
+            {shouldPass ? voteFor : voteAgainst}
+          </Typography>
+
+          <Typography variant="subtitle2">{percentageStr}</Typography>
+        </Stack>
+        <Stack direction="row">
+          <Box
+            component="div"
+            sx={{
+              pt: RADIUS,
+              backgroundColor: barColor,
+              borderTopLeftRadius: RADIUS,
+              borderBottomLeftRadius: RADIUS,
+              borderTopRightRadius: percentage === 100 ? RADIUS : "0",
+              borderBottomRightRadius: percentage === 100 ? RADIUS : "0",
+            }}
+            width={percentageStr}
+          />
+          <Box
+            component="div"
+            sx={{
+              pt: RADIUS,
+              backgroundColor:
+                theme.palette.mode === "dark" ? grey[800] : grey[200],
+              borderTopLeftRadius: percentage === 0 ? RADIUS : "0",
+              borderBottomLeftRadius: percentage === 0 ? RADIUS : "0",
+              borderTopRightRadius: RADIUS,
+              borderBottomRightRadius: RADIUS,
+            }}
+            width={remainingPercentageStr}
+          />
+        </Stack>
       </Stack>
-      <Stack direction="row">
-        <Box
-          component="div"
-          sx={{
-            pt: RADIUS,
-            backgroundColor: barColor,
-            borderTopLeftRadius: RADIUS,
-            borderBottomLeftRadius: RADIUS,
-            borderTopRightRadius: percentage === 100 ? RADIUS : "0",
-            borderBottomRightRadius: percentage === 100 ? RADIUS : "0",
-          }}
-          width={percentageStr}
-        />
-        <Box
-          component="div"
-          sx={{
-            pt: RADIUS,
-            backgroundColor:
-              theme.palette.mode === "dark" ? grey[800] : grey[200],
-            borderTopLeftRadius: percentage === 0 ? RADIUS : "0",
-            borderBottomLeftRadius: percentage === 0 ? RADIUS : "0",
-            borderTopRightRadius: RADIUS,
-            borderBottomRightRadius: RADIUS,
-          }}
-          width={remainingPercentageStr}
-        />
-      </Stack>
-    </Stack>
+    </Tooltip>
   );
 }

--- a/src/pages/Governance/Proposal/card/ResultsSection.tsx
+++ b/src/pages/Governance/Proposal/card/ResultsSection.tsx
@@ -30,8 +30,16 @@ export default function ResultsSection({proposal}: ResultsSectionProps) {
   return (
     <Section title="Results">
       <Stack spacing={1}>
-        <ResultBar shouldPass={true} percentage={votePercentage.yes} />
-        <ResultBar shouldPass={false} percentage={votePercentage.no} />
+        <ResultBar
+          shouldPass={true}
+          votes={proposal.yes_votes}
+          percentage={votePercentage.yes}
+        />
+        <ResultBar
+          shouldPass={false}
+          votes={proposal.no_votes}
+          percentage={votePercentage.no}
+        />
       </Stack>
     </Section>
   );


### PR DESCRIPTION
Per @movekevin's request, this PR added tooltips to show votes on hover. I thought about showing the number statically in the results section, but I really don't want to break Josh's beautiful design. Thus added the votes number in tooltips on hover. Should be sufficient enough.
<img width="1198" alt="Screen Shot 2022-08-23 at 5 30 23 PM" src="https://user-images.githubusercontent.com/109111707/186289434-e50fd356-9e4b-4de3-bc72-61d00a697341.png">
<img width="1199" alt="Screen Shot 2022-08-23 at 5 30 08 PM" src="https://user-images.githubusercontent.com/109111707/186289444-482f9835-98ec-49bf-935e-d0364a04aaca.png">
