### PR TITLE
use state to show stake pool, voter, operator changes on the ui

### DIFF
--- a/src/api/hooks/useGetAccountResource.ts
+++ b/src/api/hooks/useGetAccountResource.ts
@@ -1,5 +1,5 @@
 import {Types} from "aptos";
-import {useQuery} from "react-query";
+import {useQuery, UseQueryResult} from "react-query";
 import {getAccountResources} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../GlobalState";
@@ -8,6 +8,7 @@ type useGetAccountResourceResponse = {
   accountResource: Types.MoveResource | undefined;
   isLoading: boolean;
   isError: boolean;
+  refetch: () => Promise<UseQueryResult>;
 };
 
 export function useGetAccountResource(
@@ -19,16 +20,16 @@ export function useGetAccountResource(
     Array<Types.MoveResource>,
     ResponseError
   >(
-    ["accountResources", {address}, state.network_value],
+    ["accountResource", {address}, state.network_value],
     () => getAccountResources({address}, state.network_value),
     {refetchOnWindowFocus: false},
   );
 
-  const {isLoading, isError} = accountResourcesResult;
+  const {isLoading, isError, refetch} = accountResourcesResult;
 
   const accountResource = accountResourcesResult.data?.find(
     (r) => r.type === resource,
   );
 
-  return {accountResource, isLoading, isError};
+  return {accountResource, isLoading, isError, refetch};
 }

--- a/src/pages/Governance/Stake/Create.tsx
+++ b/src/pages/Governance/Stake/Create.tsx
@@ -7,7 +7,11 @@ import useAmountInput from "./hooks/useAmountInput";
 import TransactionResponseSnackbar from "../components/snackbar/TransactionResponseSnackbar";
 import LoadingModal from "../components/LoadingModal";
 
-export function Create() {
+type CreateProps = {
+  onCreateStackingPool: () => void;
+};
+
+export function Create({onCreateStackingPool}: CreateProps): JSX.Element {
   const {isConnected: isWalletConnected} = useWalletContext();
 
   const {
@@ -57,6 +61,7 @@ export function Create() {
       clearStakingAmount();
       clearOperatorAddr();
       clearVoterAddr();
+      onCreateStackingPool();
     }
   }, [transactionResponse]);
 

--- a/src/pages/Governance/Stake/Create.tsx
+++ b/src/pages/Governance/Stake/Create.tsx
@@ -8,10 +8,12 @@ import TransactionResponseSnackbar from "../components/snackbar/TransactionRespo
 import LoadingModal from "../components/LoadingModal";
 
 type CreateProps = {
-  onCreateStackingPool: () => void;
+  onCreateStackingPoolSuccess: () => void;
 };
 
-export function Create({onCreateStackingPool}: CreateProps): JSX.Element {
+export function Create({
+  onCreateStackingPoolSuccess,
+}: CreateProps): JSX.Element {
   const {isConnected: isWalletConnected} = useWalletContext();
 
   const {
@@ -61,7 +63,7 @@ export function Create({onCreateStackingPool}: CreateProps): JSX.Element {
       clearStakingAmount();
       clearOperatorAddr();
       clearVoterAddr();
-      onCreateStackingPool();
+      onCreateStackingPoolSuccess();
     }
   }, [transactionResponse]);
 

--- a/src/pages/Governance/Stake/components/CreateOrEdit.tsx
+++ b/src/pages/Governance/Stake/components/CreateOrEdit.tsx
@@ -26,7 +26,7 @@ export function CreateOrEdit({
     setHasStakePool(!!stakePool);
   }, [stakePool]);
 
-  const onCreateStackingPool = () => {
+  const onCreateStackingPoolSuccess = () => {
     setHasStakePool(true);
     refetch();
   };
@@ -39,5 +39,5 @@ export function CreateOrEdit({
   if (stakePool && hasStakePool)
     return <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />;
 
-  return <Create onCreateStackingPool={onCreateStackingPool} />;
+  return <Create onCreateStackingPoolSuccess={onCreateStackingPoolSuccess} />;
 }

--- a/src/pages/Governance/Stake/components/CreateOrEdit.tsx
+++ b/src/pages/Governance/Stake/components/CreateOrEdit.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 
 import {useGetAccountResource} from "../../../../api/hooks/useGetAccountResource";
 import LoadingModal from "../../components/LoadingModal";
@@ -12,25 +12,32 @@ type CreateOrEditProps = {
 export function CreateOrEdit({
   isWalletConnected,
   accountAddress,
-}: CreateOrEditProps) {
+}: CreateOrEditProps): JSX.Element {
+  const [hasStakePool, setHasStakePool] = useState<boolean>(false);
+
   const {
     accountResource: stakePool,
     isLoading,
     isError,
+    refetch,
   } = useGetAccountResource(accountAddress || "0x1", "0x1::stake::StakePool");
+
+  useEffect(() => {
+    setHasStakePool(!!stakePool);
+  }, [stakePool]);
+
+  const onCreateStackingPool = () => {
+    setHasStakePool(true);
+    refetch();
+  };
 
   if (isLoading) return <LoadingModal open={isLoading} />;
 
   // handle errors
   if (isError) return <div>Error</div>;
 
-  return (
-    <>
-      {stakePool ? (
-        <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />
-      ) : (
-        <Create />
-      )}
-    </>
-  );
+  if (stakePool && hasStakePool)
+    return <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />;
+
+  return <Create onCreateStackingPool={onCreateStackingPool} />;
 }

--- a/src/pages/Governance/Stake/components/EditOperator.tsx
+++ b/src/pages/Governance/Stake/components/EditOperator.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {
   Grid,
   Button,
@@ -23,9 +23,11 @@ type EditOperatorProps = {
 export function EditOperator({
   isWalletConnected,
   operatorAddress,
-}: EditOperatorProps) {
+}: EditOperatorProps): JSX.Element {
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
+  const [currOperatorAddress, setCurrOperatorAddress] =
+    useState<string>(operatorAddress);
 
   const {
     addr: operatorAddr,
@@ -43,6 +45,7 @@ export function EditOperator({
 
   useEffect(() => {
     if (transactionResponse?.transactionSubmitted) {
+      setCurrOperatorAddress(operatorAddr);
       clearOperatorAddr();
     }
   }, [transactionResponse]);
@@ -90,7 +93,7 @@ export function EditOperator({
               <Typography variant="subtitle1">
                 Current Operator Address:
               </Typography>
-              <HashButton hash={operatorAddress} />
+              <HashButton hash={currOperatorAddress} />
             </Stack>
           </Grid>
           <Grid item xs={12}>

--- a/src/pages/Governance/Stake/components/EditVoter.tsx
+++ b/src/pages/Governance/Stake/components/EditVoter.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {
   Grid,
   Button,
@@ -20,9 +20,13 @@ type EditVoterProps = {
   delegatedVoter: string;
 };
 
-export function EditVoter({isWalletConnected, delegatedVoter}: EditVoterProps) {
+export function EditVoter({
+  isWalletConnected,
+  delegatedVoter,
+}: EditVoterProps): JSX.Element {
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
+  const [voterAddress, setVoterAddress] = useState<string>(delegatedVoter);
 
   const {
     addr: voterAddr,
@@ -40,6 +44,7 @@ export function EditVoter({isWalletConnected, delegatedVoter}: EditVoterProps) {
 
   useEffect(() => {
     if (transactionResponse?.transactionSubmitted) {
+      setVoterAddress(voterAddr);
       clearVoterAddr();
     }
   }, [transactionResponse]);
@@ -87,7 +92,7 @@ export function EditVoter({isWalletConnected, delegatedVoter}: EditVoterProps) {
               <Typography variant="subtitle1">
                 Current Voter Address:
               </Typography>
-              <HashButton hash={delegatedVoter} />
+              <HashButton hash={voterAddress} />
             </Stack>
           </Grid>
           <Grid item xs={12}>

--- a/src/pages/Governance/Stake/components/EditVoter.tsx
+++ b/src/pages/Governance/Stake/components/EditVoter.tsx
@@ -26,7 +26,8 @@ export function EditVoter({
 }: EditVoterProps): JSX.Element {
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
-  const [voterAddress, setVoterAddress] = useState<string>(delegatedVoter);
+  const [currVoterAddress, setCurrVoterAddress] =
+    useState<string>(delegatedVoter);
 
   const {
     addr: voterAddr,
@@ -44,7 +45,7 @@ export function EditVoter({
 
   useEffect(() => {
     if (transactionResponse?.transactionSubmitted) {
-      setVoterAddress(voterAddr);
+      setCurrVoterAddress(voterAddr);
       clearVoterAddr();
     }
   }, [transactionResponse]);
@@ -92,7 +93,7 @@ export function EditVoter({
               <Typography variant="subtitle1">
                 Current Voter Address:
               </Typography>
-              <HashButton hash={voterAddress} />
+              <HashButton hash={currVoterAddress} />
             </Stack>
           </Grid>
           <Grid item xs={12}>


### PR DESCRIPTION
After users initialize staking pool OR change operator OR change voter, we want to show the new app state (without the need for them to refresh the page)

https://user-images.githubusercontent.com/29798064/186471548-806724a3-5615-4e7f-b0ce-434951c319ea.mov



