### PR TITLE
[Governance] fix time is "0"

### DIFF
--- a/src/pages/Transactions/helpers.tsx
+++ b/src/pages/Transactions/helpers.tsx
@@ -15,7 +15,7 @@ import MultipleStopRoundedIcon from "@mui/icons-material/MultipleStopRounded";
 import UpdateRoundedIcon from "@mui/icons-material/UpdateRounded";
 
 export function renderTimestamp(timestamp?: string) {
-  if (!timestamp)
+  if (!timestamp || timestamp === "0")
     return (
       <Typography variant="subtitle2" align="center">
         -


### PR DESCRIPTION
"0" is used as a placeholder for `null` for timestamps on chain. Therefore, "0" should not be a valid time. This PR fix this problem.


|Before|
|<img width="1583" alt="Screen Shot 2022-08-24 at 7 33 17 PM" src="https://user-images.githubusercontent.com/109111707/186561516-33f28bf1-44d3-405a-9f37-ce20e16d19bc.png">|
|---|
|After|
|<img width="1555" alt="Screen Shot 2022-08-24 at 7 35 04 PM" src="https://user-images.githubusercontent.com/109111707/186561562-74a6c476-193c-4680-8baf-d749dfbfe440.png">|