### PR TITLE
[Explorer] fix hash button link

### DIFF
--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -21,24 +21,27 @@ export enum HashType {
   OTHERS = "others",
 }
 
+function getHashLinkStr(hash: string, type: HashType): string {
+  switch (type) {
+    case HashType.ACCOUNT:
+      return `/account/${hash}`;
+    case HashType.TRANSACTION:
+      return `/txn/${hash}`;
+    case HashType.OTHERS:
+      return "";
+    default:
+      return assertNever(type);
+  }
+}
+
 function HashLink(hash: string, type: HashType): JSX.Element {
   switch (type) {
     case HashType.ACCOUNT:
-      return (
-        <Link
-          component={RRD.Link}
-          to={`/account/${hash}`}
-          target="_blank"
-          color="inherit"
-        >
-          {hash}
-        </Link>
-      );
     case HashType.TRANSACTION:
       return (
         <Link
           component={RRD.Link}
-          to={`/txn/${hash}`}
+          to={getHashLinkStr(hash, type)}
           target="_blank"
           color="inherit"
         >

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -13,12 +13,51 @@ import {grey} from "../themes/colors/aptosColorPalette";
 import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
 import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
 import {truncateAddress} from "../pages/utils";
+import {assertNever} from "../utils";
+
+export enum HashType {
+  ACCOUNT = "account",
+  TRANSACTION = "transaction",
+  OTHERS = "others",
+}
+
+function HashLink(hash: string, type: HashType): JSX.Element {
+  switch (type) {
+    case HashType.ACCOUNT:
+      return (
+        <Link
+          component={RRD.Link}
+          to={`/account/${hash}`}
+          target="_blank"
+          color="inherit"
+        >
+          {hash}
+        </Link>
+      );
+    case HashType.TRANSACTION:
+      return (
+        <Link
+          component={RRD.Link}
+          to={`/txn/${hash}`}
+          target="_blank"
+          color="inherit"
+        >
+          {hash}
+        </Link>
+      );
+    case HashType.OTHERS:
+      return <>{hash}</>;
+    default:
+      return assertNever(type);
+  }
+}
 
 interface HashButtonProps {
   hash: string;
+  type: HashType;
 }
 
-export default function HashButton({hash}: HashButtonProps) {
+export default function HashButton({hash, type}: HashButtonProps) {
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null,
   );
@@ -109,14 +148,7 @@ export default function HashButton({hash}: HashButtonProps) {
             },
           }}
         >
-          <Link
-            component={RRD.Link}
-            to={`/account/${hash}`}
-            target="_blank"
-            color="inherit"
-          >
-            {hash}
-          </Link>
+          {HashLink(hash, type)}
           <IconButton
             aria-label="collapse hash"
             onClick={hashCollapse}

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -11,7 +11,7 @@ import Typography from "@mui/material/Typography";
 import {useNavigate} from "react-router-dom";
 import GeneralTableRow from "../components/GeneralTableRow";
 import GeneralTableHeaderCell from "../components/GeneralTableHeaderCell";
-import HashButton from "./HashButton";
+import HashButton, {HashType} from "./HashButton";
 
 import {Types} from "aptos";
 import {
@@ -78,7 +78,7 @@ function TransactionGasCell({transaction}: TransactionCellProps) {
 function TransactionHashCell({transaction}: TransactionCellProps) {
   return (
     <TableCell>
-      <HashButton hash={transaction.hash} />
+      <HashButton hash={transaction.hash} type={HashType.TRANSACTION} />
     </TableCell>
   );
 }

--- a/src/pages/Governance/Proposal/Header.tsx
+++ b/src/pages/Governance/Proposal/Header.tsx
@@ -9,7 +9,7 @@ import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import {useTheme} from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {getStatusColor, isVotingClosed} from "../utils";
-import HashButton from "../../../components/HashButton";
+import HashButton, {HashType} from "../../../components/HashButton";
 import StatusIcon from "../components/StatusIcon";
 import ProposalStatusTooltip from "../components/ProposalStatusTooltip";
 
@@ -110,7 +110,7 @@ function ProposerAndTimeComponent({
           PROPOSER:
         </Typography>
       </Stack>
-      <HashButton hash={proposal.proposer} />
+      <HashButton hash={proposal.proposer} type={HashType.ACCOUNT} />
     </Stack>
   );
 

--- a/src/pages/Governance/Proposals/Table.tsx
+++ b/src/pages/Governance/Proposals/Table.tsx
@@ -17,7 +17,7 @@ import {Proposal} from "../Types";
 import {useGetProposal} from "../hooks/useGetProposal";
 import GeneralTableRow from "../../../components/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/GeneralTableHeaderCell";
-import HashButton from "../../../components/HashButton";
+import HashButton, {HashType} from "../../../components/HashButton";
 import {teal} from "../../../themes/colors/aptosColorPalette";
 import StatusIcon from "../components/StatusIcon";
 import ProposalStatusTooltip from "../components/ProposalStatusTooltip";
@@ -61,7 +61,7 @@ function StatusCell({proposal}: ProposalCellProps) {
 function ProposerCell({proposal}: ProposalCellProps) {
   return (
     <TableCell sx={{textAlign: "left"}}>
-      <HashButton hash={proposal.proposer} />
+      <HashButton hash={proposal.proposer} type={HashType.ACCOUNT} />
     </TableCell>
   );
 }

--- a/src/pages/Governance/Stake/components/EditOperator.tsx
+++ b/src/pages/Governance/Stake/components/EditOperator.tsx
@@ -13,7 +13,7 @@ import TransactionResponseSnackbar from "../../components/snackbar/TransactionRe
 import LoadingModal from "../../components/LoadingModal";
 import useAddressInput from "../../../../api/hooks/useAddressInput";
 import useSubmitChangeOperatorStake from "../../hooks/useSubmitChangeOperatorStake";
-import HashButton from "../../../../components/HashButton";
+import HashButton, {HashType} from "../../../../components/HashButton";
 
 type EditOperatorProps = {
   isWalletConnected: boolean;
@@ -93,7 +93,7 @@ export function EditOperator({
               <Typography variant="subtitle1">
                 Current Operator Address:
               </Typography>
-              <HashButton hash={currOperatorAddress} />
+              <HashButton hash={currOperatorAddress} type={HashType.ACCOUNT} />
             </Stack>
           </Grid>
           <Grid item xs={12} sm={8}>

--- a/src/pages/Governance/Stake/components/EditVoter.tsx
+++ b/src/pages/Governance/Stake/components/EditVoter.tsx
@@ -13,7 +13,7 @@ import TransactionResponseSnackbar from "../../components/snackbar/TransactionRe
 import LoadingModal from "../../components/LoadingModal";
 import useAddressInput from "../../../../api/hooks/useAddressInput";
 import useSubmitChangeVoterStake from "../../hooks/useSubmitChangeVoterStake";
-import HashButton from "../../../../components/HashButton";
+import HashButton, {HashType} from "../../../../components/HashButton";
 
 type EditVoterProps = {
   isWalletConnected: boolean;
@@ -93,7 +93,7 @@ export function EditVoter({
               <Typography variant="subtitle1">
                 Current Voter Address:
               </Typography>
-              <HashButton hash={currVoterAddress} />
+              <HashButton hash={currVoterAddress} type={HashType.ACCOUNT} />
             </Stack>
           </Grid>
           <Grid item xs={12} sm={8}>


### PR DESCRIPTION
A few days ago I added a link for HashButon so that clicking on the expanded hash button will bring us to the account page for that hash. The bug was, the link is set to account page for all hashes. Clicking on a transaction hash button also brings us to account page which is wrong. This PR fixes the bug by adding `type` property for the component `HashButton` and redirecting to the correct page on click.