### PR TITLE
[Governance] staking page wallet connection hot fix

### DIFF
--- a/src/pages/Governance/Stake/components/CreateOrEdit.tsx
+++ b/src/pages/Governance/Stake/components/CreateOrEdit.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {useGetAccountResource} from "../../../../api/hooks/useGetAccountResource";
+import LoadingModal from "../../components/LoadingModal";
 import {Create} from "../Create";
 import {Edit} from "../Edit";
 
@@ -13,10 +14,11 @@ export function CreateOrEdit({
 }: CreateOrEditProps): JSX.Element {
   const [hasStakePool, setHasStakePool] = useState<boolean>(false);
 
-  const {accountResource: stakePool, refetch} = useGetAccountResource(
-    accountAddress || "0x1",
-    "0x1::stake::StakePool",
-  );
+  const {
+    accountResource: stakePool,
+    isLoading,
+    refetch,
+  } = useGetAccountResource(accountAddress || "0x1", "0x1::stake::StakePool");
 
   useEffect(() => {
     setHasStakePool(!!stakePool);
@@ -26,6 +28,8 @@ export function CreateOrEdit({
     setHasStakePool(true);
     refetch();
   };
+
+  if (isLoading) return <LoadingModal open={isLoading} />;
 
   if (stakePool && hasStakePool) {
     return <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />;

--- a/src/pages/Governance/Stake/components/CreateOrEdit.tsx
+++ b/src/pages/Governance/Stake/components/CreateOrEdit.tsx
@@ -1,7 +1,5 @@
 import React, {useEffect, useState} from "react";
-
 import {useGetAccountResource} from "../../../../api/hooks/useGetAccountResource";
-import LoadingModal from "../../components/LoadingModal";
 import {Create} from "../Create";
 import {Edit} from "../Edit";
 
@@ -15,12 +13,10 @@ export function CreateOrEdit({
 }: CreateOrEditProps): JSX.Element {
   const [hasStakePool, setHasStakePool] = useState<boolean>(false);
 
-  const {
-    accountResource: stakePool,
-    isLoading,
-    isError,
-    refetch,
-  } = useGetAccountResource(accountAddress || "0x1", "0x1::stake::StakePool");
+  const {accountResource: stakePool, refetch} = useGetAccountResource(
+    accountAddress || "0x1",
+    "0x1::stake::StakePool",
+  );
 
   useEffect(() => {
     setHasStakePool(!!stakePool);
@@ -31,13 +27,9 @@ export function CreateOrEdit({
     refetch();
   };
 
-  if (isLoading) return <LoadingModal open={isLoading} />;
-
-  // handle errors
-  if (isError) return <div>Error</div>;
-
-  if (stakePool && hasStakePool)
+  if (stakePool && hasStakePool) {
     return <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />;
-
-  return <Create onCreateStackingPoolSuccess={onCreateStackingPoolSuccess} />;
+  } else {
+    return <Create onCreateStackingPoolSuccess={onCreateStackingPoolSuccess} />;
+  }
 }


### PR DESCRIPTION
To address bug report https://aptos-org.slack.com/archives/C03SS1MMX3K/p1661805542133359.
|Before|After|
|---|---|
|<img width="1402" alt="Screen Shot 2022-08-29 at 4 09 56 PM" src="https://user-images.githubusercontent.com/109111707/187315636-4d764973-e289-47b3-bb8a-b071b7b9f61f.png">|<img width="1401" alt="Screen Shot 2022-08-29 at 4 10 31 PM" src="https://user-images.githubusercontent.com/109111707/187315632-73b0de1e-cc08-4007-913b-834a5acc10c3.png">|

This is a hot fix to show the staking page even when the connected account is not in the right network. 

Ideally, we should prevent users connect their accounts on the wrong network in the wallet extension. This will take some decent effort and some time to wait for Chrome store review. So here we implement this hot fix in the Governance UI as a temporary solution. 

The hot fix is safe because when users try to submit the staking transaction with wrong account-network relationship, the transaction will fail anyway.
