### PR TITLE
[Governance] add error message when account does not exist

### DIFF
--- a/src/pages/Governance/Stake/components/CreateOrEdit.tsx
+++ b/src/pages/Governance/Stake/components/CreateOrEdit.tsx
@@ -3,6 +3,8 @@ import {useGetAccountResource} from "../../../../api/hooks/useGetAccountResource
 import LoadingModal from "../../components/LoadingModal";
 import {Create} from "../Create";
 import {Edit} from "../Edit";
+import {Alert} from "@mui/material";
+import {useGlobalState} from "../../../../GlobalState";
 
 type CreateOrEditProps = {
   isWalletConnected: boolean;
@@ -12,11 +14,13 @@ export function CreateOrEdit({
   isWalletConnected,
   accountAddress,
 }: CreateOrEditProps): JSX.Element {
+  const [state, _] = useGlobalState();
   const [hasStakePool, setHasStakePool] = useState<boolean>(false);
 
   const {
     accountResource: stakePool,
     isLoading,
+    isError,
     refetch,
   } = useGetAccountResource(accountAddress || "0x1", "0x1::stake::StakePool");
 
@@ -29,7 +33,17 @@ export function CreateOrEdit({
     refetch();
   };
 
-  if (isLoading) return <LoadingModal open={isLoading} />;
+  if (isLoading) {
+    return <LoadingModal open={isLoading} />;
+  }
+
+  if (isError) {
+    return (
+      <Alert severity="error">
+        {`Account ${accountAddress} is not found in the current network "${state.network_name}". Please switch to your owner account in the wallet.`}
+      </Alert>
+    );
+  }
 
   if (stakePool && hasStakePool) {
     return <Edit stakePool={stakePool} isWalletConnected={isWalletConnected} />;


### PR DESCRIPTION
This is a follow up of #131. 

Synced up with @kent-white, the new plan is to show error message when the connected account does not exist in the current network. We want to prompt users to switch to the correct account in the wallet app. 

<img width="1401" alt="Screen Shot 2022-08-29 at 5 48 17 PM" src="https://user-images.githubusercontent.com/109111707/187324182-06393a98-8237-4f3f-99bb-4cbe94e1babc.png">
