### PR TITLE
[NHC] Add support for specifying public key and noise port if necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "aptos": "^1.3.7",
-    "aptos-node-checker-client": "0.0.1",
+    "aptos-node-checker-client": "0.0.2",
     "date-fns": "^2.29.1",
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",

--- a/src/pages/NodeChecker/EvaluationDisplay.tsx
+++ b/src/pages/NodeChecker/EvaluationDisplay.tsx
@@ -39,11 +39,11 @@ export default function EvaluationDisplay({
     return (
       <Card>
         <Box
-          minHeight={300}
+          minHeight={320}
           sx={{
             display: "flex",
             flexDirection: "column",
-            margin: 2,
+            margin: 3,
           }}
         >
           <Box>
@@ -55,7 +55,13 @@ export default function EvaluationDisplay({
               sx={{mt: 2}}
             />
           </Box>
-          <Typography variant="body1" marginBottom={2}>
+          <Typography
+            variant="body1"
+            marginBottom={2}
+            sx={{
+              wordWrap: "break-word",
+            }}
+          >
             {content}
           </Typography>
           {linkButton}
@@ -78,7 +84,7 @@ export default function EvaluationDisplay({
   });
 
   return (
-    <Box marginX={10}>
+    <Box marginX={6}>
       <Divider />
       <Grid mb={12}>
         <Typography

--- a/src/pages/NodeChecker/hooks/usePortInput.tsx
+++ b/src/pages/NodeChecker/hooks/usePortInput.tsx
@@ -12,8 +12,8 @@ function isValidPort(port: string): boolean {
   return portNumber >= 1 && portNumber <= 65535;
 }
 
-const usePortInput = () => {
-  const [port, setPort] = useState<string>("");
+const usePortInput = (initialValue: string) => {
+  const [port, setPort] = useState<string>(initialValue);
   const [portIsValid, setPortIsValid] = useState<boolean>(true);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,10 +2737,10 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-aptos-node-checker-client@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/aptos-node-checker-client/-/aptos-node-checker-client-0.0.1.tgz#a0c0a6c81280bc15be1ef65e0f6d2a8004722029"
-  integrity sha512-SCdT1AlbyYHSPx9X8RmSNpcchYhHOYiJSf2x3pFPe0GOIcaAG5jRGz+p5usEjCfcTLYnUP5Vh/atkIoSx6Cw4Q==
+aptos-node-checker-client@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/aptos-node-checker-client/-/aptos-node-checker-client-0.0.2.tgz#2984a7b3bd908fc7c5ba3ff085639a8a1efdb891"
+  integrity sha512-W1Fd6ybB69OW4v3vDmDdmzO7HknYTjmZeHAlt/dlzmnZGKKu9zd3dfx0vt/aSY1f5WTkjMI3hOqYVFAgR6SQYg==
   dependencies:
     axios "^0.27.2"
 


### PR DESCRIPTION
## Summary
The new HandshakeEvaluator requires that the user provides a public key. This change makes it possible for them to do that. The public key field is only shown if necessary.

## Test plan
I tested both remote and local NHCs, each with different baseline configurations that sometimes require the public key. Every use case I tested worked with the UI.

<img width="2378" alt="image" src="https://user-images.githubusercontent.com/7816187/188038919-c92c5080-0441-40e8-88df-ec0529447cd2.png">
