### PR TITLE
[Explorer] add dev mode

### DIFF
--- a/src/GlobalState.tsx
+++ b/src/GlobalState.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import {networks, defaultNetworkName, NetworkName} from "./constants";
+import {
+  networks,
+  defaultNetworkName,
+  NetworkName,
+  features,
+  defaultFeatureName,
+  FeatureName,
+} from "./constants";
 
 const selected_network = safeGetSelectedNetworkName();
 
@@ -14,22 +21,44 @@ function safeGetSelectedNetworkName(): NetworkName {
   return defaultNetworkName;
 }
 
+const selected_feature = safeGetSelectedFeatureName();
+
+function safeGetSelectedFeatureName(): FeatureName {
+  let selected_feature = localStorage.getItem("selected_feature");
+  if (selected_feature) {
+    selected_feature = selected_feature.toLowerCase();
+    if (selected_feature in features) {
+      return selected_feature as FeatureName;
+    }
+  }
+  return defaultFeatureName;
+}
+
 export type GlobalState = {
   network_name: NetworkName;
   network_value: string;
+  feature_name: FeatureName;
 };
 
 const defaultGlobalState: GlobalState = {
   network_name: selected_network,
   network_value: networks[selected_network],
+  feature_name: selected_feature,
 };
 
 function reducer(state: GlobalState, newValue: GlobalState): GlobalState {
-  if (newValue.network_name)
+  if (newValue.network_name) {
     localStorage.setItem(
       "selected_network",
       newValue.network_name.toLowerCase(),
     );
+  }
+  if (newValue.feature_name) {
+    localStorage.setItem(
+      "selected_feature",
+      newValue.feature_name.toLowerCase(),
+    );
+  }
   return {...state, ...newValue};
 }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,3 +1,6 @@
+/**
+ * Network
+ */
 export const devnetUrl =
   process.env.APTOS_DEVNET_URL || "https://fullnode.devnet.aptoslabs.com/";
 
@@ -26,5 +29,34 @@ if (!(defaultNetworkName in networks)) {
 
 export const defaultNetwork = networks[defaultNetworkName];
 
+/**
+ * Feature
+ */
+export const features = {
+  prod: "Production Mode",
+  dev: "Development Mode",
+};
+
+export type FeatureName = keyof typeof features;
+
+// Remove trailing slashes
+for (const key of Object.keys(features)) {
+  const featureName = key as FeatureName;
+  if (features[featureName].endsWith("/")) {
+    features[featureName] = features[featureName].slice(0, -1);
+  }
+}
+
+export const defaultFeatureName: FeatureName = "prod" as const;
+
+if (!(defaultFeatureName in features)) {
+  throw `defaultFeatureName '${defaultFeatureName}' not in Features!`;
+}
+
+export const defaultFeature = features[defaultFeatureName];
+
+/**
+ * Wallet
+ */
 export const installWalletUrl =
   "https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci";

--- a/src/pages/layout/FeatureBar.tsx
+++ b/src/pages/layout/FeatureBar.tsx
@@ -1,0 +1,75 @@
+import React, {useEffect} from "react";
+import {Box, Link, Stack, Typography} from "@mui/material";
+import {useSearchParams} from "react-router-dom";
+import {useGlobalState} from "../../GlobalState";
+import {features, FeatureName, defaultFeatureName} from "../../constants";
+
+const ALERT_COLOR: string = "#F97373"; // red
+
+/**
+ * This is the information bar on top of the screen when the current feature is not "prod".
+ * This bar is used to indicate that it is now in development mode.
+ */
+export default function FeatureBar() {
+  const [state, dispatch] = useGlobalState();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  function maybeSetFeature(featureNameString: string | null) {
+    if (!featureNameString || state.feature_name === featureNameString) {
+      return;
+    }
+    if (!(featureNameString in features)) {
+      return;
+    }
+    const feature_name = featureNameString as FeatureName;
+    const network_name = state.network_name;
+    const network_value = state.network_value;
+    if (feature_name) {
+      // only show the "feature" param in the url when it's not "prod"
+      // we don't want the users to know the existence of the "feature" param
+      if (feature_name !== defaultFeatureName) {
+        setSearchParams({network: network_name, feature: feature_name});
+      } else {
+        setSearchParams({network: network_name});
+      }
+      dispatch({network_name, network_value, feature_name});
+    }
+  }
+
+  const goToProd = () => {
+    maybeSetFeature(defaultFeatureName);
+  };
+
+  useEffect(() => {
+    const feature_name = searchParams.get("feature");
+    if (feature_name) {
+      maybeSetFeature(feature_name);
+    } else {
+      // the "feature" param being null means that it's in "prod"
+      // so set feature to "prod"
+      maybeSetFeature(defaultFeatureName);
+    }
+  });
+
+  if (state.feature_name === defaultFeatureName) {
+    return null;
+  }
+
+  return (
+    <Box sx={{backgroundColor: ALERT_COLOR}} padding={1}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Typography>{`This is the ${
+          features[state.feature_name]
+        }.`}</Typography>
+        <Link
+          component="button"
+          variant="body2"
+          color="inherit"
+          onClick={goToProd}
+        >
+          Go To Prod
+        </Link>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/pages/layout/Header.tsx
+++ b/src/pages/layout/Header.tsx
@@ -16,6 +16,7 @@ import Nav from "../../components/Nav";
 import NavMobile from "../../components/NavMobile";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import {useInView} from "react-intersection-observer";
+import FeatureBar from "./FeatureBar";
 
 export default function Header() {
   const scrollTop = () => {
@@ -71,6 +72,7 @@ export default function Header() {
             }),
         }}
       >
+        <FeatureBar />
         <Container maxWidth={false}>
           <Toolbar
             sx={{

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect} from "react";
 import {FormControl, Select, SelectChangeEvent} from "@mui/material";
-import {NetworkName, networks} from "../../constants";
+import {defaultFeatureName, NetworkName, networks} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useTheme} from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";
@@ -16,11 +16,18 @@ export default function NetworkSelect() {
   function maybeSetNetwork(networkNameString: string | null) {
     if (!networkNameString || state.network_name === networkNameString) return;
     if (!(networkNameString in networks)) return;
+    const feature_name = state.feature_name;
     const network_name = networkNameString as NetworkName;
     const network_value = networks[network_name];
     if (network_value) {
-      setSearchParams({network: network_name});
-      dispatch({network_name, network_value});
+      // only show the "feature" param in the url when it's not "prod"
+      // we don't want the users to know the existence of the "feature" param
+      if (feature_name !== defaultFeatureName) {
+        setSearchParams({network: network_name, feature: feature_name});
+      } else {
+        setSearchParams({network: network_name});
+      }
+      dispatch({network_name, network_value, feature_name});
     }
   }
 

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
 import Header from "./Header";
 import Footer from "./Footer";
 import {GlobalStateProvider} from "../../GlobalState";


### PR DESCRIPTION
As discussed in https://aptos-org.slack.com/archives/C03NTMWVA6Q/p1662755968130119, I'm looking for a solution to hide in-development features from users. After doing some research on the third-party tools that supports all the fancy things including A/B test and data analysis, I finally landed on an extremely simple and 100% free solution. We will use the param in the URL to identify the current mode (prod/dev). The implementation is similar to how we handle networks. In the future, we can potentially support more features. For example, we might have dev1 and dev2 which gates different in-dev features. 

https://user-images.githubusercontent.com/109111707/189464809-93f1d1ff-a532-40b9-b664-da0a8962ba59.mov

