### PR TITLE
[Explorer] re-organize files

### DIFF
--- a/src/components/IndividualPageContent/CollapsibleCard.tsx
+++ b/src/components/IndividualPageContent/CollapsibleCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Stack, Typography, useTheme, Box, Grid} from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import {grey} from "../../../../themes/colors/aptosColorPalette";
+import {grey} from "../../themes/colors/aptosColorPalette";
 
 type CollapsibleCardProps = {
   titleKey: string;

--- a/src/components/IndividualPageContent/CollapsibleCards.tsx
+++ b/src/components/IndividualPageContent/CollapsibleCards.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Stack, Typography, useTheme, Box, Button} from "@mui/material";
-import {grey} from "../../../../themes/colors/aptosColorPalette";
+import {grey} from "../../themes/colors/aptosColorPalette";
 
 // return true if there is at least 1 card is not expanded
 function getNotAllExpanded(expandedList: boolean[]): boolean {

--- a/src/components/IndividualPageContent/ContentBox.tsx
+++ b/src/components/IndividualPageContent/ContentBox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Box, Stack, useTheme} from "@mui/material";
-import {grey} from "../../../../themes/colors/aptosColorPalette";
+import {grey} from "../../themes/colors/aptosColorPalette";
 
 interface ContentBoxProps {
   children: React.ReactNode;

--- a/src/components/IndividualPageContent/ContentRow.tsx
+++ b/src/components/IndividualPageContent/ContentRow.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Grid, Box, Typography} from "@mui/material";
-import {grey} from "../../../../themes/colors/aptosColorPalette";
+import {grey} from "../../themes/colors/aptosColorPalette";
 import EmptyValue from "./EmptyValue";
 
 type ContentRowProps = {

--- a/src/components/IndividualPageContent/EmptyValue.tsx
+++ b/src/components/IndividualPageContent/EmptyValue.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Box} from "@mui/material";
-import {grey} from "../../../../themes/colors/aptosColorPalette";
+import {grey} from "../../themes/colors/aptosColorPalette";
 
 export default function EmptyValue() {
   return <Box color={grey[450]}>N/A</Box>;

--- a/src/components/IndividualPageContent/JsonCard.tsx
+++ b/src/components/IndividualPageContent/JsonCard.tsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import {Box, useTheme} from "@mui/material";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import EmptyValue from "../pages/Transaction/Tabs/Components/EmptyValue";
+import EmptyValue from "./EmptyValue";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -8,8 +8,8 @@ import {
 } from "../../Transactions/helpers";
 import Row from "./Components/Row";
 import HashButton, {HashType} from "../../../components/HashButton";
-import ContentBox from "./Components/ContentBox";
-import ContentRow from "./Components/ContentRow";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -5,11 +5,11 @@ import {renderDebug} from "../../utils";
 import Divider from "@mui/material/Divider";
 import Row from "./Components/Row";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
-import CollapsibleCards from "./Components/CollapsibleCards";
+import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import useExpandedList from "../hooks/useExpandedList";
-import ContentRow from "./Components/ContentRow";
-import CollapsibleCard from "./Components/CollapsibleCard";
-import JsonCard from "../../../components/JsonCard";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
+import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
+import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 
 function Change({change, i}: {change: Types.WriteSetChange; i: number}) {
   return (

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -4,11 +4,11 @@ import {Stack, Box} from "@mui/material";
 import {renderDebug} from "../../utils";
 import Divider from "@mui/material/Divider";
 import Row from "./Components/Row";
-import CollapsibleCard from "./Components/CollapsibleCard";
+import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
-import ContentRow from "./Components/ContentRow";
-import JsonCard from "../../../components/JsonCard";
-import CollapsibleCards from "./Components/CollapsibleCards";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
+import JsonCard from "../../../components/IndividualPageContent/JsonCard";
+import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import useExpandedList from "../hooks/useExpandedList";
 
 function Event({event}: {event: Types.Event}) {

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -3,8 +3,8 @@ import {Types} from "aptos";
 import {Stack, Box} from "@mui/material";
 import {renderGas, renderSuccess} from "../../Transactions/helpers";
 import Row from "./Components/Row";
-import ContentRow from "./Components/ContentRow";
-import ContentBox from "./Components/ContentBox";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 

--- a/src/pages/Transaction/Tabs/PayloadTab.tsx
+++ b/src/pages/Transaction/Tabs/PayloadTab.tsx
@@ -3,8 +3,8 @@ import {Types} from "aptos";
 import {Box, Typography} from "@mui/material";
 import {renderDebug} from "../../utils";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
-import CollapsibleCard from "./Components/CollapsibleCard";
-import JsonCard from "../../../components/JsonCard";
+import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
+import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 
 type PayloadTabProps = {
   transaction: Types.Transaction;

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -5,8 +5,8 @@ import {renderGas, renderTimestamp} from "../../Transactions/helpers";
 import Row from "./Components/Row";
 import HashButton, {HashType} from "../../../components/HashButton";
 import {renderDebug} from "../../utils";
-import ContentBox from "./Components/ContentBox";
-import ContentRow from "./Components/ContentRow";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 
 type PendingTransactionOverviewTabProps = {

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -7,8 +7,8 @@ import {
   renderTimestamp,
 } from "../../Transactions/helpers";
 import Row from "./Components/Row";
-import ContentRow from "./Components/ContentRow";
-import ContentBox from "./Components/ContentBox";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -9,11 +9,11 @@ import {
 } from "../../Transactions/helpers";
 import Row from "./Components/Row";
 import HashButton, {HashType} from "../../../components/HashButton";
-import ContentBox from "./Components/ContentBox";
-import ContentRow from "./Components/ContentRow";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
+import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
-import JsonCard from "../../../components/JsonCard";
+import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;


### PR DESCRIPTION
Move some reusable components to global components folder. The following PRs will use them for the account page.