### PR TITLE
[Explorer] new txn page: add tooltips

### DIFF
--- a/src/components/IndividualPageContent/ContentBox.tsx
+++ b/src/components/IndividualPageContent/ContentBox.tsx
@@ -1,25 +1,30 @@
 import * as React from "react";
-import {Box, Stack, useTheme} from "@mui/material";
+import {Box, BoxProps, Stack, useTheme} from "@mui/material";
 import {grey} from "../../themes/colors/aptosColorPalette";
 
-interface ContentBoxProps {
+interface ContentBoxProps extends BoxProps {
   children: React.ReactNode;
 }
 
-export default function ContentBox({children}: ContentBoxProps): JSX.Element {
+export default function ContentBox({
+  children,
+  ...props
+}: ContentBoxProps): JSX.Element {
   const theme = useTheme();
   // TODO: unify colors for the new transaction page
   const backgroundColor = theme.palette.mode === "dark" ? grey[800] : grey[50];
 
   return (
     <Box
-      paddingX={4}
+      paddingLeft={4}
+      paddingRight={4}
       paddingY={4}
       marginTop={3}
       sx={{
         backgroundColor: backgroundColor,
         borderRadius: "15px",
       }}
+      {...props}
     >
       <Stack direction="column" spacing={3}>
         {children}

--- a/src/components/IndividualPageContent/ContentRow.tsx
+++ b/src/components/IndividualPageContent/ContentRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Grid, Box, Typography, Stack} from "@mui/material";
 import {grey} from "../../themes/colors/aptosColorPalette";
-import EmptyValue from "./EmptyValue";
+import EmptyValue from "./ContentValue/EmptyValue";
 
 type ContentRowProps = {
   title: string;

--- a/src/components/IndividualPageContent/ContentRow.tsx
+++ b/src/components/IndividualPageContent/ContentRow.tsx
@@ -1,15 +1,21 @@
 import React from "react";
-import {Grid, Box, Typography} from "@mui/material";
+import {Grid, Box, Typography, Stack} from "@mui/material";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import EmptyValue from "./EmptyValue";
 
 type ContentRowProps = {
   title: string;
   value: React.ReactNode;
+  tooltip?: React.ReactNode;
   i?: any;
 };
 
-export default function ContentRow({title, value, i}: ContentRowProps) {
+export default function ContentRow({
+  title,
+  value,
+  tooltip,
+  i,
+}: ContentRowProps) {
   return (
     <Box>
       <Grid
@@ -17,12 +23,16 @@ export default function ContentRow({title, value, i}: ContentRowProps) {
         direction={{xs: "column", md: "row"}}
         rowSpacing={1}
         columnSpacing={4}
+        alignItems="center"
         key={i}
       >
         <Grid item md={3}>
-          <Typography variant="body2" color={grey[450]}>
-            {title}
-          </Typography>
+          <Stack direction="row">
+            {tooltip}
+            <Typography variant="body2" color={grey[450]}>
+              {title}
+            </Typography>
+          </Stack>
         </Grid>
         <Grid
           item

--- a/src/components/IndividualPageContent/ContentValue/EmptyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/EmptyValue.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Box} from "@mui/material";
-import {grey} from "../../themes/colors/aptosColorPalette";
+import {grey} from "../../../themes/colors/aptosColorPalette";
 
 export default function EmptyValue() {
   return <Box color={grey[450]}>N/A</Box>;

--- a/src/components/IndividualPageContent/ContentValue/GasValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/GasValue.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import NumberFormat from "react-number-format";
+
+type GasValueProps = {
+  gas: string;
+};
+
+export default function GasValue({gas}: GasValueProps) {
+  return <NumberFormat value={gas} displayType="text" thousandSeparator />;
+}

--- a/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
@@ -1,9 +1,9 @@
 import React, {useState} from "react";
-import {parseTimestamp, timestampDisplay} from "../../pages/utils";
+import {parseTimestamp, timestampDisplay} from "../../../pages/utils";
 import EmptyValue from "./EmptyValue";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {IconButton, Stack, Tooltip, Typography, useTheme} from "@mui/material";
-import {grey} from "../../themes/colors/aptosColorPalette";
+import {grey} from "../../../themes/colors/aptosColorPalette";
 
 const TOOLTIP_TIME = 2000; // 2s
 

--- a/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
@@ -2,8 +2,9 @@ import React, {useState} from "react";
 import {parseTimestamp, timestampDisplay} from "../../../pages/utils";
 import EmptyValue from "./EmptyValue";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import {IconButton, Stack, Tooltip, Typography, useTheme} from "@mui/material";
+import {IconButton, Stack, Typography, useTheme} from "@mui/material";
 import {grey} from "../../../themes/colors/aptosColorPalette";
+import StyledTooltip from "../../StyledTooltip";
 
 const TOOLTIP_TIME = 2000; // 2s
 
@@ -40,7 +41,7 @@ export default function TimestampValue({timestamp}: TimestampValueProps) {
       <Typography fontSize="inherit">
         {timestamp_display.local_formatted}
       </Typography>
-      <Tooltip
+      <StyledTooltip
         title="Timestamp copied"
         placement="right"
         open={tooltipOpen}
@@ -51,7 +52,7 @@ export default function TimestampValue({timestamp}: TimestampValueProps) {
         <IconButton onClick={copyTimestamp} sx={{padding: 0.6}}>
           <ContentCopyIcon sx={{color: color, fontSize: 15}} />
         </IconButton>
-      </Tooltip>
+      </StyledTooltip>
     </Stack>
   );
 }

--- a/src/components/IndividualPageContent/JsonCard.tsx
+++ b/src/components/IndividualPageContent/JsonCard.tsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import {Box, useTheme} from "@mui/material";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import EmptyValue from "./EmptyValue";
+import EmptyValue from "./ContentValue/EmptyValue";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";

--- a/src/components/IndividualPageContent/LearnMoreTooltip.tsx
+++ b/src/components/IndividualPageContent/LearnMoreTooltip.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import {Box, Link, Typography, Tooltip, useTheme} from "@mui/material";
+import {grey} from "../../themes/colors/aptosColorPalette";
+import {Stack} from "@mui/system";
+
+function TooltipBox({children}: {children?: React.ReactNode}) {
+  return <Box sx={{width: 25}}>{children}</Box>;
+}
+
+type LearnMoreTooltipProps = {
+  text: string;
+  link?: string;
+  linkToText?: boolean;
+};
+
+export function LearnMoreTooltip({
+  text,
+  link,
+  linkToText,
+}: LearnMoreTooltipProps): JSX.Element {
+  // TODO: unify colors for the new transaction page
+  const theme = useTheme();
+  const color = theme.palette.mode === "dark" ? grey[600] : grey[200];
+
+  return (
+    <TooltipBox>
+      <Tooltip
+        title={
+          <Stack alignItems="flex-end">
+            {linkToText ? (
+              <Link alignSelf="flex-end" href={link} color="inherit">
+                {text}
+              </Link>
+            ) : (
+              <>
+                <Typography variant="inherit">{text}</Typography>
+                {link && (
+                  <Link alignSelf="flex-end" href={link} color="inherit">
+                    Learn More
+                  </Link>
+                )}
+              </>
+            )}
+          </Stack>
+        }
+        arrow
+      >
+        <HelpOutlineOutlinedIcon fontSize="inherit" htmlColor={color} />
+      </Tooltip>
+    </TooltipBox>
+  );
+}
+
+export function LearnMoreTooltipPlaceholder(): JSX.Element {
+  return <TooltipBox></TooltipBox>;
+}

--- a/src/components/IndividualPageContent/LearnMoreTooltip.tsx
+++ b/src/components/IndividualPageContent/LearnMoreTooltip.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import {Box, Link, Typography, Tooltip, useTheme} from "@mui/material";
+import {Box, Link, Typography, useTheme} from "@mui/material";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import {Stack} from "@mui/system";
+import StyledTooltip from "../StyledTooltip";
 
 function TooltipBox({children}: {children?: React.ReactNode}) {
   return <Box sx={{width: 25}}>{children}</Box>;
@@ -25,7 +26,7 @@ export function LearnMoreTooltip({
 
   return (
     <TooltipBox>
-      <Tooltip
+      <StyledTooltip
         title={
           <Stack alignItems="flex-end">
             {linkToText ? (
@@ -47,7 +48,7 @@ export function LearnMoreTooltip({
         arrow
       >
         <HelpOutlineOutlinedIcon fontSize="inherit" htmlColor={color} />
-      </Tooltip>
+      </StyledTooltip>
     </TooltipBox>
   );
 }

--- a/src/components/IndividualPageContent/TimestampValue.tsx
+++ b/src/components/IndividualPageContent/TimestampValue.tsx
@@ -1,0 +1,57 @@
+import React, {useState} from "react";
+import {parseTimestamp, timestampDisplay} from "../../pages/utils";
+import EmptyValue from "./EmptyValue";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import {IconButton, Stack, Tooltip, Typography, useTheme} from "@mui/material";
+import {grey} from "../../themes/colors/aptosColorPalette";
+
+const TOOLTIP_TIME = 2000; // 2s
+
+type TimestampValueProps = {
+  timestamp: string;
+};
+
+export default function TimestampValue({timestamp}: TimestampValueProps) {
+  const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
+
+  // TODO: unify colors for the new transaction page
+  const theme = useTheme();
+  const color = theme.palette.mode === "dark" ? grey[600] : grey[200];
+
+  if (timestamp === "0") {
+    return <EmptyValue />;
+  }
+
+  const moment = parseTimestamp(timestamp);
+  const timestamp_display = timestampDisplay(moment);
+
+  const copyTimestamp = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    await navigator.clipboard.writeText(timestamp);
+
+    setTooltipOpen(true);
+
+    setTimeout(() => {
+      setTooltipOpen(false);
+    }, TOOLTIP_TIME);
+  };
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Typography fontSize="inherit">
+        {timestamp_display.local_formatted}
+      </Typography>
+      <Tooltip
+        title="Timestamp copied"
+        placement="right"
+        open={tooltipOpen}
+        disableFocusListener
+        disableHoverListener
+        disableTouchListener
+      >
+        <IconButton onClick={copyTimestamp} sx={{padding: 0.6}}>
+          <ContentCopyIcon sx={{color: color, fontSize: 15}} />
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+}

--- a/src/components/StyledTooltip.tsx
+++ b/src/components/StyledTooltip.tsx
@@ -1,0 +1,21 @@
+import {Box, Tooltip, TooltipProps} from "@mui/material";
+import React from "react";
+
+interface StyledTooltipProps extends TooltipProps {
+  title: NonNullable<React.ReactNode>;
+}
+
+export default function StyledTooltip({
+  children,
+  title,
+  ...props
+}: StyledTooltipProps) {
+  return (
+    <Tooltip
+      title={<Box sx={{fontSize: 13, fontFamily: "sans-serif"}}>{title}</Box>}
+      {...props}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -13,6 +13,8 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
+import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
+import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type BlockMetadataOverviewTabProps = {
   transaction: Types.Transaction;
@@ -61,12 +63,12 @@ export default function BlockMetadataOverviewTab({
         />
         <ContentRow
           title="Timestamp:"
-          value={transactionData.timestamp}
+          value={<TimestampValue timestamp={transactionData.timestamp} />}
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
           title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
+          value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -12,6 +12,7 @@ import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {getLearnMoreTooltip} from "../helpers";
 
 type BlockMetadataOverviewTabProps = {
   transaction: Types.Transaction;
@@ -26,13 +27,11 @@ export default function BlockMetadataOverviewTab({
 
   return inDev ? (
     <Box marginBottom={3}>
-      <ContentBox>
-        <ContentRow title="ID:" value={transactionData.id} />
-        <ContentRow title="Version:" value={transactionData.version} />
-        <ContentRow title="Round:" value={transactionData.round} />
+      <ContentBox paddingLeft={1.5}>
         <ContentRow
           title="Status:"
           value={<TransactionStatus success={transactionData.success} />}
+          tooltip={getLearnMoreTooltip("status")}
         />
         <ContentRow
           title="Proposer:"
@@ -42,27 +41,55 @@ export default function BlockMetadataOverviewTab({
               type={HashType.ACCOUNT}
             />
           }
+          tooltip={getLearnMoreTooltip("Proposer")}
         />
         <ContentRow
-          title="State Root Hash:"
-          value={transactionData.state_root_hash}
+          title="ID:"
+          value={transactionData.id}
+          tooltip={getLearnMoreTooltip("id")}
         />
         <ContentRow
-          title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          title={"Version:"}
+          value={transactionData.version}
+          tooltip={getLearnMoreTooltip("version")}
+        />
+
+        <ContentRow
+          title="Round:"
+          value={transactionData.round}
+          tooltip={getLearnMoreTooltip("round")}
+        />
+        <ContentRow
+          title="Timestamp:"
+          value={transactionData.timestamp}
+          tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
           title="Gas Used:"
           value={renderGas(transactionData.gas_used)}
+          tooltip={getLearnMoreTooltip("gas_used")}
         />
-        <ContentRow title="VM Status:" value={transactionData.vm_status} />
+        <ContentRow
+          title="VM Status:"
+          value={transactionData.vm_status}
+          tooltip={getLearnMoreTooltip("vm_status")}
+        />
+      </ContentBox>
+      <ContentBox>
+        <ContentRow
+          title="State Root Hash:"
+          value={transactionData.state_root_hash}
+          tooltip={getLearnMoreTooltip("state_root_hash")}
+        />
+        <ContentRow
+          title="Event Root Hash:"
+          value={transactionData.event_root_hash}
+          tooltip={getLearnMoreTooltip("event_root_hash")}
+        />
         <ContentRow
           title="Accumulator Root Hash:"
           value={transactionData.accumulator_root_hash}
-        />
-        <ContentRow
-          title="Timestamp:"
-          value={renderTimestamp(transactionData.timestamp)}
+          tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
     </Box>

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -8,6 +8,7 @@ import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
+import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type GenesisTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -35,7 +36,7 @@ export default function GenesisTransactionOverviewTab({
 
         <ContentRow
           title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
+          value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -7,6 +7,7 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {getLearnMoreTooltip} from "../helpers";
 
 type GenesisTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -21,27 +22,43 @@ export default function GenesisTransactionOverviewTab({
   return inDev ? (
     <Box marginBottom={3}>
       <ContentBox>
-        <ContentRow title="Version:" value={transactionData.version} />
         <ContentRow
           title="Status:"
           value={<TransactionStatus success={transactionData.success} />}
+          tooltip={getLearnMoreTooltip("status")}
         />
+        <ContentRow
+          title={"Version:"}
+          value={transactionData.version}
+          tooltip={getLearnMoreTooltip("version")}
+        />
+
+        <ContentRow
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
+          tooltip={getLearnMoreTooltip("gas_used")}
+        />
+        <ContentRow
+          title="VM Status:"
+          value={transactionData.vm_status}
+          tooltip={getLearnMoreTooltip("vm_status")}
+        />
+      </ContentBox>
+      <ContentBox>
         <ContentRow
           title="State Root Hash:"
           value={transactionData.state_root_hash}
+          tooltip={getLearnMoreTooltip("state_root_hash")}
         />
         <ContentRow
           title="Event Root Hash:"
           value={transactionData.event_root_hash}
+          tooltip={getLearnMoreTooltip("event_root_hash")}
         />
-        <ContentRow
-          title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
-        />
-        <ContentRow title="VM Status:" value={transactionData.vm_status} />
         <ContentRow
           title="Accumulator Root Hash:"
           value={transactionData.accumulator_root_hash}
+          tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
     </Box>

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -10,6 +10,8 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
+import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
+import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -38,17 +40,21 @@ export default function PendingTransactionOverviewTab({
         />
         <ContentRow
           title="Expiration Timestamp:"
-          value={renderTimestamp(transactionData.expiration_timestamp_secs)}
+          value={
+            <TimestampValue
+              timestamp={transactionData.expiration_timestamp_secs}
+            />
+          }
           tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}
         />
         <ContentRow
           title="Max Gas:"
-          value={renderGas(transactionData.max_gas_amount)}
+          value={<GasValue gas={transactionData.max_gas_amount} />}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="Gas Unit Price:"
-          value={renderGas(transactionData.gas_unit_price)}
+          value={<GasValue gas={transactionData.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -8,6 +8,8 @@ import {renderDebug} from "../../utils";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {getLearnMoreTooltip} from "../helpers";
+import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -27,26 +29,32 @@ export default function PendingTransactionOverviewTab({
           value={
             <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
           }
+          tooltip={getLearnMoreTooltip("sender")}
         />
         <ContentRow
           title="Sequence Number:"
           value={transactionData.sequence_number}
+          tooltip={getLearnMoreTooltip("sequence_number")}
         />
         <ContentRow
           title="Expiration Timestamp:"
           value={renderTimestamp(transactionData.expiration_timestamp_secs)}
+          tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}
         />
         <ContentRow
           title="Max Gas:"
           value={renderGas(transactionData.max_gas_amount)}
+          tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="Gas Unit Price:"
           value={renderGas(transactionData.gas_unit_price)}
+          tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow
           title="Signature:"
-          value={renderDebug(transactionData.signature)}
+          value={<JsonCard data={transactionData.signature} />}
+          tooltip={getLearnMoreTooltip("signature")}
         />
       </ContentBox>
     </Box>

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -11,6 +11,7 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {getLearnMoreTooltip} from "../helpers";
 
 type StateCheckpointOverviewTabProps = {
   transaction: Types.Transaction;
@@ -26,34 +27,50 @@ export default function StateCheckpointOverviewTab({
   return inDev ? (
     <Box marginBottom={3}>
       <ContentBox>
-        <ContentRow title="Version:" value={transactionData.version} />
         <ContentRow
           title="Status:"
           value={<TransactionStatus success={transactionData.success} />}
+          tooltip={getLearnMoreTooltip("status")}
         />
         <ContentRow
-          title="State Root Hash:"
-          value={transactionData.state_root_hash}
-        />
-        <ContentRow
-          title="Event Root Hash:"
-          value={transactionData.event_root_hash}
-        />
-        <ContentRow
-          title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
-        />
-        <ContentRow title="VM Status:" value={transactionData.vm_status} />
-        <ContentRow
-          title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
+          title={"Version:"}
+          value={transactionData.version}
+          tooltip={getLearnMoreTooltip("version")}
         />
         {"timestamp" in transactionData && (
           <ContentRow
             title="Timestamp:"
-            value={renderTimestamp(transactionData.timestamp)}
+            value={transactionData.timestamp}
+            tooltip={getLearnMoreTooltip("timestamp")}
           />
         )}
+        <ContentRow
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
+          tooltip={getLearnMoreTooltip("gas_used")}
+        />
+        <ContentRow
+          title="VM Status:"
+          value={transactionData.vm_status}
+          tooltip={getLearnMoreTooltip("vm_status")}
+        />
+      </ContentBox>
+      <ContentBox>
+        <ContentRow
+          title="State Root Hash:"
+          value={transactionData.state_root_hash}
+          tooltip={getLearnMoreTooltip("state_root_hash")}
+        />
+        <ContentRow
+          title="Event Root Hash:"
+          value={transactionData.event_root_hash}
+          tooltip={getLearnMoreTooltip("event_root_hash")}
+        />
+        <ContentRow
+          title="Accumulator Root Hash:"
+          value={transactionData.accumulator_root_hash}
+          tooltip={getLearnMoreTooltip("accumulator_root_hash")}
+        />
       </ContentBox>
     </Box>
   ) : (

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -12,6 +12,8 @@ import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
+import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
+import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type StateCheckpointOverviewTabProps = {
   transaction: Types.Transaction;
@@ -40,13 +42,13 @@ export default function StateCheckpointOverviewTab({
         {"timestamp" in transactionData && (
           <ContentRow
             title="Timestamp:"
-            value={transactionData.timestamp}
+            value={<TimestampValue timestamp={transactionData.timestamp} />}
             tooltip={getLearnMoreTooltip("timestamp")}
           />
         )}
         <ContentRow
           title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
+          value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -15,7 +15,8 @@ import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import {getLearnMoreTooltip} from "../helpers";
-import TimestampValue from "../../../components/IndividualPageContent/TimestampValue";
+import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
+import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -68,17 +69,17 @@ export default function UserTransactionOverviewTab({
         />
         <ContentRow
           title="Gas Used:"
-          value={renderGas(transactionData.gas_used)}
+          value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
           title="Max Gas:"
-          value={renderGas(transactionData.max_gas_amount)}
+          value={<GasValue gas={transactionData.max_gas_amount} />}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="Gas Unit Price:"
-          value={renderGas(transactionData.gas_unit_price)}
+          value={<GasValue gas={transactionData.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -14,6 +14,8 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
+import {getLearnMoreTooltip} from "../helpers";
+import TimestampValue from "../../../components/IndividualPageContent/TimestampValue";
 
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -27,58 +29,85 @@ export default function UserTransactionOverviewTab({
 
   return inDev ? (
     <Box marginBottom={3}>
-      <ContentBox>
+      <ContentBox paddingLeft={1.5}>
+        <ContentRow
+          title="Status:"
+          value={<TransactionStatus success={transactionData.success} />}
+          tooltip={getLearnMoreTooltip("status")}
+        />
         <ContentRow
           title="Sender:"
           value={
             <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
           }
+          tooltip={getLearnMoreTooltip("sender")}
+        />
+        <ContentRow
+          title={"Version:"}
+          value={transactionData.version}
+          tooltip={getLearnMoreTooltip("version")}
         />
         <ContentRow
           title="Sequence Number:"
           value={transactionData.sequence_number}
+          tooltip={getLearnMoreTooltip("sequence_number")}
         />
         <ContentRow
           title="Expiration Timestamp:"
-          value={renderTimestamp(transactionData.expiration_timestamp_secs)}
-        />
-        <ContentRow title={"Version:"} value={transactionData.version} />
-        <ContentRow
-          title="Status:"
-          value={<TransactionStatus success={transactionData.success} />}
-        />
-        <ContentRow
-          title="State Root Hash:"
-          value={transactionData.state_root_hash}
+          value={
+            <TimestampValue
+              timestamp={transactionData.expiration_timestamp_secs}
+            />
+          }
+          tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}
         />
         <ContentRow
-          title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          title="Timestamp:"
+          value={<TimestampValue timestamp={transactionData.timestamp} />}
+          tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
           title="Gas Used:"
           value={renderGas(transactionData.gas_used)}
+          tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
           title="Max Gas:"
           value={renderGas(transactionData.max_gas_amount)}
+          tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="Gas Unit Price:"
           value={renderGas(transactionData.gas_unit_price)}
+          tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
-        <ContentRow title="VM Status:" value={transactionData.vm_status} />
+        <ContentRow
+          title="VM Status:"
+          value={transactionData.vm_status}
+          tooltip={getLearnMoreTooltip("vm_status")}
+        />
       </ContentBox>
       <ContentBox>
         <ContentRow
           title="Signature:"
           value={<JsonCard data={transactionData.signature} />}
+          tooltip={getLearnMoreTooltip("signature")}
+        />
+        <ContentRow
+          title="State Root Hash:"
+          value={transactionData.state_root_hash}
+          tooltip={getLearnMoreTooltip("state_root_hash")}
+        />
+        <ContentRow
+          title="Event Root Hash:"
+          value={transactionData.event_root_hash}
+          tooltip={getLearnMoreTooltip("event_root_hash")}
         />
         <ContentRow
           title="Accumulator Root Hash:"
           value={transactionData.accumulator_root_hash}
+          tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
-        <ContentRow title="Timestamp:" value={transactionData.timestamp} />
       </ContentBox>
     </Box>
   ) : (

--- a/src/pages/Transaction/helpers.tsx
+++ b/src/pages/Transaction/helpers.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import {
+  LearnMoreTooltip,
+  LearnMoreTooltipPlaceholder,
+} from "../../components/IndividualPageContent/LearnMoreTooltip";
+
+export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
+  switch (txnField) {
+    case "status":
+      return <LearnMoreTooltipPlaceholder />;
+    case "sender":
+      return (
+        <LearnMoreTooltip
+          text="Sender is the address of the originator account for a transaction."
+          link="https://aptos.dev/reference/glossary/#sender"
+        />
+      );
+    case "proposer":
+      return <LearnMoreTooltipPlaceholder />;
+    case "id":
+      return <LearnMoreTooltipPlaceholder />;
+    case "version":
+      return (
+        <LearnMoreTooltip
+          text="A version is also called “height” in blockchain literature."
+          link="https://aptos.dev/reference/glossary/#version"
+        />
+      );
+    case "sequence_number":
+      return (
+        <LearnMoreTooltip
+          text="The sequence number for an account indicates the number of transactions that have been submitted and committed on chain from that account."
+          link="https://aptos.dev/reference/glossary/#sequence-number"
+        />
+      );
+    case "round":
+      return (
+        <LearnMoreTooltip
+          text="A round consists of achieving consensus on a block of transactions and their execution results."
+          link="https://aptos.dev/reference/glossary/#round"
+        />
+      );
+    case "expiration_timestamp_secs":
+      return (
+        <LearnMoreTooltip
+          text="A transaction ceases to be valid after its expiration time."
+          link="https://aptos.dev/reference/glossary/#expiration-time"
+        />
+      );
+    case "timestamp":
+      return (
+        <LearnMoreTooltip text="Timestamp is the machine timestamp of when the block is committed." />
+      );
+    case "gas_used":
+      return <LearnMoreTooltipPlaceholder />;
+    case "max_gas_amount":
+      return (
+        <LearnMoreTooltip
+          text="The Maximum Gas Amount of a transaction is the maximum amount of gas the sender is ready to pay for the transaction."
+          link="https://aptos.dev/reference/glossary/#maximum-gas-amount"
+        />
+      );
+    case "gas_unit_price":
+      return (
+        <LearnMoreTooltip
+          text="Learn more about Gas Price"
+          link="https://aptos.dev/reference/glossary/#gas-price"
+          linkToText
+        />
+      );
+    case "vm_status":
+      return (
+        <LearnMoreTooltip
+          text="Learn more about VM"
+          link="https://aptos.dev/reference/glossary/#move-virtual-machine-mvm"
+          linkToText
+        />
+      );
+    case "signature":
+      return <LearnMoreTooltipPlaceholder />;
+    case "state_root_hash":
+      return (
+        <LearnMoreTooltip
+          text="State root hash is a Merkle hash over all keys and values the state of the Aptos blockchain at a given version."
+          link="https://aptos.dev/reference/glossary/#state-root-hash"
+        />
+      );
+    case "event_root_hash":
+      return (
+        <LearnMoreTooltip
+          text="Learn more about Event"
+          link="https://aptos.dev/reference/glossary/#event"
+          linkToText
+        />
+      );
+    case "accumulator_root_hash":
+      return (
+        <LearnMoreTooltip
+          text="An accumulator root hash is the root hash of a Merkle accumulator."
+          link="https://aptos.dev/reference/glossary/#merkle-accumulator"
+        />
+      );
+    default:
+      return <LearnMoreTooltipPlaceholder />;
+  }
+}


### PR DESCRIPTION
In this PR:
* reordered fileds in txn Overview tabs
* added tooltips for fields to explain what it is and provide useful links to learn more
* code clean up
<img width="1815" alt="Screen Shot 2022-09-15 at 3 16 42 PM" src="https://user-images.githubusercontent.com/109111707/190519867-ded8c539-6ed2-4a84-ab6c-27c936d3b894.png">
