### PR TITLE
[Explorer] hide "Aptos Explorer" header for dev mode

### DIFF
--- a/src/components/GoBack.tsx
+++ b/src/components/GoBack.tsx
@@ -11,7 +11,7 @@ function BackButton(handleClick: () => void) {
         variant="text"
         onClick={handleClick}
         sx={{
-          mb: 4,
+          mb: 2,
           p: 0,
           "&:hover": {
             background: "transparent",

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -5,8 +5,11 @@ import IndividualPageHeader from "../../components/IndividualPageHeader";
 import AccountTabs from "./Tabs";
 import AccountTitle from "./Title";
 import AccountInfo from "./AccountInfo/Index";
+import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import HeaderSearch from "../layout/Search/Index";
 
 export default function AccountPage() {
+  const inDev = useGetInDevMode();
   const {address} = useParams();
 
   if (typeof address !== "string") {
@@ -15,7 +18,7 @@ export default function AccountPage() {
 
   return (
     <Grid container spacing={1}>
-      <IndividualPageHeader />
+      {inDev ? <HeaderSearch /> : <IndividualPageHeader />}
       <Grid item xs={12}>
         <Stack direction="column" spacing={4} marginTop={2}>
           <AccountTitle address={address} />

--- a/src/pages/Transaction/Index.tsx
+++ b/src/pages/Transaction/Index.tsx
@@ -11,8 +11,11 @@ import Error from "./Error";
 import TransactionTitle from "./Title";
 import TransactionTabs from "./Tabs";
 import GoBack from "../../components/GoBack";
+import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import HeaderSearch from "../layout/Search/Index";
 
 export default function TransactionPage() {
+  const inDev = useGetInDevMode();
   const [state, _] = useGlobalState();
   const {txnHashOrVersion} = useParams();
 
@@ -45,8 +48,8 @@ export default function TransactionPage() {
   }
 
   return (
-    <Grid container spacing={1}>
-      <IndividualPageHeader />
+    <Grid container>
+      {inDev ? <HeaderSearch /> : <IndividualPageHeader />}
       <GoBack />
       <Grid item xs={12}>
         <Stack direction="column" spacing={4} marginTop={2}>


### PR DESCRIPTION
<img width="2151" alt="Screen Shot 2022-09-15 at 5 12 49 PM" src="https://user-images.githubusercontent.com/109111707/190529977-47b51bf6-08bc-48c2-8b80-dfdd85c6e47f.png">
<img width="2152" alt="Screen Shot 2022-09-15 at 5 13 01 PM" src="https://user-images.githubusercontent.com/109111707/190529979-6fb132ff-11f5-41d1-b679-4d8845e2a2da.png">