### PR TITLE
[Explorer] redirect to the new domain

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-https://explorer.devnet.aptos.dev/* https://explorer.aptoslabs.com/:splat 301!

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,11 @@ import ReactGA from "react-ga4";
 
 ReactGA.initialize(process.env.GA_TRACKING_ID || "G-8XH7V50XK7");
 
+// TODO: redirect to the new explorer domain on the domain host
+if (window.location.origin.includes("explorer.devnet.aptos.dev")) {
+  window.location.replace("https://explorer.aptoslabs.com/");
+}
+
 Sentry.init({
   dsn: "https://531160c88f78483491d129c02be9f774@o1162451.ingest.sentry.io/6249755",
   integrations: [new BrowserTracing()],


### PR DESCRIPTION
In this PR: redirect to the new domain `https://explorer.aptoslabs.com/` when users visit `https://explorer.aptoslabs.com/`.

I played with Netlify for a while and couldn't find an easy way to do the redirecting. So here it is. This is apparently not an ideal solution but it works. 