### PR TITLE
Fix some small issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "fmt": "prettier --config .prettierrc.json 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}'"
+    "fmt": "prettier --config .prettierrc.json 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}' -w"
   },
   "browserslist": {
     "production": [

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
@@ -1,5 +1,5 @@
 import {expect, it} from "@jest/globals";
-import { getFormattedBalanceStr } from "./CurrencyValue";
+import {getFormattedBalanceStr} from "./CurrencyValue";
 
 it("formats balances correctly", () => {
   expect(getFormattedBalanceStr("0")).toEqual("0");

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
@@ -6,6 +6,7 @@ it("formats balances correctly", () => {
   expect(getFormattedBalanceStr("1")).toEqual("0.00000001");
   expect(getFormattedBalanceStr("100")).toEqual("0.000001");
   expect(getFormattedBalanceStr("10000")).toEqual("0.0001");
+  expect(getFormattedBalanceStr("10000000")).toEqual("0.1");
   expect(getFormattedBalanceStr("100000000")).toEqual("1");
   expect(getFormattedBalanceStr("110000000")).toEqual("1.1");
   expect(getFormattedBalanceStr("110100000")).toEqual("1.101");

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx
@@ -1,10 +1,11 @@
 import {expect, it} from "@jest/globals";
-
-import {getFormattedBalanceStr} from "./Balance";
+import { getFormattedBalanceStr } from "./CurrencyValue";
 
 it("formats balances correctly", () => {
   expect(getFormattedBalanceStr("0")).toEqual("0");
   expect(getFormattedBalanceStr("1")).toEqual("0.00000001");
+  expect(getFormattedBalanceStr("100")).toEqual("0.000001");
+  expect(getFormattedBalanceStr("10000")).toEqual("0.0001");
   expect(getFormattedBalanceStr("100000000")).toEqual("1");
   expect(getFormattedBalanceStr("110000000")).toEqual("1.1");
   expect(getFormattedBalanceStr("110100000")).toEqual("1.101");

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const APTOS_DECIMALS = 8;
 
-function trimRight(rightSide: string){
+function trimRight(rightSide: string) {
   while (rightSide.endsWith("0")) {
     rightSide = rightSide.slice(0, -1);
   }
@@ -12,7 +12,7 @@ function trimRight(rightSide: string){
 export function getFormattedBalanceStr(
   balance: string,
   decimals?: number,
-  fixedDecimalPlaces?: number
+  fixedDecimalPlaces?: number,
 ): string {
   // If it's zero, just return it
   if (balance == "0") {
@@ -24,12 +24,12 @@ export function getFormattedBalanceStr(
 
   // If length is less than decimals, pad with 0s to decimals length and return
   if (len <= decimals) {
-   return "0." + (trimRight("0".repeat(decimals - len) + balance) || '0');
+    return "0." + (trimRight("0".repeat(decimals - len) + balance) || "0");
   }
 
   // Otherwise, insert decimal point at len - decimals
   const leftSide = BigInt(balance.slice(0, len - decimals)).toLocaleString(
-    "en-US"
+    "en-US",
   );
   let rightSide = balance.slice(len - decimals);
   if (BigInt(rightSide) == BigInt(0)) {
@@ -53,11 +53,30 @@ type CurrencyValueProps = {
   currencyCode?: string | React.ReactNode;
 };
 
-export default function CurrencyValue({amount, decimals, fixedDecimalPlaces, currencyCode}: CurrencyValueProps) {
+export default function CurrencyValue({
+  amount,
+  decimals,
+  fixedDecimalPlaces,
+  currencyCode,
+}: CurrencyValueProps) {
   let number = getFormattedBalanceStr(amount, decimals, fixedDecimalPlaces);
-  return <div>{number}{currencyCode ? [" ", currencyCode] : null}</div>;
+  return (
+    <div>
+      {number}
+      {currencyCode ? [" ", currencyCode] : null}
+    </div>
+  );
 }
 
-export function APTCurrencyValue({amount, decimals, fixedDecimalPlaces}: CurrencyValueProps) {
-  return <CurrencyValue {...{amount, decimals, fixedDecimalPlaces}} currencyCode="APT" />;
+export function APTCurrencyValue({
+  amount,
+  decimals,
+  fixedDecimalPlaces,
+}: CurrencyValueProps) {
+  return (
+    <CurrencyValue
+      {...{amount, decimals, fixedDecimalPlaces}}
+      currencyCode="APT"
+    />
+  );
 }

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -24,7 +24,7 @@ export function getFormattedBalanceStr(
 
   // If length is less than decimals, pad with 0s to decimals length and return
   if (len <= decimals) {
-   return trimRight("0." + "0".repeat(decimals - len) + balance);
+   return "0." + (trimRight("0".repeat(decimals - len) + balance) || '0');
   }
 
   // Otherwise, insert decimal point at len - decimals

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+const APTOS_DECIMALS = 8;
+
+function trimRight(rightSide: string){
+  while (rightSide.endsWith("0")) {
+    rightSide = rightSide.slice(0, -1);
+  }
+  return rightSide;
+}
+
+export function getFormattedBalanceStr(
+  balance: string,
+  decimals?: number,
+  fixedDecimalPlaces?: number
+): string {
+  // If it's zero, just return it
+  if (balance == "0") {
+    return balance;
+  }
+
+  const len = balance.length;
+  decimals = decimals || APTOS_DECIMALS;
+
+  // If length is less than decimals, pad with 0s to decimals length and return
+  if (len <= decimals) {
+   return trimRight("0." + "0".repeat(decimals - len) + balance);
+  }
+
+  // Otherwise, insert decimal point at len - decimals
+  const leftSide = BigInt(balance.slice(0, len - decimals)).toLocaleString(
+    "en-US"
+  );
+  let rightSide = balance.slice(len - decimals);
+  if (BigInt(rightSide) == BigInt(0)) {
+    return leftSide;
+  }
+
+  // remove trailing 0s
+  rightSide = trimRight(rightSide);
+
+  if (fixedDecimalPlaces && rightSide.length > fixedDecimalPlaces) {
+    rightSide = rightSide.slice(0, fixedDecimalPlaces - rightSide.length);
+  }
+
+  return leftSide + "." + trimRight(rightSide);
+}
+
+type CurrencyValueProps = {
+  amount: string;
+  decimals?: number;
+  fixedDecimalPlaces?: number;
+  currencyCode?: string | React.ReactNode;
+};
+
+export default function CurrencyValue({amount, decimals, fixedDecimalPlaces, currencyCode}: CurrencyValueProps) {
+  let number = getFormattedBalanceStr(amount, decimals, fixedDecimalPlaces);
+  return <div>{number}{currencyCode ? [" ", currencyCode] : null}</div>;
+}
+
+export function APTCurrencyValue({amount, decimals, fixedDecimalPlaces}: CurrencyValueProps) {
+  return <CurrencyValue {...{amount, decimals, fixedDecimalPlaces}} currencyCode="APT" />;
+}

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -60,12 +60,15 @@ export default function CurrencyValue({
   currencyCode,
 }: CurrencyValueProps) {
   let number = getFormattedBalanceStr(amount, decimals, fixedDecimalPlaces);
-  return (
-    <div>
-      {number}
-      {currencyCode ? [" ", currencyCode] : null}
-    </div>
-  );
+  if (currencyCode) {
+    return (
+      <span>
+        {number} {currencyCode}
+      </span>
+    );
+  } else {
+    return <span>{number}</span>;
+  }
 }
 
 export function APTCurrencyValue({

--- a/src/components/IndividualPageContent/ContentValue/GasValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/GasValue.tsx
@@ -6,5 +6,7 @@ type GasValueProps = {
 };
 
 export default function GasValue({gas}: GasValueProps) {
-  return <NumberFormat value={gas} displayType="text" thousandSeparator />;
+  return <span>
+    <NumberFormat value={gas} displayType="text" thousandSeparator /> Gas Units
+  </span>;
 }

--- a/src/components/IndividualPageContent/ContentValue/GasValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/GasValue.tsx
@@ -6,7 +6,10 @@ type GasValueProps = {
 };
 
 export default function GasValue({gas}: GasValueProps) {
-  return <span>
-    <NumberFormat value={gas} displayType="text" thousandSeparator /> Gas Units
-  </span>;
+  return (
+    <span>
+      <NumberFormat value={gas} displayType="text" thousandSeparator /> Gas
+      Units
+    </span>
+  );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,10 @@ ReactGA.initialize(process.env.GA_TRACKING_ID || "G-8XH7V50XK7");
 
 // TODO: redirect to the new explorer domain on the domain host
 if (window.location.origin.includes("explorer.devnet.aptos.dev")) {
-  const new_location = window.location.href.replace("explorer.devnet.aptos.dev", "explorer.aptoslabs.com")
+  const new_location = window.location.href.replace(
+    "explorer.devnet.aptos.dev",
+    "explorer.aptoslabs.com",
+  );
   window.location.replace(new_location);
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,8 @@ ReactGA.initialize(process.env.GA_TRACKING_ID || "G-8XH7V50XK7");
 
 // TODO: redirect to the new explorer domain on the domain host
 if (window.location.origin.includes("explorer.devnet.aptos.dev")) {
-  window.location.replace("https://explorer.aptoslabs.com/");
+  const new_location = window.location.href.replace("explorer.devnet.aptos.dev", "explorer.aptoslabs.com")
+  window.location.replace(new_location);
 }
 
 Sentry.init({

--- a/src/pages/Account/AccountInfo/Balance.tsx
+++ b/src/pages/Account/AccountInfo/Balance.tsx
@@ -1,56 +1,12 @@
 import React from "react";
 import {Typography} from "@mui/material";
 import {useGetAccountResources} from "../../../api/hooks/useGetAccountResources";
-
-const APTOS_DECIMALS = 8;
+import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 
 interface CoinStore {
   coin: {
     value: string;
   };
-}
-
-export function getFormattedBalanceStr(
-  balance: string,
-  decimals?: number,
-  toFix?: number,
-): string {
-  // If it's zero, just return it
-  if (balance == "0") {
-    return balance;
-  }
-
-  const len = balance.length;
-  decimals = decimals || APTOS_DECIMALS;
-
-  // If length is less than decimals, pad with 0s to decimals length and return
-  if (len <= decimals) {
-    return "0." + "0".repeat(decimals - len) + balance;
-  }
-
-  // Otherwise, insert decimal point at len - decimals
-  const leftSide = BigInt(balance.slice(0, len - decimals)).toLocaleString(
-    "en-US",
-  );
-  let rightSide = balance.slice(len - decimals);
-  if (BigInt(rightSide) == BigInt(0)) {
-    return leftSide;
-  }
-  // remove trailing 0s
-  while (rightSide.endsWith("0")) {
-    rightSide = rightSide.slice(0, -1);
-  }
-
-  if (toFix && rightSide.length > toFix) {
-    rightSide = rightSide.slice(0, toFix - rightSide.length);
-
-    // remove trailing 0s again
-    while (rightSide.endsWith("0")) {
-      rightSide = rightSide.slice(0, -1);
-    }
-  }
-
-  return leftSide + "." + rightSide;
 }
 
 type BalanceProps = {
@@ -66,7 +22,7 @@ export default function Balance({address}: BalanceProps) {
 
   const coinStore = data.find(
     (resource) =>
-      resource.type === "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+      resource.type === "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>"
   );
 
   if (!coinStore) {

--- a/src/pages/Account/AccountInfo/Balance.tsx
+++ b/src/pages/Account/AccountInfo/Balance.tsx
@@ -22,7 +22,7 @@ export default function Balance({address}: BalanceProps) {
 
   const coinStore = data.find(
     (resource) =>
-      resource.type === "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>"
+      resource.type === "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
   );
 
   if (!coinStore) {

--- a/src/pages/LandingPage/NetworkInfo/TotalStake.tsx
+++ b/src/pages/LandingPage/NetworkInfo/TotalStake.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useGetValidatorSet} from "../../../api/hooks/useGetValidatorSet";
-import {getFormattedBalanceStr} from "../../Account/AccountInfo/Balance";
+import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import MetricCard from "./MetricCard";
 
 export default function TotalStake() {

--- a/src/pages/LandingPage/NetworkInfo/TotalSupply.tsx
+++ b/src/pages/LandingPage/NetworkInfo/TotalSupply.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useGetCoinSupplyLimit} from "../../../api/hooks/useGetCoinSupplyLimit";
-import {getFormattedBalanceStr} from "../../Account/AccountInfo/Balance";
+import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import MetricCard from "./MetricCard";
 
 export default function TotalSupply() {

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -15,7 +15,6 @@ import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 
-
 type BlockMetadataOverviewTabProps = {
   transaction: Types.Transaction;
 };

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -14,7 +14,7 @@ import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
+
 
 type BlockMetadataOverviewTabProps = {
   transaction: Types.Transaction;
@@ -55,7 +55,6 @@ export default function BlockMetadataOverviewTab({
           value={transactionData.version}
           tooltip={getLearnMoreTooltip("version")}
         />
-
         <ContentRow
           title="Round:"
           value={transactionData.round}
@@ -67,8 +66,8 @@ export default function BlockMetadataOverviewTab({
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
-          title="Gas Units:"
-          value={<GasValue gas={transactionData.gas_used} />}
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
@@ -119,7 +118,7 @@ export default function BlockMetadataOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -67,7 +67,7 @@ export default function BlockMetadataOverviewTab({
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
-          title="Gas Used:"
+          title="Gas Units:"
           value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
@@ -119,7 +119,7 @@ export default function BlockMetadataOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -8,7 +8,7 @@ import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
+
 
 type GenesisTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -35,8 +35,8 @@ export default function GenesisTransactionOverviewTab({
         />
 
         <ContentRow
-          title="Gas Units:"
-          value={<GasValue gas={transactionData.gas_used} />}
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
@@ -76,7 +76,7 @@ export default function GenesisTransactionOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -9,7 +9,6 @@ import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 
-
 type GenesisTransactionOverviewTabProps = {
   transaction: Types.Transaction;
 };

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -35,7 +35,7 @@ export default function GenesisTransactionOverviewTab({
         />
 
         <ContentRow
-          title="Gas Used:"
+          title="Gas Units:"
           value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
@@ -76,7 +76,7 @@ export default function GenesisTransactionOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -13,7 +13,6 @@ import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 
-
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
 };

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -11,8 +11,8 @@ import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
+
 
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -49,8 +49,8 @@ export default function PendingTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}
         />
         <ContentRow
-          title="Max Gas:"
-          value={<GasValue gas={transactionData.max_gas_amount} />}
+          title="Max Gas Limit:"
+          value={renderGas(transactionData.max_gas_amount)}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
@@ -83,7 +83,7 @@ export default function PendingTransactionOverviewTab({
           value={renderTimestamp(transactionData.expiration_timestamp_secs)}
         />
         <Row
-          title={"Max Gas:"}
+          title={"Max Gas Limit:"}
           value={renderGas(transactionData.max_gas_amount)}
         />
         <Row

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -12,6 +12,7 @@ import {getLearnMoreTooltip} from "../helpers";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
+import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -54,7 +55,7 @@ export default function PendingTransactionOverviewTab({
         />
         <ContentRow
           title="Gas Unit Price:"
-          value={<GasValue gas={transactionData.gas_unit_price} />}
+          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -47,7 +47,7 @@ export default function StateCheckpointOverviewTab({
           />
         )}
         <ContentRow
-          title="Gas Used:"
+          title="Gas Units:"
           value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
@@ -88,7 +88,7 @@ export default function StateCheckpointOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -13,7 +13,7 @@ import TransactionStatus from "../../../components/TransactionStatus";
 import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
+
 
 type StateCheckpointOverviewTabProps = {
   transaction: Types.Transaction;
@@ -47,8 +47,8 @@ export default function StateCheckpointOverviewTab({
           />
         )}
         <ContentRow
-          title="Gas Units:"
-          value={<GasValue gas={transactionData.gas_used} />}
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
@@ -88,7 +88,7 @@ export default function StateCheckpointOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Accumulator Root Hash:"}

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -14,7 +14,6 @@ import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 
-
 type StateCheckpointOverviewTabProps = {
   transaction: Types.Transaction;
 };

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -18,7 +18,6 @@ import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 
-
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;
 };
@@ -85,8 +84,14 @@ export default function UserTransactionOverviewTab({
         />
         <ContentRow
           title="Gas Fee:"
-          value={<APTCurrencyValue
-            amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
+          value={
+            <APTCurrencyValue
+              amount={(
+                BigInt(transactionData.gas_unit_price) *
+                BigInt(transactionData.gas_used)
+              ).toString()}
+            />
+          }
           tooltip={getLearnMoreTooltip("gas_spent")}
         />
         <ContentRow
@@ -156,8 +161,14 @@ export default function UserTransactionOverviewTab({
         />
         <Row
           title={"Gas Fee:"}
-          value={<APTCurrencyValue
-            amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
+          value={
+            <APTCurrencyValue
+              amount={(
+                BigInt(transactionData.gas_unit_price) *
+                BigInt(transactionData.gas_used)
+              ).toString()}
+            />
+          }
         />
 
         <Row title={"VM Status:"} value={transactionData.vm_status} />

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -16,8 +16,8 @@ import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
+
 
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -69,13 +69,13 @@ export default function UserTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
-          title="Gas Units:"
-          value={<GasValue gas={transactionData.gas_used} />}
+          title="Gas Used:"
+          value={renderGas(transactionData.gas_used)}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
-          title="Max Gas:"
-          value={<GasValue gas={transactionData.max_gas_amount} />}
+          title="Max Gas Limit:"
+          value={renderGas(transactionData.max_gas_amount)}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
@@ -145,10 +145,10 @@ export default function UserTransactionOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
+        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
         <Row
-          title={"Max Gas:"}
-          value={<GasValue gas={transactionData.max_gas_amount} />}
+          title={"Max Gas Limit:"}
+          value={renderGas(transactionData.max_gas_amount)}
         />
         <Row
           title={"Gas Unit Price:"}

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -17,6 +17,7 @@ import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
+import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 
 type UserTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -68,19 +69,25 @@ export default function UserTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow
-          title="Gas Used:"
+          title="Gas Units:"
           value={<GasValue gas={transactionData.gas_used} />}
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
-          title="Max Gas:"
-          value={<GasValue gas={transactionData.max_gas_amount} />}
-          tooltip={getLearnMoreTooltip("max_gas_amount")}
+          title="Gas Unit Price:"
+          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
+          tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow
-          title="Gas Unit Price:"
-          value={<GasValue gas={transactionData.gas_unit_price} />}
-          tooltip={getLearnMoreTooltip("gas_unit_price")}
+          title="Gas Spent:"
+          value={<APTCurrencyValue
+            amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
+          tooltip={getLearnMoreTooltip("gas_spent")}
+        />
+        <ContentRow
+          title="Max Gas:"
+          value={<APTCurrencyValue amount={transactionData.max_gas_amount} />}
+          tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="VM Status:"
@@ -138,14 +145,19 @@ export default function UserTransactionOverviewTab({
           title={"Event Root Hash:"}
           value={transactionData.event_root_hash}
         />
-        <Row title={"Gas Used:"} value={renderGas(transactionData.gas_used)} />
-        <Row
-          title={"Max Gas:"}
-          value={renderGas(transactionData.max_gas_amount)}
-        />
+        <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
         <Row
           title={"Gas Unit Price:"}
-          value={renderGas(transactionData.gas_unit_price)}
+          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
+        />
+        <Row
+          title={"Gas Spent:"}
+          value={<APTCurrencyValue
+            amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
+        />
+        <Row
+          title={"Max Gas:"}
+          value={<APTCurrencyValue amount={transactionData.max_gas_amount} />}
         />
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -74,20 +74,20 @@ export default function UserTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("gas_used")}
         />
         <ContentRow
+          title="Max Gas:"
+          value={<GasValue gas={transactionData.max_gas_amount} />}
+          tooltip={getLearnMoreTooltip("max_gas_amount")}
+        />
+        <ContentRow
           title="Gas Unit Price:"
           value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow
-          title="Gas Spent:"
+          title="Gas Fee:"
           value={<APTCurrencyValue
             amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
           tooltip={getLearnMoreTooltip("gas_spent")}
-        />
-        <ContentRow
-          title="Max Gas:"
-          value={<APTCurrencyValue amount={transactionData.max_gas_amount} />}
-          tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="VM Status:"
@@ -147,18 +147,19 @@ export default function UserTransactionOverviewTab({
         />
         <Row title={"Gas Units:"} value={renderGas(transactionData.gas_used)} />
         <Row
+          title={"Max Gas:"}
+          value={<GasValue gas={transactionData.max_gas_amount} />}
+        />
+        <Row
           title={"Gas Unit Price:"}
           value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
         />
         <Row
-          title={"Gas Spent:"}
+          title={"Gas Fee:"}
           value={<APTCurrencyValue
             amount={(BigInt(transactionData.gas_unit_price) * BigInt(transactionData.gas_used)).toString()} />}
         />
-        <Row
-          title={"Max Gas:"}
-          value={<APTCurrencyValue amount={transactionData.max_gas_amount} />}
-        />
+
         <Row title={"VM Status:"} value={transactionData.vm_status} />
         <Row
           title={"Signature:"}

--- a/src/pages/Transactions/helpers.tsx
+++ b/src/pages/Transactions/helpers.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 import {parseTimestamp, timestampDisplay} from "../utils";
-import NumberFormat from "react-number-format";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import GasValue from "../../components/IndividualPageContent/ContentValue/GasValue";
 import Title from "../../components/Title";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
@@ -29,7 +29,7 @@ export function renderTimestamp(timestamp?: string) {
 }
 
 export function renderGas(gas: string) {
-  return <NumberFormat value={gas} displayType="text" thousandSeparator />;
+  return <GasValue gas={gas} />;
 }
 
 export function renderSuccess(success: boolean) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ We can consider the version to be Infinity for this case.
 */
 export function sortTransactions(
   a: Types.Transaction,
-  b: Types.Transaction
+  b: Types.Transaction,
 ): number {
   const first = "version" in a ? parseInt(a.version) : Infinity;
   const second = "version" in b ? parseInt(b.version) : Infinity;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ We can consider the version to be Infinity for this case.
 */
 export function sortTransactions(
   a: Types.Transaction,
-  b: Types.Transaction,
+  b: Types.Transaction
 ): number {
   const first = "version" in a ? parseInt(a.version) : Infinity;
   const second = "version" in b ? parseInt(b.version) : Infinity;
@@ -29,8 +29,8 @@ Converts a utf8 string encoded as hex back to string
 if hex starts with 0x - ignore this part and start from the 3rd char (at index 2).
 */
 export function hex_to_string(hex: string): string {
-  var hexString = hex.toString();
-  var str = "";
+  const hexString = hex.toString();
+  let str = "";
   let n = hex.startsWith("0x") ? 2 : 0;
   for (n; n < hexString.length; n += 2) {
     str += String.fromCharCode(parseInt(hexString.substring(n, n + 2), 16));


### PR DESCRIPTION
Fix a few small issues:
1. Keep rest of URL intact when redirecting from old to new explorer URL
2. Gas prices: show units, unit price, and the total actual spent (and now, in APT!)

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1482859/192123108-5171895b-063e-44ac-a45d-3c1d2de9165e.png">


https://aptos.dev/concepts/basics-gas-txn-fee/
Max gas (amount) -> maximum number of gas units you want to spend on a txn
Gas used -> number of gas units you spent on a transaction
Gas unit price -> amount (in APT) you want to pay for a single gas unit
Gas fee -> Total number of gas units used * the gas unit price; how much APT of gas total the transaction cost to execute