### PR TITLE
[Explorer] block page more

### DIFF
--- a/src/pages/Block/Tabs/OverviewTab.tsx
+++ b/src/pages/Block/Tabs/OverviewTab.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
+import {getLearnMoreTooltip} from "../../Transaction/helpers";
+import HashButton, {HashType} from "../../../components/HashButton";
 
 function VersionValue({data}: {data: Types.Block}) {
   const {first_version, last_version} = data;
@@ -20,20 +22,63 @@ function VersionValue({data}: {data: Types.Block}) {
   );
 }
 
+function BlockMetadataRows({
+  blockTxn,
+}: {
+  blockTxn: Types.Transaction | undefined;
+}) {
+  if (!blockTxn) {
+    return null;
+  }
+
+  const txn = blockTxn as Types.Transaction_BlockMetadataTransaction;
+
+  return (
+    <>
+      <ContentRow
+        title="Proposer:"
+        value={<HashButton hash={txn.proposer} type={HashType.ACCOUNT} />}
+        tooltip={getLearnMoreTooltip("proposer")}
+      />
+      <ContentRow
+        title="Round:"
+        value={txn.round}
+        tooltip={getLearnMoreTooltip("round")}
+      />
+    </>
+  );
+}
+
 type OverviewTabProps = {
   data: Types.Block;
 };
 
 export default function OverviewTab({data}: OverviewTabProps) {
+  const blockTxn: Types.Transaction | undefined = (
+    data.transactions ?? []
+  ).find((txn) => {
+    return txn.type === "block_metadata_transaction";
+  });
+
   return (
     <Box marginBottom={3}>
       <ContentBox>
-        <ContentRow title={"Block Height:"} value={data.block_height} />
-        <ContentRow title={"Version:"} value={<VersionValue data={data} />} />
+        <ContentRow
+          title={"Block Height:"}
+          value={data.block_height}
+          tooltip={getLearnMoreTooltip("block_height")}
+        />
+        <ContentRow
+          title={"Version:"}
+          value={<VersionValue data={data} />}
+          tooltip={getLearnMoreTooltip("version")}
+        />
         <ContentRow
           title={"Timestamp:"}
           value={<TimestampValue timestamp={data.block_timestamp} />}
+          tooltip={getLearnMoreTooltip("timestamp")}
         />
+        <BlockMetadataRows blockTxn={blockTxn} />
       </ContentBox>
     </Box>
   );

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -42,7 +42,7 @@ export default function BlockMetadataOverviewTab({
               type={HashType.ACCOUNT}
             />
           }
-          tooltip={getLearnMoreTooltip("Proposer")}
+          tooltip={getLearnMoreTooltip("proposer")}
         />
         <ContentRow
           title="ID:"

--- a/src/pages/Transaction/helpers.tsx
+++ b/src/pages/Transaction/helpers.tsx
@@ -95,6 +95,8 @@ export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
           link="https://aptos.dev/reference/glossary/#merkle-accumulator"
         />
       );
+    case "block_height":
+      return <LearnMoreTooltipPlaceholder />;
     default:
       return <LearnMoreTooltipPlaceholder />;
   }


### PR DESCRIPTION
This PR added more fields to the block page Overview tab.
<img width="1205" alt="Screen Shot 2022-09-26 at 12 08 35 PM" src="https://user-images.githubusercontent.com/109111707/192360358-c79f724a-6b08-4274-8bd4-003b4409bd2b.png">
