### PR TITLE
[Explorer] show user transactions only on home page

### DIFF
--- a/src/api/hooks/useGetUserTransactionVersions.ts
+++ b/src/api/hooks/useGetUserTransactionVersions.ts
@@ -1,0 +1,43 @@
+import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+
+const USER_TRANSACTIONS_FROM_QUERY = gql`
+  query UserTransactions($limit: Int, $start_version: bigint) {
+    user_transactions(
+      limit: $limit
+      order_by: {version: desc}
+      where: {version: {_lte: $start_version}}
+    ) {
+      version
+    }
+  }
+`;
+
+const USER_TRANSACTIONS_QUERY = gql`
+  query UserTransactions($limit: Int) {
+    user_transactions(limit: $limit, order_by: {version: desc}) {
+      version
+    }
+  }
+`;
+
+export default function useGetUserTransactionVersions(
+  limit: number,
+  startVersion?: number,
+): number[] {
+  const {loading, error, data} = useGraphqlQuery(
+    startVersion ? USER_TRANSACTIONS_FROM_QUERY : USER_TRANSACTIONS_QUERY,
+    {variables: {limit: limit, start_version: startVersion}},
+  );
+
+  if (loading || error || !data) {
+    return [];
+  }
+
+  const versions: number[] = (data?.user_transactions ?? []).map(
+    (txn: {version: number}) => {
+      return txn.version;
+    },
+  );
+
+  return versions;
+}

--- a/src/api/hooks/useGetUserTransactionVersions.ts
+++ b/src/api/hooks/useGetUserTransactionVersions.ts
@@ -33,7 +33,7 @@ export default function useGetUserTransactionVersions(
     return [];
   }
 
-  const versions: number[] = (data?.user_transactions ?? []).map(
+  const versions: number[] = data.user_transactions.map(
     (txn: {version: number}) => {
       return txn.version;
     },

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -8,6 +8,7 @@ import Box from "@mui/material/Box";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
 import NetworkInfo from "./NetworkInfo/Index";
 import TransactionsPreview from "./TransactionsPreview";
+import UserTransactionsPreview from "./UserTransactionsPreview";
 
 export default function LandingPage() {
   const inDev = useGetInDevMode();
@@ -20,7 +21,7 @@ export default function LandingPage() {
       </Typography>
       <NetworkInfo />
       <HeaderSearch />
-      <TransactionsPreview />
+      <UserTransactionsPreview />
     </Box>
   ) : (
     <Box>

--- a/src/pages/LandingPage/UserTransactionsPreview.tsx
+++ b/src/pages/LandingPage/UserTransactionsPreview.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import * as RRD from "react-router-dom";
+import {Stack} from "@mui/material";
+import {UserTransactionsTable} from "../Transactions/TransactionsTable";
+import useGetUserTransactionVersions from "../../api/hooks/useGetUserTransactionVersions";
+
+const PREVIEW_TRANSACTIONS_COUNT = 10;
+
+export default function UserTransactionsPreview() {
+  const versions = useGetUserTransactionVersions(PREVIEW_TRANSACTIONS_COUNT);
+
+  return (
+    <>
+      <Stack spacing={2}>
+        <Box sx={{width: "auto", overflowX: "auto"}}>
+          <UserTransactionsTable versions={versions} />
+        </Box>
+        <Box sx={{display: "flex", justifyContent: "center"}}>
+          <Button
+            component={RRD.Link}
+            to="/transactions"
+            variant="primary"
+            sx={{margin: "0 auto", mt: 6}}
+          >
+            View all Transactions
+          </Button>
+        </Box>
+      </Stack>
+    </>
+  );
+}

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -21,6 +21,7 @@ import {TableTransactionStatus} from "../../components/TransactionStatus";
 import {getFormattedTimestamp} from "../utils";
 import GasFeeValue from "../../components/IndividualPageContent/ContentValue/GasFeeValue";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetTransaction} from "../../api/hooks/useGetTransaction";
 
 type TransactionCellProps = {
   transaction: Types.Transaction;
@@ -140,6 +141,33 @@ function TransactionRow({transaction, columns}: TransactionRowProps) {
   );
 }
 
+type UserTransactionRowProps = {
+  version: number;
+  columns: TransactionColumn[];
+};
+
+function UserTransactionRow({version, columns}: UserTransactionRowProps) {
+  const navigate = useNavigate();
+  const {data: transaction} = useGetTransaction(version.toString());
+
+  if (!transaction) {
+    return null;
+  }
+
+  const rowClick = () => {
+    navigate(`/txn/${version}`);
+  };
+
+  return (
+    <GeneralTableRow onClick={rowClick}>
+      {columns.map((column) => {
+        const Cell = TransactionCells[column];
+        return <Cell key={column} transaction={transaction} />;
+      })}
+    </GeneralTableRow>
+  );
+}
+
 type TransactionHeaderCellProps = {
   column: TransactionColumn;
 };
@@ -182,7 +210,7 @@ function TransactionHeaderCell({column}: TransactionHeaderCellProps) {
   }
 }
 
-type Props = {
+type TransactionsTableProps = {
   transactions: Types.Transaction[];
   columns?: TransactionColumn[];
 };
@@ -190,7 +218,7 @@ type Props = {
 export default function TransactionsTable({
   transactions,
   columns = DEFAULT_COLUMNS,
-}: Props) {
+}: TransactionsTableProps) {
   return (
     <Table>
       <TableHead>
@@ -206,6 +234,39 @@ export default function TransactionsTable({
             <TransactionRow
               key={`${i}-${transaction.hash}`}
               transaction={transaction}
+              columns={columns}
+            />
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+type UserTransactionsTableProps = {
+  versions: number[];
+  columns?: TransactionColumn[];
+};
+
+export function UserTransactionsTable({
+  versions,
+  columns = DEFAULT_COLUMNS,
+}: UserTransactionsTableProps) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {columns.map((column) => (
+            <TransactionHeaderCell key={column} column={column} />
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {versions.map((version, i) => {
+          return (
+            <UserTransactionRow
+              key={`${i}-${version}`}
+              version={version}
               columns={columns}
             />
           );


### PR DESCRIPTION
Transactions type filtering has not been supported yet. Although we do want users to see user transactions only, at least in the home page. Therefore this PR is a walk around before we have transaction type filtering supported.
<img width="1172" alt="Screen Shot 2022-09-30 at 2 16 57 PM" src="https://user-images.githubusercontent.com/109111707/193358691-bf914aeb-b83f-4ce7-ad0b-4b90a0456b07.png">
