### PR TITLE
redirect governance endpoints to governance foundation site

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/proposals  https://governance.aptosfoundation.org  200
+/proposals  https://governance.aptosfoundation.org
 /*    /index.html   200 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/proposals  https://governance.aptosfoundation.org
+/proposals/*  https://governance.aptosfoundation.org
 /*    /index.html   200 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,3 @@
+/proposals/*  https://governance.aptosfoundation.org/  200
+
 /*    /index.html   200 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
-/proposals/*  https://governance.aptosfoundation.org/  200
+/proposals/*  https://governance.aptosfoundation.org  200
 
 /*    /index.html   200 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,2 @@
-/proposals/*  https://governance.aptosfoundation.org  200
-
+/proposals  https://governance.aptosfoundation.org  200
 /*    /index.html   200 


### PR DESCRIPTION
redirect governance endpoints to governance foundation site #194


Test
https://deploy-preview-194--aptos-explorer.netlify.app/proposals should redirect to https://governance.aptosfoundation.org/