### PR TITLE
[Explorer] account transactions walk around

### DIFF
--- a/src/api/hooks/useGetAccountTransactions.ts
+++ b/src/api/hooks/useGetAccountTransactions.ts
@@ -4,23 +4,18 @@ import {getAccountTransactions} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../GlobalState";
 
-const QUERY_LIMIT = 100;
-
 export function useGetAccountTransactions(
   address: string,
-  sequenceNumber: string | undefined,
 ): UseQueryResult<Array<Types.Transaction>, ResponseError> {
   const [state, _setState] = useGlobalState();
 
-  const sequence = sequenceNumber === undefined ? 0 : parseInt(sequenceNumber);
-  const limit = sequence < QUERY_LIMIT ? undefined : QUERY_LIMIT;
-  const start = sequence < QUERY_LIMIT ? undefined : sequence - QUERY_LIMIT;
+  const limit = 100;
 
   const accountTransactionsResult = useQuery<
     Array<Types.Transaction>,
     ResponseError
-  >(["accountTransactions", {address,start, limit}, state.network_value], () =>
-    getAccountTransactions({address, start, limit}, state.network_value),
+  >(["accountTransactions", {address, limit}, state.network_value], () =>
+    getAccountTransactions({address, limit}, state.network_value),
   );
 
   return accountTransactionsResult;

--- a/src/api/hooks/useGetAccountTransactions.ts
+++ b/src/api/hooks/useGetAccountTransactions.ts
@@ -13,7 +13,7 @@ export function useGetAccountTransactions(
     Array<Types.Transaction>,
     ResponseError
   >(["accountTransactions", {address}, state.network_value], () =>
-    getAccountTransactions({address}, state.network_value),
+    getAccountTransactions({address, limit:1000}, state.network_value),
   );
 
   return accountTransactionsResult;

--- a/src/api/hooks/useGetAccountTransactions.ts
+++ b/src/api/hooks/useGetAccountTransactions.ts
@@ -4,16 +4,23 @@ import {getAccountTransactions} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../GlobalState";
 
+const QUERY_LIMIT = 100;
+
 export function useGetAccountTransactions(
   address: string,
+  sequenceNumber: string | undefined,
 ): UseQueryResult<Array<Types.Transaction>, ResponseError> {
   const [state, _setState] = useGlobalState();
+
+  const sequence = sequenceNumber === undefined ? 0 : parseInt(sequenceNumber);
+  const limit = sequence < QUERY_LIMIT ? undefined : QUERY_LIMIT;
+  const start = sequence < QUERY_LIMIT ? undefined : sequence - QUERY_LIMIT;
 
   const accountTransactionsResult = useQuery<
     Array<Types.Transaction>,
     ResponseError
-  >(["accountTransactions", {address}, state.network_value], () =>
-    getAccountTransactions({address, limit:1000}, state.network_value),
+  >(["accountTransactions", {address,start, limit}, state.network_value], () =>
+    getAccountTransactions({address, start, limit}, state.network_value),
   );
 
   return accountTransactionsResult;

--- a/src/pages/Account/Tabs/TransactionsTab.tsx
+++ b/src/pages/Account/Tabs/TransactionsTab.tsx
@@ -3,13 +3,28 @@ import {Alert} from "@mui/material";
 import TransactionsTable from "../../Transactions/TransactionsTable";
 import Error from "../Error";
 import {useGetAccountTransactions} from "../../../api/hooks/useGetAccountTransactions";
+import {useQuery} from "react-query";
+import {Types} from "aptos";
+import {ResponseError} from "../../../api/client";
+import {useGlobalState} from "../../../GlobalState";
+import {getAccount} from "../../../api";
 
 type TransactionsTabProps = {
   address: string;
 };
 
 export default function TransactionsTab({address}: TransactionsTabProps) {
-  const {isLoading, data, error} = useGetAccountTransactions(address);
+  const [state, _] = useGlobalState();
+
+  const {data: accountData} = useQuery<Types.AccountData, ResponseError>(
+    ["account", {address}, state.network_value],
+    () => getAccount({address}, state.network_value),
+  );
+
+  const {isLoading, data, error} = useGetAccountTransactions(
+    address,
+    accountData?.sequence_number,
+  );
 
   if (isLoading) {
     return null;

--- a/src/pages/Account/Tabs/TransactionsTab.tsx
+++ b/src/pages/Account/Tabs/TransactionsTab.tsx
@@ -3,28 +3,13 @@ import {Alert} from "@mui/material";
 import TransactionsTable from "../../Transactions/TransactionsTable";
 import Error from "../Error";
 import {useGetAccountTransactions} from "../../../api/hooks/useGetAccountTransactions";
-import {useQuery} from "react-query";
-import {Types} from "aptos";
-import {ResponseError} from "../../../api/client";
-import {useGlobalState} from "../../../GlobalState";
-import {getAccount} from "../../../api";
 
 type TransactionsTabProps = {
   address: string;
 };
 
 export default function TransactionsTab({address}: TransactionsTabProps) {
-  const [state, _] = useGlobalState();
-
-  const {data: accountData} = useQuery<Types.AccountData, ResponseError>(
-    ["account", {address}, state.network_value],
-    () => getAccount({address}, state.network_value),
-  );
-
-  const {isLoading, data, error} = useGetAccountTransactions(
-    address,
-    accountData?.sequence_number,
-  );
+  const {isLoading, data, error} = useGetAccountTransactions(address);
 
   if (isLoading) {
     return null;


### PR DESCRIPTION
### Known issue
Aptos API has an issue that `getAccountTransactions` returns the oldest `limit` count of transactions, while the expected behavior is to return the latest `limit` count of transactions. This PR (https://github.com/aptos-labs/aptos-core/pull/4778) will fix this issue. However, the fix won't be live any time soon. We need to at least "fix" this issue at some level ASAP. Therefore the walk around in this PR.

### Walk around
Previously we don't pass in a `limit` param when querying account transactions, the default `limit = 25` will be applied. So We always get the oldest 25 transactions. This PR changed the `limit` to `1000`. With this change, we will always get the latest 1000 transactions. So for account with <= 1000 transactions, at least we're showing the correct transactions. We don't anticipate to have many accounts with > 1000 transactions, so this walk around will work for most of the accounts. We don't make the limit bigger than 1000, because with 1000 transactions, the page rendering time will be within a few seconds which is bearable. Pagination will be added later.

