### PR TITLE
[Explorer] token related changes

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -38,9 +38,11 @@ export default function ExplorerRoutes() {
         <Route path="/block">
           <Route path=":height" element={<BlockPage />} />
         </Route>
-        <Route path="/token">
-          <Route path=":param" element={<TokenPage />} />
-        </Route>
+        <Route
+          path="/token/:tokenId/:propertyVersion"
+          element={<TokenPage />}
+        />
+        <Route path="/token/:tokenId" element={<TokenPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </ExplorerLayout>

--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -38,11 +38,10 @@ export default function ExplorerRoutes() {
         <Route path="/block">
           <Route path=":height" element={<BlockPage />} />
         </Route>
-        <Route
-          path="/token/:tokenId/:propertyVersion"
-          element={<TokenPage />}
-        />
-        <Route path="/token/:tokenId" element={<TokenPage />} />
+        <Route path="/token">
+          <Route path=":tokenId" element={<TokenPage />} />
+          <Route path=":tokenId/:propertyVersion" element={<TokenPage />} />
+        </Route>
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </ExplorerLayout>

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -96,6 +96,7 @@ export default function HashButton({hash, type, ...props}: HashButtonProps) {
               theme.palette.mode === "dark" ? grey[500] : grey[300]
             }`,
           },
+          minWidth: 141,
         }}
         aria-describedby={id}
         onClick={hashExpand}

--- a/src/pages/Account/Components/TokensTable.tsx
+++ b/src/pages/Account/Components/TokensTable.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {useTheme} from "@mui/material";
+import {Box} from "@mui/material";
 import * as RRD from "react-router-dom";
 import Link from "@mui/material/Link";
 import Table from "@mui/material/Table";
@@ -25,7 +25,15 @@ function TokenNameCell({token}: TokenCellProps) {
         color="primary"
         underline="none"
       >
-        {token?.name}
+        <Box
+          sx={{
+            maxWidth: {xs: 150, md: 250, lg: 400},
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {token?.name}
+        </Box>
       </Link>
     </TableCell>
   );
@@ -34,12 +42,32 @@ function TokenNameCell({token}: TokenCellProps) {
 // TODO: link to collection page
 function CollectionNameCell({token}: TokenCellProps) {
   return (
-    <TableCell sx={{textAlign: "left"}}>{token?.collection_name}</TableCell>
+    <TableCell
+      sx={{
+        textAlign: "left",
+        maxWidth: {xs: 150, md: 250, lg: 400},
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      }}
+    >
+      {token?.collection_name}
+    </TableCell>
   );
 }
 
 function StoreCell({token}: TokenCellProps) {
-  return <TableCell sx={{textAlign: "left"}}>{token?.table_type}</TableCell>;
+  return (
+    <TableCell
+      sx={{
+        textAlign: "left",
+        maxWidth: {xs: 150, md: 250, lg: 400},
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      }}
+    >
+      {token?.table_type}
+    </TableCell>
+  );
 }
 
 function PropertyVersionCell({token}: TokenCellProps) {
@@ -97,8 +125,6 @@ type TokenHeaderCellProps = {
 };
 
 function TokenHeaderCell({column}: TokenHeaderCellProps) {
-  const theme = useTheme();
-
   switch (column) {
     case "name":
       return <GeneralTableHeaderCell header="Name" />;
@@ -107,12 +133,7 @@ function TokenHeaderCell({column}: TokenHeaderCellProps) {
     case "store":
       return <GeneralTableHeaderCell header="Store" />;
     case "propertyVersion":
-      return (
-        <GeneralTableHeaderCell
-          header="Property Version"
-          textAlignRight={true}
-        />
-      );
+      return <GeneralTableHeaderCell header="Version" textAlignRight={true} />;
     case "amount":
       return <GeneralTableHeaderCell header="Amount" textAlignRight={true} />;
     default:

--- a/src/pages/Account/Components/TokensTable.tsx
+++ b/src/pages/Account/Components/TokensTable.tsx
@@ -21,9 +21,7 @@ function TokenNameCell({token}: TokenCellProps) {
     <TableCell sx={{textAlign: "left"}}>
       <Link
         component={RRD.Link}
-        to={`/token/${
-          "token_data_id_hash" in token && token.token_data_id_hash
-        }`}
+        to={`/token/${token?.token_data_id_hash}/${token?.property_version}`}
         color="primary"
         underline="none"
       >
@@ -40,6 +38,10 @@ function CollectionNameCell({token}: TokenCellProps) {
   );
 }
 
+function StoreCell({token}: TokenCellProps) {
+  return <TableCell sx={{textAlign: "left"}}>{token?.table_type}</TableCell>;
+}
+
 function PropertyVersionCell({token}: TokenCellProps) {
   return (
     <TableCell sx={{textAlign: "right"}}>{token?.property_version}</TableCell>
@@ -53,6 +55,7 @@ function AmountCell({token}: TokenCellProps) {
 const TokenCells = Object.freeze({
   name: TokenNameCell,
   collectionName: CollectionNameCell,
+  store: StoreCell,
   propertyVersion: PropertyVersionCell,
   amount: AmountCell,
 });
@@ -62,6 +65,7 @@ type Column = keyof typeof TokenCells;
 const DEFAULT_COLUMNS: Column[] = [
   "name",
   "collectionName",
+  "store",
   "propertyVersion",
   "amount",
 ];
@@ -75,9 +79,7 @@ function TokenRow({token, columns}: TokenRowProps) {
   const navigate = useNavigate();
 
   const rowClick = () => {
-    navigate(
-      `/token/${"token_data_id_hash" in token && token.token_data_id_hash}`,
-    );
+    navigate(`/token/${token?.token_data_id_hash}/${token?.property_version}`);
   };
 
   return (
@@ -102,6 +104,8 @@ function TokenHeaderCell({column}: TokenHeaderCellProps) {
       return <GeneralTableHeaderCell header="Name" />;
     case "collectionName":
       return <GeneralTableHeaderCell header="Collection" />;
+    case "store":
+      return <GeneralTableHeaderCell header="Store" />;
     case "propertyVersion":
       return (
         <GeneralTableHeaderCell

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -16,14 +16,14 @@ import CollapsibleCard from "../../../components/IndividualPageContent/Collapsib
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 const copyToClipboard = (content: any) => {
-  const el = document.createElement('textarea');
+  const el = document.createElement("textarea");
   el.value = content;
   document.body.appendChild(el);
   el.select();
-  document.execCommand('copy');
+  document.execCommand("copy");
   document.body.removeChild(el);
 };
 
@@ -40,10 +40,9 @@ function Content({
         {data.map((module, i) => (
           <Stack direction="column" key={i} spacing={3}>
             <Row title={"Bytecode:"} value={module.bytecode} />
-            <div onClick={()=>copyToClipboard(JSON.stringify(module.abi))}>
-              ABI<ContentCopyIcon
-                fontSize="small"
-              />:
+            <div onClick={() => copyToClipboard(JSON.stringify(module.abi))}>
+              ABI
+              <ContentCopyIcon fontSize="small" />:
             </div>
             <Row title="" value={renderDebug(module.abi)} />
           </Stack>

--- a/src/pages/Account/Tabs/TokensTab.tsx
+++ b/src/pages/Account/Tabs/TokensTab.tsx
@@ -11,6 +11,7 @@ const TOKENS_QUERY = gql`
       token_data_id_hash
       name
       collection_name
+      table_type
       property_version
       amount
     }

--- a/src/pages/LandingPage/UserTransactionsPreview.tsx
+++ b/src/pages/LandingPage/UserTransactionsPreview.tsx
@@ -5,11 +5,17 @@ import * as RRD from "react-router-dom";
 import {Stack} from "@mui/material";
 import {UserTransactionsTable} from "../Transactions/TransactionsTable";
 import useGetUserTransactionVersions from "../../api/hooks/useGetUserTransactionVersions";
+import TransactionsPreview from "./TransactionsPreview";
 
 const PREVIEW_TRANSACTIONS_COUNT = 10;
 
 export default function UserTransactionsPreview() {
   const versions = useGetUserTransactionVersions(PREVIEW_TRANSACTIONS_COUNT);
+
+  // TODO: remove the fallback below when indexer is stable
+  if (versions.length === 0) {
+    return <TransactionsPreview />;
+  }
 
   return (
     <>

--- a/src/pages/Token/Index.tsx
+++ b/src/pages/Token/Index.tsx
@@ -27,15 +27,15 @@ const TOKEN_QUERY = gql`
 `;
 
 export default function TokenPage() {
-  const {param} = useParams();
+  const {tokenId} = useParams();
 
-  if (typeof param !== "string") {
+  if (typeof tokenId !== "string") {
     return null;
   }
 
   const {loading, error, data} = useQuery(TOKEN_QUERY, {
     variables: {
-      token_id: param,
+      token_id: tokenId,
     },
   });
 

--- a/src/pages/Token/Index.tsx
+++ b/src/pages/Token/Index.tsx
@@ -29,10 +29,6 @@ const TOKEN_QUERY = gql`
 export default function TokenPage() {
   const {tokenId} = useParams();
 
-  if (typeof tokenId !== "string") {
-    return null;
-  }
-
   const {loading, error, data} = useQuery(TOKEN_QUERY, {
     variables: {
       token_id: tokenId,


### PR DESCRIPTION
As discussed with @bowenyang007, a few token related changes are made in this PR:
* add token Store column in account page tokens table
* add `propertyVersion` as a url param for the token page
* add Owner(s) field for token page
* the old Owner field should really be "Royalty  Payee" and be moved below "Royalty"