### PR TITLE
[Explorer] fix warnings

### DIFF
--- a/src/api/hooks/useGetBlock.ts
+++ b/src/api/hooks/useGetBlock.ts
@@ -4,23 +4,23 @@ import {getBlockByHeight, getBlockByVersion} from "../../api";
 import {ResponseError} from "../../api/client";
 import {useGlobalState} from "../../GlobalState";
 
-export function useGetBlockByHeight(height: number) {
+export function useGetBlockByHeight(height: number, withTransactions = true) {
   const [state, _setState] = useGlobalState();
 
   const result = useQuery<Types.Block, ResponseError>(
     ["block", height, state.network_value],
-    () => getBlockByHeight(height, state.network_value),
+    () => getBlockByHeight(height, withTransactions, state.network_value),
   );
 
   return result;
 }
 
-export function useGetBlockByVersion(version: number) {
+export function useGetBlockByVersion(version: number, withTransactions = true) {
   const [state, _setState] = useGlobalState();
 
   const result = useQuery<Types.Block, ResponseError>(
     ["block", version, state.network_value],
-    () => getBlockByVersion(version, state.network_value),
+    () => getBlockByVersion(version, withTransactions, state.network_value),
   );
 
   return result;

--- a/src/api/hooks/useGetBlock.ts
+++ b/src/api/hooks/useGetBlock.ts
@@ -4,23 +4,35 @@ import {getBlockByHeight, getBlockByVersion} from "../../api";
 import {ResponseError} from "../../api/client";
 import {useGlobalState} from "../../GlobalState";
 
-export function useGetBlockByHeight(height: number, withTransactions = true) {
+export function useGetBlockByHeight({
+  height,
+  withTransactions = true,
+}: {
+  height: number;
+  withTransactions?: boolean;
+}) {
   const [state, _setState] = useGlobalState();
 
   const result = useQuery<Types.Block, ResponseError>(
     ["block", height, state.network_value],
-    () => getBlockByHeight(height, withTransactions, state.network_value),
+    () => getBlockByHeight({height, withTransactions}, state.network_value),
   );
 
   return result;
 }
 
-export function useGetBlockByVersion(version: number, withTransactions = true) {
+export function useGetBlockByVersion({
+  version,
+  withTransactions = true,
+}: {
+  version: number;
+  withTransactions?: boolean;
+}) {
   const [state, _setState] = useGlobalState();
 
   const result = useQuery<Types.Block, ResponseError>(
     ["block", version, state.network_value],
-    () => getBlockByVersion(version, withTransactions, state.network_value),
+    () => getBlockByVersion({version, withTransactions}, state.network_value),
   );
 
   return result;

--- a/src/api/hooks/useGetTPS.ts
+++ b/src/api/hooks/useGetTPS.ts
@@ -6,7 +6,7 @@ import {useGetTPSByBlockHeight} from "./useGetTPSByBlockHeight";
 
 export function useGetTPS() {
   const [state, _] = useGlobalState();
-  const [blockHeight, setBlockHeight] = useState<number | null>(null);
+  const [blockHeight, setBlockHeight] = useState<number | undefined>();
   const {tps} = useGetTPSByBlockHeight(blockHeight);
 
   const {data: ledgerData} = useQuery(

--- a/src/api/hooks/useGetTPSByBlockHeight.ts
+++ b/src/api/hooks/useGetTPSByBlockHeight.ts
@@ -23,11 +23,14 @@ export function useGetTPSByBlockHeight(currentBlockHeight: number | undefined) {
 
   const [tps, setTps] = useState<number | null>(null);
 
-  const {data: startBlock} = useGetBlockByHeight(
-    blockHeight - TPS_FREQUENCY,
-    false,
-  );
-  const {data: endBlock} = useGetBlockByHeight(blockHeight, false);
+  const {data: startBlock} = useGetBlockByHeight({
+    height: blockHeight - TPS_FREQUENCY,
+    withTransactions: false,
+  });
+  const {data: endBlock} = useGetBlockByHeight({
+    height: blockHeight,
+    withTransactions: false,
+  });
 
   useEffect(() => {
     if (startBlock !== undefined && endBlock !== undefined) {

--- a/src/api/hooks/useGetTPSByBlockHeight.ts
+++ b/src/api/hooks/useGetTPSByBlockHeight.ts
@@ -18,12 +18,16 @@ function calculateTps(startBlock: Types.Block, endBlock: Types.Block): number {
   return (endTransactionVersion - startTransactionVersion) / durationInSec;
 }
 
-export function useGetTPSByBlockHeight(currentBlockHeight: number | null) {
+export function useGetTPSByBlockHeight(currentBlockHeight: number | undefined) {
   const blockHeight = currentBlockHeight ?? TPS_FREQUENCY;
+
   const [tps, setTps] = useState<number | null>(null);
 
-  const {data: startBlock} = useGetBlockByHeight(blockHeight - TPS_FREQUENCY);
-  const {data: endBlock} = useGetBlockByHeight(blockHeight);
+  const {data: startBlock} = useGetBlockByHeight(
+    blockHeight - TPS_FREQUENCY,
+    false,
+  );
+  const {data: endBlock} = useGetBlockByHeight(blockHeight, false);
 
   useEffect(() => {
     if (startBlock !== undefined && endBlock !== undefined) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -136,19 +136,19 @@ export function getTableItem(
 }
 
 export function getBlockByHeight(
-  height: number,
-  withTransactions: boolean,
+  requestParameters: {height: number; withTransactions: boolean},
   nodeUrl: string,
 ): Promise<Types.Block> {
+  const {height, withTransactions} = requestParameters;
   const client = new AptosClient(nodeUrl, config);
   return withResponseError(client.getBlockByHeight(height, withTransactions));
 }
 
 export function getBlockByVersion(
-  version: number,
-  withTransactions: boolean,
+  requestParameters: {version: number; withTransactions: boolean},
   nodeUrl: string,
 ): Promise<Types.Block> {
+  const {version, withTransactions} = requestParameters;
   const client = new AptosClient(nodeUrl, config);
   return withResponseError(client.getBlockByVersion(version, withTransactions));
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -137,18 +137,20 @@ export function getTableItem(
 
 export function getBlockByHeight(
   height: number,
+  withTransactions: boolean,
   nodeUrl: string,
 ): Promise<Types.Block> {
   const client = new AptosClient(nodeUrl, config);
-  return withResponseError(client.getBlockByHeight(height, true));
+  return withResponseError(client.getBlockByHeight(height, withTransactions));
 }
 
 export function getBlockByVersion(
   version: number,
+  withTransactions: boolean,
   nodeUrl: string,
 ): Promise<Types.Block> {
   const client = new AptosClient(nodeUrl, config);
-  return withResponseError(client.getBlockByVersion(version, true));
+  return withResponseError(client.getBlockByVersion(version, withTransactions));
 }
 
 export async function getRecentBlocks(

--- a/src/components/IndividualPageContent/ContentRow.tsx
+++ b/src/components/IndividualPageContent/ContentRow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Box, Typography, Stack} from "@mui/material";
+import {Box} from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import EmptyValue from "./ContentValue/EmptyValue";
@@ -27,17 +27,18 @@ export default function ContentRow({
         key={i}
       >
         <Grid xs={12} sm={3}>
-          <Box>
-            <Typography variant="body2" color={grey[450]}>
-              {title}
-              <Box
-                component="span"
-                sx={{display: "inline", whiteSpace: "nowrap"}}
-              >
-                &nbsp;
-                <Box sx={{display: "inline-block"}}>{tooltip}</Box>
-              </Box>
-            </Typography>
+          <Box sx={{fontSize: "0.875rem", color: grey[450]}}>
+            {title}
+            <Box
+              component="span"
+              sx={{
+                display: "inline",
+                whiteSpace: "nowrap",
+              }}
+            >
+              &nbsp;
+              <Box sx={{display: "inline-block"}}>{tooltip}</Box>
+            </Box>
           </Box>
         </Grid>
         <Grid

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -16,14 +16,14 @@ import CollapsibleCard from "../../../components/IndividualPageContent/Collapsib
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 const copyToClipboard = (content: any) => {
-  const el = document.createElement('textarea');
+  const el = document.createElement("textarea");
   el.value = content;
   document.body.appendChild(el);
   el.select();
-  document.execCommand('copy');
+  document.execCommand("copy");
   document.body.removeChild(el);
 };
 
@@ -40,10 +40,9 @@ function Content({
         {data.map((module, i) => (
           <Stack direction="column" key={i} spacing={3}>
             <Row title={"Bytecode:"} value={module.bytecode} />
-            <div onClick={()=>copyToClipboard(JSON.stringify(module.abi))}>
-              ABI<ContentCopyIcon
-                fontSize="small"
-              />:
+            <div onClick={() => copyToClipboard(JSON.stringify(module.abi))}>
+              ABI
+              <ContentCopyIcon fontSize="small" />:
             </div>
             <Row title="" value={renderDebug(module.abi)} />
           </Stack>

--- a/src/pages/Block/Index.tsx
+++ b/src/pages/Block/Index.tsx
@@ -14,7 +14,9 @@ export default function BlockPage() {
     return null;
   }
 
-  const {data, isLoading, error} = useGetBlockByHeight(parseInt(height));
+  const {data, isLoading, error} = useGetBlockByHeight({
+    height: parseInt(height),
+  });
 
   if (isLoading) {
     return null;

--- a/src/pages/layout/Search/SearchBlockByHeight.tsx
+++ b/src/pages/layout/Search/SearchBlockByHeight.tsx
@@ -9,7 +9,9 @@ type SearchBlockByHeightProps = {
 export default function SearchBlockByHeight({
   height,
 }: SearchBlockByHeightProps) {
-  const {isLoading, isError, data} = useGetBlockByHeight(parseInt(height));
+  const {isLoading, isError, data} = useGetBlockByHeight({
+    height: parseInt(height),
+  });
 
   if (isLoading || isError || !data) {
     return null;

--- a/src/pages/layout/Search/SearchBlockByVersion.tsx
+++ b/src/pages/layout/Search/SearchBlockByVersion.tsx
@@ -9,7 +9,9 @@ type SearchBlockByVersionProps = {
 export default function SearchBlockByVersion({
   version,
 }: SearchBlockByVersionProps) {
-  const {isLoading, isError, data} = useGetBlockByVersion(parseInt(version));
+  const {isLoading, isError, data} = useGetBlockByVersion({
+    version: parseInt(version),
+  });
 
   if (isLoading || isError || !data) {
     return null;


### PR DESCRIPTION
This PR fixed two nits. One was caused by including an icon component (a `<div>`) in a Typography (a `<p>`). The other was caused by querying block with transactions while transactions were not needed.