### PR TITLE
[Explorer] launch new explorer

### DIFF
--- a/src/api/hooks/useGetInDevMode.ts
+++ b/src/api/hooks/useGetInDevMode.ts
@@ -4,3 +4,8 @@ export function useGetInDevMode(): boolean {
   const [state, _] = useGlobalState();
   return state.feature_name && state.feature_name === "dev";
 }
+
+export function useGetInGtmMode(): boolean {
+  const [state, _] = useGlobalState();
+  return state.feature_name && state.feature_name === "gtm";
+}

--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -11,7 +11,7 @@ import {
   isValidAccountAddress,
   isValidTxnHashOrVersion,
 } from "../../pages/utils";
-import {useGetInDevMode} from "./useGetInDevMode";
+import {useGetInGtmMode} from "./useGetInDevMode";
 
 export type SearchResult = {
   label: string;
@@ -24,7 +24,7 @@ export const NotFoundResult: SearchResult = {
 };
 
 export default function useGetSearchResults(input: string) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [results, setResults] = useState<SearchResult[]>([]);
   const [state, _setState] = useGlobalState();
 
@@ -109,7 +109,7 @@ export default function useGetSearchResults(input: string) {
       if (isValidTxnHashOrVer) {
         promises.push(txnPromise);
       }
-      if (inDev && isValidBlockHeightOrVer) {
+      if (inGtm && isValidBlockHeightOrVer) {
         promises.push(blockByHeightPromise);
         promises.push(blockByVersionPromise);
       }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -5,7 +5,7 @@ import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import {Menu, MenuItem} from "@mui/material";
 import Fade from "@mui/material/Fade";
-import {useGetInDevMode} from "../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 
 function NavButton({
   to,
@@ -36,7 +36,7 @@ function NavButton({
 }
 
 export default function Nav() {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [governanceMenuEl, setGovernanceMenuEl] = useState<null | HTMLElement>(
     null,
   );
@@ -69,7 +69,7 @@ export default function Nav() {
         title="View All Transactions"
         label="Transactions"
       />
-      {inDev && (
+      {inGtm && (
         <>
           <NavButton to="/blocks" title="View Latest Blocks" label="Blocks" />
           <NavButton
@@ -79,7 +79,7 @@ export default function Nav() {
           />
         </>
       )}
-      {!inDev && (
+      {!inGtm && (
         <>
           <Button
             variant="nav"

--- a/src/components/NavMobile.tsx
+++ b/src/components/NavMobile.tsx
@@ -11,10 +11,10 @@ import {useTheme} from "@mui/material";
 import {useNavigate} from "react-router-dom";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import {useGetInDevMode} from "../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 
 export default function NavMobile() {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [governanceMenuOpen, setGovernanceMenuOpen] = useState<boolean>(false);
   const theme = useTheme();
@@ -63,7 +63,7 @@ export default function NavMobile() {
       >
         {menuOpen ? <CloseIcon /> : <HamburgerIcon />}
       </Button>
-      {inDev ? (
+      {inGtm ? (
         <Menu
           anchorEl={menuAnchorEl}
           open={menuOpen}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,16 +1,16 @@
 import {Grid, Typography} from "@mui/material";
 import * as React from "react";
-import {useGetInDevMode} from "../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 import HeaderSearch from "../pages/layout/Search/Index";
 import DividerHero from "./DividerHero";
 import GoBack from "./GoBack";
 
 export default function PageHeader() {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   return (
     <>
-      {inDev ? <GoBack /> : null}
-      {inDev ? (
+      {inGtm ? <GoBack /> : null}
+      {inGtm ? (
         <HeaderSearch />
       ) : (
         <Grid item xs={12}>

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -34,6 +34,7 @@ export const defaultNetwork = networks[defaultNetworkName];
  */
 export const features = {
   prod: "Production Mode",
+  gtm: "Mainnet Production Mode",
   dev: "Development Mode",
 };
 
@@ -47,7 +48,7 @@ for (const key of Object.keys(features)) {
   }
 }
 
-export const defaultFeatureName: FeatureName = "prod" as const;
+export const defaultFeatureName: FeatureName = "gtm" as const;
 
 if (!(defaultFeatureName in features)) {
   throw `defaultFeatureName '${defaultFeatureName}' not in Features!`;

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import AccountTabs, {TabValue} from "./Tabs";
 import AccountTitle from "./Title";
 import AccountInfo from "./AccountInfo/Index";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import BalanceCard from "./BalanceCard";
 import PageHeader from "../../components/PageHeader";
 import {useGetIsGraphqlClientSupported} from "../../api/hooks/useGraphqlClient";
@@ -20,7 +20,7 @@ const TAB_VALUES_FULL: TabValue[] = [
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
 export default function AccountPage() {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
   const {address} = useParams();
 
@@ -33,7 +33,7 @@ export default function AccountPage() {
       <Grid item xs={12} md={12} lg={12}>
         <PageHeader />
       </Grid>
-      {inDev ? (
+      {inGtm ? (
         <>
           <Grid item xs={12} md={8} lg={9} alignSelf="center">
             <AccountTitle address={address} />
@@ -56,7 +56,7 @@ export default function AccountPage() {
         <AccountTabs
           address={address}
           tabValues={
-            inDev && isGraphqlClientSupported ? TAB_VALUES_FULL : TAB_VALUES
+            inGtm && isGraphqlClientSupported ? TAB_VALUES_FULL : TAB_VALUES
           }
         />
       </Grid>

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -11,7 +11,7 @@ import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalance
 import DynamicFeedIcon from "@mui/icons-material/DynamicFeed";
 import ExtensionIcon from "@mui/icons-material/Extension";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
 import TokensTab from "./Tabs/TokensTab";
@@ -82,7 +82,7 @@ export default function AccountTabs({
   address,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [value, setValue] = useState<TabValue>(tabValues[0]);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
@@ -90,7 +90,7 @@ export default function AccountTabs({
   };
 
   // TODO: use LinkTab for better navigation
-  return inDev ? (
+  return inGtm ? (
     <Box sx={{width: "100%"}}>
       <Box>
         <StyledTabs value={value} onChange={handleChange}>

--- a/src/pages/Account/Tabs/InfoTab.tsx
+++ b/src/pages/Account/Tabs/InfoTab.tsx
@@ -8,7 +8,7 @@ import {getAccount} from "../../../api";
 import Divider from "@mui/material/Divider";
 import Error from "../Error";
 import Row from "../Row";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
@@ -59,7 +59,7 @@ type InfoTabProps = {
 };
 
 export default function InfoTab({address}: InfoTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [state, _] = useGlobalState();
 
   const {isLoading, data, error} = useQuery<Types.AccountData, ResponseError>(
@@ -75,7 +75,7 @@ export default function InfoTab({address}: InfoTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inDev ? (
+  return inGtm ? (
     <InfoContent data={data} />
   ) : (
     <Stack

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -9,7 +9,7 @@ import {useGlobalState} from "../../../GlobalState";
 import {ResponseError} from "../../../api/client";
 import {useQuery} from "react-query";
 import {getAccountModules} from "../../../api";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
@@ -100,7 +100,7 @@ function ModulesContent({
 }
 
 export default function ModulesTab({address}: ModulesTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [state, _] = useGlobalState();
 
   const {isLoading, data, error} = useQuery<
@@ -118,7 +118,7 @@ export default function ModulesTab({address}: ModulesTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inDev ? (
+  return inGtm ? (
     <ModulesContent data={data} />
   ) : (
     <Stack

--- a/src/pages/Account/Tabs/ResourcesTab.tsx
+++ b/src/pages/Account/Tabs/ResourcesTab.tsx
@@ -11,7 +11,7 @@ import useExpandedList from "../../../components/hooks/useExpandedList";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 
 function Content({
   data,
@@ -74,7 +74,7 @@ type ResourcesTabProps = {
 };
 
 export default function ResourcesTab({address}: ResourcesTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const {isLoading, data, error} = useGetAccountResources(address);
 
   if (isLoading) {
@@ -85,7 +85,7 @@ export default function ResourcesTab({address}: ResourcesTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inDev ? (
+  return inGtm ? (
     <ResourcesContent data={data} />
   ) : (
     <Stack

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -5,17 +5,17 @@ import DividerHero from "../../components/DividerHero";
 import HeadingSub from "../../components/HeadingSub";
 import HeaderSearch from "../layout/Search/Index";
 import Box from "@mui/material/Box";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import NetworkInfo from "./NetworkInfo/Index";
 import TransactionsPreview from "./TransactionsPreview";
 import UserTransactionsPreview from "./UserTransactionsPreview";
 import {useGetIsGraphqlClientSupported} from "../../api/hooks/useGraphqlClient";
 
 export default function LandingPage() {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
 
-  return inDev ? (
+  return inGtm ? (
     <Box>
       <HeadingSub>Network</HeadingSub>
       <Typography variant="h3" component="h3" marginBottom={4}>

--- a/src/pages/Transaction/Tabs.tsx
+++ b/src/pages/Transaction/Tabs.tsx
@@ -19,7 +19,7 @@ import CallMergeOutlinedIcon from "@mui/icons-material/CallMergeOutlined";
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 
 function getTabValues(transaction: Types.Transaction): TabValue[] {
   switch (transaction.type) {
@@ -113,7 +113,7 @@ export default function TransactionTabs({
   transaction,
   tabValues = getTabValues(transaction),
 }: TransactionTabsProps): JSX.Element {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [value, setValue] = useState<TabValue>(tabValues[0]);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
@@ -121,7 +121,7 @@ export default function TransactionTabs({
   };
 
   // TODO: use LinkTab for better navigation
-  return inDev ? (
+  return inGtm ? (
     <Box sx={{width: "100%"}}>
       <Box>
         <StyledTabs value={value} onChange={handleChange}>

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -9,7 +9,7 @@ import {
   OldTransactionStatus,
   TransactionStatus,
 } from "../../../components/TransactionStatus";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
@@ -22,11 +22,11 @@ type BlockMetadataOverviewTabProps = {
 export default function BlockMetadataOverviewTab({
   transaction,
 }: BlockMetadataOverviewTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const transactionData =
     transaction as Types.Transaction_BlockMetadataTransaction;
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginBottom={3}>
       <ContentBox paddingLeft={1.5}>
         <ContentRow

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -4,7 +4,7 @@ import {Stack, Box} from "@mui/material";
 import {renderDebug} from "../../utils";
 import Divider from "@mui/material/Divider";
 import Row from "./Components/Row";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
@@ -34,7 +34,7 @@ type ChangesTabProps = {
 };
 
 export default function ChangesTab({transaction}: ChangesTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
 
   if (!("changes" in transaction)) {
     return <EmptyTabContent />;
@@ -45,7 +45,7 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(changes.length);
 
-  return inDev ? (
+  return inGtm ? (
     <CollapsibleCards
       expandedList={expandedList}
       expandAll={expandAll}

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -5,7 +5,7 @@ import {renderDebug} from "../../utils";
 import Divider from "@mui/material/Divider";
 import Row from "./Components/Row";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
@@ -28,7 +28,7 @@ type EventsTabProps = {
 };
 
 export default function EventsTab({transaction}: EventsTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
 
   if (!("events" in transaction)) {
     return <EmptyTabContent />;
@@ -39,7 +39,7 @@ export default function EventsTab({transaction}: EventsTabProps) {
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(events.length);
 
-  return inDev ? (
+  return inGtm ? (
     <CollapsibleCards
       expandedList={expandedList}
       expandAll={expandAll}

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -8,7 +8,7 @@ import {
   OldTransactionStatus,
   TransactionStatus,
 } from "../../../components/TransactionStatus";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
@@ -19,10 +19,10 @@ type GenesisTransactionOverviewTabProps = {
 export default function GenesisTransactionOverviewTab({
   transaction,
 }: GenesisTransactionOverviewTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_GenesisTransaction;
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow

--- a/src/pages/Transaction/Tabs/PayloadTab.tsx
+++ b/src/pages/Transaction/Tabs/PayloadTab.tsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import {Types} from "aptos";
 import {Box, Typography} from "@mui/material";
 import {renderDebug} from "../../utils";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
@@ -12,7 +12,7 @@ type PayloadTabProps = {
 };
 
 export default function PayloadTab({transaction}: PayloadTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const [expanded, setExpanded] = useState<boolean>(true);
 
   if (!("payload" in transaction)) {
@@ -23,7 +23,7 @@ export default function PayloadTab({transaction}: PayloadTabProps) {
     setExpanded(!expanded);
   };
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginTop={3}>
       <CollapsibleCard
         key={0}

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -6,7 +6,7 @@ import HashButton, {HashType} from "../../../components/HashButton";
 import {getFormattedTimestamp, renderDebug} from "../../utils";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
@@ -20,10 +20,10 @@ type PendingTransactionOverviewTabProps = {
 export default function PendingTransactionOverviewTab({
   transaction,
 }: PendingTransactionOverviewTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_PendingTransaction;
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -8,7 +8,7 @@ import {
   OldTransactionStatus,
   TransactionStatus,
 } from "../../../components/TransactionStatus";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
@@ -21,11 +21,11 @@ type StateCheckpointOverviewTabProps = {
 export default function StateCheckpointOverviewTab({
   transaction,
 }: StateCheckpointOverviewTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const transactionData =
     transaction as Types.Transaction_StateCheckpointTransaction;
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -10,7 +10,7 @@ import {
   OldTransactionStatus,
   TransactionStatus,
 } from "../../../components/TransactionStatus";
-import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
@@ -77,10 +77,10 @@ type UserTransactionOverviewTabProps = {
 export default function UserTransactionOverviewTab({
   transaction,
 }: UserTransactionOverviewTabProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_UserTransaction;
 
-  return inDev ? (
+  return inGtm ? (
     <Box marginBottom={3}>
       <ContentBox padding={4}>
         <ContentRow

--- a/src/pages/Transaction/Title.tsx
+++ b/src/pages/Transaction/Title.tsx
@@ -3,18 +3,18 @@ import React from "react";
 import {Types} from "aptos";
 import HashButtonCopyable from "../../components/HashButtonCopyable";
 import {TransactionType} from "../../components/TransactionType";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 
 type TransactionTitleProps = {
   transaction: Types.Transaction;
 };
 
 export default function TransactionTitle({transaction}: TransactionTitleProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
 
-  return inDev ? (
+  return inGtm ? (
     <Stack
       direction={{xs: "column"}}
       alignItems="flex-start"

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -20,7 +20,7 @@ import {TableTransactionType} from "../../components/TransactionType";
 import {TableTransactionStatus} from "../../components/TransactionStatus";
 import {getFormattedTimestamp} from "../utils";
 import GasFeeValue from "../../components/IndividualPageContent/ContentValue/GasFeeValue";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import {useGetTransaction} from "../../api/hooks/useGetTransaction";
 
 type TransactionCellProps = {
@@ -81,9 +81,9 @@ function TransactionVersionCell({transaction}: TransactionCellProps) {
 }
 
 function TransactionGasCell({transaction}: TransactionCellProps) {
-  const inDev = useGetInDevMode();
+  const inGtm = useGetInGtmMode();
 
-  return inDev ? (
+  return inGtm ? (
     <TableCell sx={{textAlign: "right"}}>
       {"gas_used" in transaction && "gas_unit_price" in transaction ? (
         <GasFeeValue

--- a/src/pages/layout/FeatureBar.tsx
+++ b/src/pages/layout/FeatureBar.tsx
@@ -36,7 +36,7 @@ export default function FeatureBar() {
     }
   }
 
-  const goToProd = () => {
+  const goToDefaultMode = () => {
     maybeSetFeature(defaultFeatureName);
   };
 
@@ -61,9 +61,9 @@ export default function FeatureBar() {
           component="button"
           variant="body2"
           color="inherit"
-          onClick={goToProd}
+          onClick={goToDefaultMode}
         >
-          Go To Prod
+          {`Go To ${defaultFeatureName} Mode`}
         </Link>
       </Stack>
     </Box>


### PR DESCRIPTION
Yay~ Finally we're releasing the new version Explorer to users. This PR added a new feature `gtm` (get to market) that represent the explorer mode of mainnet launch. `gtm` will be the new default mode. After the new version has been running for a few days and working well, I'll remove the `gtm` flag and make it `prod`. Code clean up will be done by then too.