### PR TITLE
[Explorer] default feature always gtm

### DIFF
--- a/src/pages/layout/FeatureBar.tsx
+++ b/src/pages/layout/FeatureBar.tsx
@@ -44,6 +44,10 @@ export default function FeatureBar() {
     const feature_name = searchParams.get("feature");
     if (feature_name) {
       maybeSetFeature(feature_name);
+    } else {
+      // the "feature" param being null means that it's in mainnet production mode (gtm)
+      // so set feature to "gtm"
+      maybeSetFeature(defaultFeatureName);
     }
   });
 


### PR DESCRIPTION
Always set to default feature (gtm) unless there is a feature param in the url. This way users will be ensured to see the new version.