### PR TITLE
[Explorer] Chain IDs in network button

### DIFF
--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -114,6 +114,7 @@ export default function NetworkSelect() {
               color={grey[450]}
             >
               <Typography variant="body2">Network</Typography>
+              <Typography variant="body2">Chain ID</Typography>
             </Stack>
           </MenuItem>
           {Object.keys(networks).map((network_name: string) => (
@@ -126,6 +127,12 @@ export default function NetworkSelect() {
                 width="100%"
               >
                 <Typography>{network_name}</Typography>
+                <Typography
+                  variant="body2"
+                  sx={{color: theme.palette.text.disabled}}
+                >
+                  {3}
+                </Typography>
               </Stack>
             </MenuItem>
           ))}

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -14,6 +14,66 @@ import Box from "@mui/material/Box";
 import {useSearchParams} from "react-router-dom";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import {Stack} from "@mui/system";
+import {
+  useGetChainIdCached,
+  useGetChainIdAndCache,
+} from "../../api/hooks/useGetNetworkChainIds";
+
+function NetworkAndChainIdCached({
+  networkName,
+  chainId,
+}: {
+  networkName: string;
+  chainId: string | null;
+}) {
+  const theme = useTheme();
+
+  return (
+    <>
+      <Typography>{networkName}</Typography>
+      <Typography variant="body2" sx={{color: theme.palette.text.disabled}}>
+        {chainId}
+      </Typography>
+    </>
+  );
+}
+
+function NetworkAndChainId({networkName}: {networkName: string}) {
+  const theme = useTheme();
+  const chainId = useGetChainIdAndCache(networkName as NetworkName);
+
+  return chainId ? (
+    <>
+      <Typography>{networkName}</Typography>
+      <Typography variant="body2" sx={{color: theme.palette.text.disabled}}>
+        {chainId}
+      </Typography>
+    </>
+  ) : null;
+}
+
+function NetworkMenuItem({networkName}: {networkName: string}) {
+  const chainIdCached = useGetChainIdCached(networkName as NetworkName);
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+      spacing={3}
+      width="100%"
+    >
+      {chainIdCached ? (
+        <NetworkAndChainIdCached
+          networkName={networkName}
+          chainId={chainIdCached}
+        />
+      ) : (
+        <NetworkAndChainId networkName={networkName} />
+      )}
+    </Stack>
+  );
+}
 
 export default function NetworkSelect() {
   const [state, dispatch] = useGlobalState();
@@ -117,23 +177,9 @@ export default function NetworkSelect() {
               <Typography variant="body2">Chain ID</Typography>
             </Stack>
           </MenuItem>
-          {Object.keys(networks).map((network_name: string) => (
-            <MenuItem key={network_name} value={network_name}>
-              <Stack
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-                spacing={3}
-                width="100%"
-              >
-                <Typography>{network_name}</Typography>
-                <Typography
-                  variant="body2"
-                  sx={{color: theme.palette.text.disabled}}
-                >
-                  {3}
-                </Typography>
-              </Stack>
+          {Object.keys(networks).map((networkName: string) => (
+            <MenuItem key={networkName} value={networkName}>
+              <NetworkMenuItem networkName={networkName} />
             </MenuItem>
           ))}
         </Select>


### PR DESCRIPTION
Previously, the implementation of chain ids introduced hooks errors. Because the hooks to get chain id data are rendered conditionally which violates React hooks policy. This PR changed the implementation so that components were rendered conditionally instead of hooks. Will land this PR upon gtm due to business requirements.
<img width="307" alt="Screen Shot 2022-10-14 at 2 48 33 PM" src="https://user-images.githubusercontent.com/109111707/195949032-aeccbb6f-adc6-40d1-a63e-44ec41abe75d.png">
