### PR TITLE
[Explorer] fix conditional hooks

### DIFF
--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import {
   Box,
   BoxProps,
@@ -61,9 +61,8 @@ interface HashButtonProps extends BoxProps {
 }
 
 export default function HashButton({hash, type, ...props}: HashButtonProps) {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
-    null,
-  );
+  const theme = useTheme();
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   const hashExpand = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -77,7 +76,6 @@ export default function HashButton({hash, type, ...props}: HashButtonProps) {
 
   const open = Boolean(anchorEl);
   const id = open ? "simple-popover" : undefined;
-  const theme = useTheme();
 
   return (
     <Box {...props}>

--- a/src/components/HeadingSub.tsx
+++ b/src/components/HeadingSub.tsx
@@ -1,14 +1,11 @@
 import * as React from "react";
 import Typography from "@mui/material/Typography";
-import {useTheme} from "@mui/material";
 
 interface ChildrenProps {
   children?: React.ReactNode;
 }
 
 export default function HeadingSub(props: ChildrenProps) {
-  const theme = useTheme();
-
   return (
     <Typography
       color="secondary"

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -61,14 +61,13 @@ function ModulesContent({
 }: {
   data: Types.MoveModuleBytecode[] | undefined;
 }): JSX.Element {
-  if (!data || data.length === 0) {
-    return <EmptyTabContent />;
-  }
-
-  const modules: Types.MoveModuleBytecode[] = data;
-
+  const modules: Types.MoveModuleBytecode[] = data ?? [];
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(modules.length);
+
+  if (modules.length === 0) {
+    return <EmptyTabContent />;
+  }
 
   return (
     <CollapsibleCards

--- a/src/pages/Account/Tabs/ResourcesTab.tsx
+++ b/src/pages/Account/Tabs/ResourcesTab.tsx
@@ -39,14 +39,14 @@ function ResourcesContent({
 }: {
   data: Types.MoveResource[] | undefined;
 }): JSX.Element {
-  if (!data || data.length === 0) {
-    return <EmptyTabContent />;
-  }
-
-  const resources: Types.MoveResource[] = data;
+  const resources: Types.MoveResource[] = data ?? [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(resources.length);
+
+  if (resources.length === 0) {
+    return <EmptyTabContent />;
+  }
 
   return (
     <CollapsibleCards

--- a/src/pages/Block/Index.tsx
+++ b/src/pages/Block/Index.tsx
@@ -10,12 +10,8 @@ import PageHeader from "../../components/PageHeader";
 export default function BlockPage() {
   const {height} = useParams();
 
-  if (typeof height !== "string") {
-    return null;
-  }
-
   const {data, isLoading, error} = useGetBlockByHeight({
-    height: parseInt(height),
+    height: parseInt(height ?? ""),
   });
 
   if (isLoading) {
@@ -23,7 +19,7 @@ export default function BlockPage() {
   }
 
   if (error) {
-    return <Error error={error} height={height} />;
+    return <Error error={error} height={height ?? ""} />;
   }
 
   if (!data) {

--- a/src/pages/LandingPage/NetworkInfo/Card.tsx
+++ b/src/pages/LandingPage/NetworkInfo/Card.tsx
@@ -3,19 +3,11 @@ import {Box, BoxProps, useTheme} from "@mui/material";
 import {grey} from "../../../themes/colors/aptosColorPalette";
 
 interface CardProps extends BoxProps {
-  effectColor?: string;
   children: React.ReactNode;
 }
 
-export default function Card({
-  effectColor: customizedEffectColor,
-  children,
-  ...props
-}: CardProps) {
+export default function Card({children, ...props}: CardProps) {
   const theme = useTheme();
-  const effectColor =
-    customizedEffectColor ??
-    (theme.palette.mode === "dark" ? grey[800] : grey[100]);
 
   return (
     <Box

--- a/src/pages/LandingPage/NetworkInfo/MetricCard.tsx
+++ b/src/pages/LandingPage/NetworkInfo/MetricCard.tsx
@@ -20,7 +20,7 @@ export default function MetricCard({
   tooltipText,
 }: MetricCardProps) {
   return (
-    <Card effectColor={aptosColorOpacity}>
+    <Card>
       <Stack alignItems="flex-end" spacing={2.5} marginTop={2}>
         <Typography fontSize={20} fontWeight={400}>
           {data}

--- a/src/pages/Token/Tabs/OverviewTab.tsx
+++ b/src/pages/Token/Tabs/OverviewTab.tsx
@@ -23,14 +23,10 @@ const OWNER_QUERY = gql`
 function OwnersRow() {
   const {tokenId, propertyVersion} = useParams();
 
-  if (propertyVersion === undefined) {
-    return null;
-  }
-
   const {data: ownersData} = useQuery(OWNER_QUERY, {
     variables: {
       token_id: tokenId,
-      property_version: parseInt(propertyVersion),
+      property_version: parseInt(propertyVersion ?? ""),
     },
   });
 

--- a/src/pages/Transaction/Index.tsx
+++ b/src/pages/Transaction/Index.tsx
@@ -9,16 +9,12 @@ import {getTransaction} from "../../api";
 import Error from "./Error";
 import TransactionTitle from "./Title";
 import TransactionTabs from "./Tabs";
-import GoBack from "../../components/GoBack";
 import PageHeader from "../../components/PageHeader";
 
 export default function TransactionPage() {
   const [state, _] = useGlobalState();
-  const {txnHashOrVersion} = useParams();
-
-  if (typeof txnHashOrVersion !== "string") {
-    return null;
-  }
+  const {txnHashOrVersion: txnParam} = useParams();
+  const txnHashOrVersion = txnParam ?? "";
 
   const {isLoading, data, error} = useQuery<Types.Transaction, ResponseError>(
     ["transaction", {txnHashOrVersion}, state.network_value],

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -42,6 +42,10 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(changes.length);
 
+  if (changes.length === 0) {
+    return <EmptyTabContent />;
+  }
+
   return inGtm ? (
     <CollapsibleCards
       expandedList={expandedList}

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -36,11 +36,8 @@ type ChangesTabProps = {
 export default function ChangesTab({transaction}: ChangesTabProps) {
   const inGtm = useGetInGtmMode();
 
-  if (!("changes" in transaction)) {
-    return <EmptyTabContent />;
-  }
-
-  const changes: Types.WriteSetChange[] = transaction.changes;
+  const changes: Types.WriteSetChange[] =
+    "changes" in transaction ? transaction.changes : [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(changes.length);

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -36,6 +36,10 @@ export default function EventsTab({transaction}: EventsTabProps) {
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(events.length);
 
+  if (events.length === 0) {
+    return <EmptyTabContent />;
+  }
+
   return inGtm ? (
     <CollapsibleCards
       expandedList={expandedList}

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -30,11 +30,8 @@ type EventsTabProps = {
 export default function EventsTab({transaction}: EventsTabProps) {
   const inGtm = useGetInGtmMode();
 
-  if (!("events" in transaction)) {
-    return <EmptyTabContent />;
-  }
-
-  const events: Types.Event[] = transaction.events;
+  const events: Types.Event[] =
+    "events" in transaction ? transaction.events : [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(events.length);

--- a/src/pages/Transactions/AllTransactions.tsx
+++ b/src/pages/Transactions/AllTransactions.tsx
@@ -68,17 +68,7 @@ function TransactionContent({data}: UseQueryResult<Array<Types.Transaction>>) {
 }
 
 function TransactionsPageInner({data}: UseQueryResult<Types.IndexResponse>) {
-  if (!data) {
-    // TODO: handle errors
-    return <>No ledger info</>;
-  }
-
-  const maxVersion = parseInt(data.ledger_version);
-  if (!maxVersion) {
-    // TODO: handle errors
-    return <>No maxVersion</>;
-  }
-
+  const maxVersion = parseInt(data?.ledger_version ?? "");
   const limit = LIMIT;
   const [state, _setState] = useGlobalState();
   const [searchParams, _setSearchParams] = useSearchParams();

--- a/src/pages/layout/Header.tsx
+++ b/src/pages/layout/Header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
 
-  const {ref, inView, entry} = useInView({
+  const {ref, inView} = useInView({
     rootMargin: "-40px 0px 0px 0px",
     threshold: 0,
   });

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -18,6 +18,7 @@ import {Stack} from "@mui/system";
 export default function NetworkSelect() {
   const [state, dispatch] = useGlobalState();
   const [searchParams, setSearchParams] = useSearchParams();
+  const theme = useTheme();
 
   function maybeSetNetwork(networkNameString: string | null) {
     if (!networkNameString || state.network_name === networkNameString) return;
@@ -54,8 +55,6 @@ export default function NetworkSelect() {
       </SvgIcon>
     );
   }
-
-  const theme = useTheme();
 
   return (
     <Box>


### PR DESCRIPTION
We got a bunch of Sentry errors that are related to conditional hooks. Basically all hooks should be used unconditionally at the top of a component. Any early return will be a violation. This PR scans the code base and fixes (hopefully) all the conditional hooks.