### PR TITLE
[Explorer] remove old explorer code

### DIFF
--- a/src/api/hooks/useGetInDevMode.ts
+++ b/src/api/hooks/useGetInDevMode.ts
@@ -4,8 +4,3 @@ export function useGetInDevMode(): boolean {
   const [state, _] = useGlobalState();
   return state.feature_name && state.feature_name === "dev";
 }
-
-export function useGetInGtmMode(): boolean {
-  const [state, _] = useGlobalState();
-  return state.feature_name && state.feature_name === "gtm";
-}

--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -11,7 +11,6 @@ import {
   isValidAccountAddress,
   isValidTxnHashOrVersion,
 } from "../../pages/utils";
-import {useGetInGtmMode} from "./useGetInDevMode";
 
 export type SearchResult = {
   label: string;
@@ -24,7 +23,6 @@ export const NotFoundResult: SearchResult = {
 };
 
 export default function useGetSearchResults(input: string) {
-  const inGtm = useGetInGtmMode();
   const [results, setResults] = useState<SearchResult[]>([]);
   const [state, _setState] = useGlobalState();
 
@@ -109,7 +107,7 @@ export default function useGetSearchResults(input: string) {
       if (isValidTxnHashOrVer) {
         promises.push(txnPromise);
       }
-      if (inGtm && isValidBlockHeightOrVer) {
+      if (isValidBlockHeightOrVer) {
         promises.push(blockByHeightPromise);
         promises.push(blockByVersionPromise);
       }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,11 +1,7 @@
-import React, {useState} from "react";
-
-import {NavLink, useNavigate} from "react-router-dom";
+import React from "react";
+import {NavLink} from "react-router-dom";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
-import {Menu, MenuItem} from "@mui/material";
-import Fade from "@mui/material/Fade";
-import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 
 function NavButton({
   to,
@@ -36,25 +32,6 @@ function NavButton({
 }
 
 export default function Nav() {
-  const inGtm = useGetInGtmMode();
-  const [governanceMenuEl, setGovernanceMenuEl] = useState<null | HTMLElement>(
-    null,
-  );
-  const navigate = useNavigate();
-  const open = Boolean(governanceMenuEl);
-
-  const handleGovernanceClick = (event: React.MouseEvent<HTMLElement>) => {
-    setGovernanceMenuEl(event.currentTarget);
-  };
-  const handleCloseAndNavigate = (to: string) => {
-    setGovernanceMenuEl(null);
-    navigate(to);
-  };
-
-  const handleClose = () => {
-    setGovernanceMenuEl(null);
-  };
-
   return (
     <Box
       sx={{
@@ -69,49 +46,12 @@ export default function Nav() {
         title="View All Transactions"
         label="Transactions"
       />
-      {inGtm && (
-        <>
-          <NavButton to="/blocks" title="View Latest Blocks" label="Blocks" />
-          <NavButton
-            to="/Validators"
-            title="View All Validators"
-            label="Validators"
-          />
-        </>
-      )}
-      {!inGtm && (
-        <>
-          <Button
-            variant="nav"
-            onClick={handleGovernanceClick}
-            title="Aptos Governance"
-            sx={{
-              color: "inherit",
-              fontSize: "1rem",
-            }}
-          >
-            Governance
-          </Button>
-          <Menu
-            open={open}
-            onClose={handleClose}
-            anchorEl={governanceMenuEl}
-            TransitionComponent={Fade}
-            aria-controls={open ? "fade-menu" : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? "true" : undefined}
-          >
-            <MenuItem onClick={() => handleCloseAndNavigate("/proposals")}>
-              Proposals
-            </MenuItem>
-            <MenuItem
-              onClick={() => handleCloseAndNavigate("/proposals/staking")}
-            >
-              Staking
-            </MenuItem>
-          </Menu>
-        </>
-      )}
+      <NavButton to="/blocks" title="View Latest Blocks" label="Blocks" />
+      <NavButton
+        to="/Validators"
+        title="View All Validators"
+        label="Validators"
+      />
     </Box>
   );
 }

--- a/src/components/NavMobile.tsx
+++ b/src/components/NavMobile.tsx
@@ -9,34 +9,23 @@ import {grey} from "../themes/colors/aptosColorPalette";
 import Box from "@mui/material/Box";
 import {useTheme} from "@mui/material";
 import {useNavigate} from "react-router-dom";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 
 export default function NavMobile() {
-  const inGtm = useGetInGtmMode();
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
-  const [governanceMenuOpen, setGovernanceMenuOpen] = useState<boolean>(false);
   const theme = useTheme();
   const navigate = useNavigate();
 
   const menuOpen = Boolean(menuAnchorEl);
-
-  const handleGovernanceClick = (event: React.MouseEvent<HTMLElement>) => {
-    setGovernanceMenuOpen(!governanceMenuOpen);
-  };
 
   const handleIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setMenuAnchorEl(event.currentTarget);
   };
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
-    setGovernanceMenuOpen(false);
   };
 
   const handleCloseAndNavigate = (to: string) => {
     setMenuAnchorEl(null);
-    setGovernanceMenuOpen(false);
     navigate(to);
   };
 
@@ -63,90 +52,35 @@ export default function NavMobile() {
       >
         {menuOpen ? <CloseIcon /> : <HamburgerIcon />}
       </Button>
-      {inGtm ? (
-        <Menu
-          anchorEl={menuAnchorEl}
-          open={menuOpen}
-          onClose={handleMenuClose}
-          MenuListProps={{
-            "aria-labelledby": "nav-mobile-button",
-            sx: {
-              minWidth: 240,
-              padding: "1rem",
-            },
-          }}
-          sx={{
-            marginTop: "1rem",
-            boxShadow: 0,
-            minWidth: "400px",
-            maxWidth: "none",
-          }}
-        >
-          <MenuItem onClick={() => handleCloseAndNavigate("/transactions")}>
-            Transactions
-          </MenuItem>
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={menuOpen}
+        onClose={handleMenuClose}
+        MenuListProps={{
+          "aria-labelledby": "nav-mobile-button",
+          sx: {
+            minWidth: 240,
+            padding: "1rem",
+          },
+        }}
+        sx={{
+          marginTop: "1rem",
+          boxShadow: 0,
+          minWidth: "400px",
+          maxWidth: "none",
+        }}
+      >
+        <MenuItem onClick={() => handleCloseAndNavigate("/transactions")}>
+          Transactions
+        </MenuItem>
 
-          <MenuItem onClick={() => handleCloseAndNavigate("/blocks")}>
-            Blocks
-          </MenuItem>
-          <MenuItem onClick={() => handleCloseAndNavigate("/Validators")}>
-            Validators
-          </MenuItem>
-        </Menu>
-      ) : (
-        <Menu
-          anchorEl={menuAnchorEl}
-          open={menuOpen}
-          onClose={handleMenuClose}
-          MenuListProps={{
-            "aria-labelledby": "nav-mobile-button",
-            sx: {
-              minWidth: 240,
-              padding: "1rem",
-            },
-          }}
-          sx={{
-            marginTop: "1rem",
-            boxShadow: 0,
-            minWidth: "400px",
-            maxWidth: "none",
-          }}
-        >
-          <MenuItem onClick={() => handleCloseAndNavigate("/transactions")}>
-            Transactions
-          </MenuItem>
-          <MenuItem
-            onClick={handleGovernanceClick}
-            sx={{display: "flex", justifyContent: "space-between"}}
-          >
-            Governance{" "}
-            {governanceMenuOpen ? (
-              <KeyboardArrowUpIcon />
-            ) : (
-              <KeyboardArrowDownIcon />
-            )}
-          </MenuItem>
-          {governanceMenuOpen && (
-            <Box
-              sx={{
-                paddingLeft: "1.5rem",
-              }}
-              aria-controls={governanceMenuOpen ? "nav-mobile-menu" : undefined}
-              aria-haspopup="true"
-              aria-expanded={governanceMenuOpen ? "true" : undefined}
-            >
-              <MenuItem onClick={() => handleCloseAndNavigate("/proposals")}>
-                Proposals
-              </MenuItem>
-              <MenuItem
-                onClick={() => handleCloseAndNavigate("/proposals/staking")}
-              >
-                Staking
-              </MenuItem>
-            </Box>
-          )}
-        </Menu>
-      )}
+        <MenuItem onClick={() => handleCloseAndNavigate("/blocks")}>
+          Blocks
+        </MenuItem>
+        <MenuItem onClick={() => handleCloseAndNavigate("/Validators")}>
+          Validators
+        </MenuItem>
+      </Menu>
     </Box>
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,34 +1,12 @@
-import {Grid, Typography} from "@mui/material";
 import * as React from "react";
-import {useGetInGtmMode} from "../api/hooks/useGetInDevMode";
 import HeaderSearch from "../pages/layout/Search/Index";
-import DividerHero from "./DividerHero";
 import GoBack from "./GoBack";
 
 export default function PageHeader() {
-  const inGtm = useGetInGtmMode();
   return (
     <>
-      {inGtm ? <GoBack /> : null}
-      {inGtm ? (
-        <HeaderSearch />
-      ) : (
-        <Grid item xs={12}>
-          <Typography
-            color="primary"
-            variant="subtitle2"
-            component="span"
-            sx={{mb: 2}}
-          >
-            Network
-          </Typography>
-          <Typography variant="h3" component="h1" gutterBottom>
-            Aptos Explorer
-          </Typography>
-          <DividerHero />
-          <HeaderSearch />
-        </Grid>
-      )}
+      <GoBack />
+      <HeaderSearch />
     </>
   );
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -34,7 +34,6 @@ export const defaultNetwork = networks[defaultNetworkName];
  */
 export const features = {
   prod: "Production Mode",
-  gtm: "Mainnet Production Mode",
   dev: "Development Mode",
 };
 
@@ -48,7 +47,7 @@ for (const key of Object.keys(features)) {
   }
 }
 
-export const defaultFeatureName: FeatureName = "gtm" as const;
+export const defaultFeatureName: FeatureName = "prod" as const;
 
 if (!(defaultFeatureName in features)) {
   throw `defaultFeatureName '${defaultFeatureName}' not in Features!`;

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -3,8 +3,6 @@ import {Grid} from "@mui/material";
 import React from "react";
 import AccountTabs, {TabValue} from "./Tabs";
 import AccountTitle from "./Title";
-import AccountInfo from "./AccountInfo/Index";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import BalanceCard from "./BalanceCard";
 import PageHeader from "../../components/PageHeader";
 import {useGetIsGraphqlClientSupported} from "../../api/hooks/useGraphqlClient";
@@ -20,7 +18,6 @@ const TAB_VALUES_FULL: TabValue[] = [
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
 export default function AccountPage() {
-  const inGtm = useGetInGtmMode();
   const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
   const {address} = useParams();
 
@@ -33,31 +30,16 @@ export default function AccountPage() {
       <Grid item xs={12} md={12} lg={12}>
         <PageHeader />
       </Grid>
-      {inGtm ? (
-        <>
-          <Grid item xs={12} md={8} lg={9} alignSelf="center">
-            <AccountTitle address={address} />
-          </Grid>
-          <Grid item xs={12} md={4} lg={3} marginTop={{md: 0, xs: 2}}>
-            <BalanceCard address={address} />
-          </Grid>
-        </>
-      ) : (
-        <>
-          <Grid item xs={12} md={12} lg={12}>
-            <AccountTitle address={address} />
-          </Grid>
-          <Grid item xs={12} md={12} lg={12} marginTop={2}>
-            <AccountInfo address={address} />
-          </Grid>
-        </>
-      )}
+      <Grid item xs={12} md={8} lg={9} alignSelf="center">
+        <AccountTitle address={address} />
+      </Grid>
+      <Grid item xs={12} md={4} lg={3} marginTop={{md: 0, xs: 2}}>
+        <BalanceCard address={address} />
+      </Grid>
       <Grid item xs={12} md={12} lg={12} marginTop={4}>
         <AccountTabs
           address={address}
-          tabValues={
-            inGtm && isGraphqlClientSupported ? TAB_VALUES_FULL : TAB_VALUES
-          }
+          tabValues={isGraphqlClientSupported ? TAB_VALUES_FULL : TAB_VALUES}
         />
       </Grid>
     </Grid>

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {useState} from "react";
-import {Tabs, Tab, Box} from "@mui/material";
+import {Box} from "@mui/material";
 import TransactionsTab from "./Tabs/TransactionsTab";
 import InfoTab from "./Tabs/InfoTab";
 import ResourcesTab from "./Tabs/ResourcesTab";
@@ -11,7 +11,6 @@ import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalance
 import DynamicFeedIcon from "@mui/icons-material/DynamicFeed";
 import ExtensionIcon from "@mui/icons-material/Extension";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
 import TokensTab from "./Tabs/TokensTab";
@@ -82,7 +81,6 @@ export default function AccountTabs({
   address,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
-  const inGtm = useGetInGtmMode();
   const [value, setValue] = useState<TabValue>(tabValues[0]);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
@@ -90,7 +88,7 @@ export default function AccountTabs({
   };
 
   // TODO: use LinkTab for better navigation
-  return inGtm ? (
+  return (
     <Box sx={{width: "100%"}}>
       <Box>
         <StyledTabs value={value} onChange={handleChange}>
@@ -107,30 +105,6 @@ export default function AccountTabs({
         </StyledTabs>
       </Box>
       <Box>
-        <TabPanel value={value} address={address} />
-      </Box>
-    </Box>
-  ) : (
-    <Box sx={{width: "100%"}}>
-      <Box sx={{borderBottom: 1, borderColor: "divider"}}>
-        <Tabs
-          value={value}
-          onChange={handleChange}
-          aria-label="account page tabs"
-          variant="scrollable"
-          scrollButtons="auto"
-        >
-          {tabValues.map((value, i) => (
-            <Tab
-              key={i}
-              label={getTabLabel(value)}
-              value={value}
-              sx={{fontSize: {xs: "medium", md: "large"}}}
-            />
-          ))}
-        </Tabs>
-      </Box>
-      <Box sx={{marginY: 3}}>
         <TabPanel value={value} address={address} />
       </Box>
     </Box>

--- a/src/pages/Account/Tabs/InfoTab.tsx
+++ b/src/pages/Account/Tabs/InfoTab.tsx
@@ -1,31 +1,15 @@
 import {Types} from "aptos";
 import {ResponseError} from "../../../api/client";
 import {useQuery} from "react-query";
-import {Box, Stack} from "@mui/material";
+import {Box} from "@mui/material";
 import React from "react";
 import {useGlobalState} from "../../../GlobalState";
 import {getAccount} from "../../../api";
-import Divider from "@mui/material/Divider";
 import Error from "../Error";
-import Row from "../Row";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {getLearnMoreTooltip} from "../../Transaction/helpers";
-
-function Content({data}: {data: Types.AccountData | undefined}): JSX.Element {
-  if (!data) {
-    return <>None</>;
-  } else {
-    return (
-      <>
-        <Row title={"Sequence Number:"} value={data.sequence_number} />
-        <Row title={"Authentication Key:"} value={data.authentication_key} />
-      </>
-    );
-  }
-}
 
 function InfoContent({
   data,
@@ -59,7 +43,6 @@ type InfoTabProps = {
 };
 
 export default function InfoTab({address}: InfoTabProps) {
-  const inGtm = useGetInGtmMode();
   const [state, _] = useGlobalState();
 
   const {isLoading, data, error} = useQuery<Types.AccountData, ResponseError>(
@@ -75,16 +58,5 @@ export default function InfoTab({address}: InfoTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inGtm ? (
-    <InfoContent data={data} />
-  ) : (
-    <Stack
-      marginX={2}
-      direction="column"
-      spacing={2}
-      divider={<Divider variant="dotted" orientation="horizontal" />}
-    >
-      <Content data={data} />
-    </Stack>
-  );
+  return <InfoContent data={data} />;
 }

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -1,56 +1,17 @@
 import {Types} from "aptos";
-import {Box, Stack} from "@mui/material";
+import {Box} from "@mui/material";
 import React from "react";
-import Divider from "@mui/material/Divider";
 import Error from "../Error";
-import Row from "../Row";
-import {renderDebug} from "../../utils";
 import {useGlobalState} from "../../../GlobalState";
 import {ResponseError} from "../../../api/client";
 import {useQuery} from "react-query";
 import {getAccountModules} from "../../../api";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-
-const copyToClipboard = (content: any) => {
-  const el = document.createElement("textarea");
-  el.value = content;
-  document.body.appendChild(el);
-  el.select();
-  document.execCommand("copy");
-  document.body.removeChild(el);
-};
-
-function Content({
-  data,
-}: {
-  data: Types.MoveModuleBytecode[] | undefined;
-}): JSX.Element {
-  if (!data || data.length === 0) {
-    return <>None</>;
-  } else {
-    return (
-      <>
-        {data.map((module, i) => (
-          <Stack direction="column" key={i} spacing={3}>
-            <Row title={"Bytecode:"} value={module.bytecode} />
-            <div onClick={() => copyToClipboard(JSON.stringify(module.abi))}>
-              ABI
-              <ContentCopyIcon fontSize="small" />:
-            </div>
-            <Row title="" value={renderDebug(module.abi)} />
-          </Stack>
-        ))}
-      </>
-    );
-  }
-}
 
 type ModulesTabProps = {
   address: string;
@@ -99,7 +60,6 @@ function ModulesContent({
 }
 
 export default function ModulesTab({address}: ModulesTabProps) {
-  const inGtm = useGetInGtmMode();
   const [state, _] = useGlobalState();
 
   const {isLoading, data, error} = useQuery<
@@ -117,16 +77,5 @@ export default function ModulesTab({address}: ModulesTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inGtm ? (
-    <ModulesContent data={data} />
-  ) : (
-    <Stack
-      marginX={2}
-      direction="column"
-      spacing={2}
-      divider={<Divider variant="dotted" orientation="horizontal" />}
-    >
-      <Content data={data} />
-    </Stack>
-  );
+  return <ModulesContent data={data} />;
 }

--- a/src/pages/Account/Tabs/ResourcesTab.tsx
+++ b/src/pages/Account/Tabs/ResourcesTab.tsx
@@ -1,38 +1,12 @@
 import {Types} from "aptos";
-import {Stack} from "@mui/material";
 import React from "react";
-import Divider from "@mui/material/Divider";
 import Error from "../Error";
-import Row from "../Row";
-import {renderDebug} from "../../utils";
 import {useGetAccountResources} from "../../../api/hooks/useGetAccountResources";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
-
-function Content({
-  data,
-}: {
-  data: Types.MoveResource[] | undefined;
-}): JSX.Element {
-  if (!data || data.length === 0) {
-    return <>None</>;
-  } else {
-    return (
-      <>
-        {data.map((resource, i) => (
-          <Stack direction="column" key={i} spacing={3}>
-            <Row title={"Type:"} value={resource.type} />
-            <Row title={"Data:"} value={renderDebug(resource.data)} />
-          </Stack>
-        ))}
-      </>
-    );
-  }
-}
 
 function ResourcesContent({
   data,
@@ -74,7 +48,6 @@ type ResourcesTabProps = {
 };
 
 export default function ResourcesTab({address}: ResourcesTabProps) {
-  const inGtm = useGetInGtmMode();
   const {isLoading, data, error} = useGetAccountResources(address);
 
   if (isLoading) {
@@ -85,16 +58,5 @@ export default function ResourcesTab({address}: ResourcesTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return inGtm ? (
-    <ResourcesContent data={data} />
-  ) : (
-    <Stack
-      marginX={2}
-      direction="column"
-      spacing={2}
-      divider={<Divider variant="dotted" orientation="horizontal" />}
-    >
-      <Content data={data} />
-    </Stack>
-  );
+  return <ResourcesContent data={data} />;
 }

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -1,34 +1,17 @@
 import React from "react";
-import LedgerInfo from "./LedgerInfo";
 import Typography from "@mui/material/Typography";
-import DividerHero from "../../components/DividerHero";
-import HeadingSub from "../../components/HeadingSub";
 import HeaderSearch from "../layout/Search/Index";
 import Box from "@mui/material/Box";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import NetworkInfo from "./NetworkInfo/Index";
 import TransactionsPreview from "./TransactionsPreview";
 
 export default function LandingPage() {
-  const inGtm = useGetInGtmMode();
-
-  return inGtm ? (
+  return (
     <Box>
       <Typography variant="h3" component="h3" marginBottom={4}>
         Aptos Explorer
       </Typography>
       <NetworkInfo />
-      <HeaderSearch />
-      <TransactionsPreview />
-    </Box>
-  ) : (
-    <Box>
-      <HeadingSub>Network</HeadingSub>
-      <Typography variant="h1" component="h1" gutterBottom>
-        Aptos Explorer
-      </Typography>
-      <DividerHero />
-      <LedgerInfo />
       <HeaderSearch />
       <TransactionsPreview />
     </Box>

--- a/src/pages/Transaction/Tabs.tsx
+++ b/src/pages/Transaction/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {useState} from "react";
-import {Tabs, Tab, Box} from "@mui/material";
+import {Box} from "@mui/material";
 import {Types} from "aptos";
 import {assertNever} from "../../utils";
 import StyledTabs from "../../components/StyledTabs";
@@ -19,7 +19,6 @@ import CallMergeOutlinedIcon from "@mui/icons-material/CallMergeOutlined";
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 
 function getTabValues(transaction: Types.Transaction): TabValue[] {
   switch (transaction.type) {
@@ -113,7 +112,6 @@ export default function TransactionTabs({
   transaction,
   tabValues = getTabValues(transaction),
 }: TransactionTabsProps): JSX.Element {
-  const inGtm = useGetInGtmMode();
   const [value, setValue] = useState<TabValue>(tabValues[0]);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
@@ -121,7 +119,7 @@ export default function TransactionTabs({
   };
 
   // TODO: use LinkTab for better navigation
-  return inGtm ? (
+  return (
     <Box sx={{width: "100%"}}>
       <Box>
         <StyledTabs value={value} onChange={handleChange}>
@@ -138,30 +136,6 @@ export default function TransactionTabs({
         </StyledTabs>
       </Box>
       <Box>
-        <TabPanel value={value} transaction={transaction} />
-      </Box>
-    </Box>
-  ) : (
-    <Box sx={{width: "100%"}}>
-      <Box sx={{borderBottom: 1, borderColor: "divider"}}>
-        <Tabs
-          value={value}
-          onChange={handleChange}
-          aria-label="account page tabs"
-          variant="scrollable"
-          scrollButtons="auto"
-        >
-          {tabValues.map((value, i) => (
-            <Tab
-              key={i}
-              label={getTabLabel(value)}
-              value={value}
-              sx={{fontSize: {xs: "medium", md: "large"}}}
-            />
-          ))}
-        </Tabs>
-      </Box>
-      <Box sx={{marginY: 3}}>
         <TabPanel value={value} transaction={transaction} />
       </Box>
     </Box>

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -1,19 +1,12 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import Row from "./Components/Row";
+import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
-import {
-  OldTransactionStatus,
-  TransactionStatus,
-} from "../../../components/TransactionStatus";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
+import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
-import {getFormattedTimestamp} from "../../utils";
 
 type BlockMetadataOverviewTabProps = {
   transaction: Types.Transaction;
@@ -22,11 +15,10 @@ type BlockMetadataOverviewTabProps = {
 export default function BlockMetadataOverviewTab({
   transaction,
 }: BlockMetadataOverviewTabProps) {
-  const inGtm = useGetInGtmMode();
   const transactionData =
     transaction as Types.Transaction_BlockMetadataTransaction;
 
-  return inGtm ? (
+  return (
     <Box marginBottom={3}>
       <ContentBox paddingLeft={1.5}>
         <ContentRow
@@ -92,48 +84,6 @@ export default function BlockMetadataOverviewTab({
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack direction="column" spacing={3}>
-        <Row title={"ID:"} value={transactionData.id} />
-        <Row title={"Version:"} value={transactionData.version} />
-        <Row title={"Round:"} value={transactionData.round} />
-        <Row
-          title={"Status:"}
-          value={<OldTransactionStatus success={transactionData.success} />}
-        />
-        <Row
-          title={"Proposer:"}
-          value={
-            <HashButton
-              hash={transactionData.proposer}
-              type={HashType.ACCOUNT}
-            />
-          }
-        />
-        <Row
-          title={"State Change Hash:"}
-          value={transactionData.state_change_hash}
-        />
-        <Row
-          title={"Event Root Hash:"}
-          value={transactionData.event_root_hash}
-        />
-        <Row
-          title={"Gas Used:"}
-          value={<GasValue gas={transactionData.gas_used} />}
-        />
-        <Row title={"VM Status:"} value={transactionData.vm_status} />
-        <Row
-          title={"Accumulator Root Hash:"}
-          value={transactionData.accumulator_root_hash}
-        />
-        <Row
-          title={"Timestamp:"}
-          value={getFormattedTimestamp(transactionData.timestamp)}
-        />
-      </Stack>
     </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -1,10 +1,5 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import {renderDebug} from "../../utils";
-import Divider from "@mui/material/Divider";
-import Row from "./Components/Row";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
@@ -12,30 +7,11 @@ import CollapsibleCard from "../../../components/IndividualPageContent/Collapsib
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 
-function Change({change, i}: {change: Types.WriteSetChange; i: number}) {
-  return (
-    <Stack direction="column" spacing={1}>
-      <Row title={"Index:"} value={i} />
-      <Row title={"Type:"} value={change.type} />
-      {"address" in change && <Row title={"Address:"} value={change.address} />}
-      <Row
-        title={"State Key Hash:"}
-        value={renderDebug(change.state_key_hash)}
-      />
-      {"data" in change && (
-        <Row title={"Data:"} value={renderDebug(change.data)} />
-      )}
-    </Stack>
-  );
-}
-
 type ChangesTabProps = {
   transaction: Types.Transaction;
 };
 
 export default function ChangesTab({transaction}: ChangesTabProps) {
-  const inGtm = useGetInGtmMode();
-
   const changes: Types.WriteSetChange[] =
     "changes" in transaction ? transaction.changes : [];
 
@@ -46,7 +22,7 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
     return <EmptyTabContent />;
   }
 
-  return inGtm ? (
+  return (
     <CollapsibleCards
       expandedList={expandedList}
       expandAll={expandAll}
@@ -71,17 +47,5 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
         </CollapsibleCard>
       ))}
     </CollapsibleCards>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack
-        direction="column"
-        spacing={3}
-        divider={<Divider variant="dotted" orientation="horizontal" />}
-      >
-        {changes.map((change, i) => (
-          <Change change={change} i={i} key={i} />
-        ))}
-      </Stack>
-    </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import {renderDebug} from "../../utils";
-import Divider from "@mui/material/Divider";
-import Row from "./Components/Row";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
@@ -13,23 +8,11 @@ import useExpandedList from "../../../components/hooks/useExpandedList";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import HashButton, {HashType} from "../../../components/HashButton";
 
-function Event({event}: {event: Types.Event}) {
-  return (
-    <Stack direction="column" spacing={1}>
-      <Row title={"Sequence Number:"} value={event.sequence_number} />
-      <Row title={"Type:"} value={event.type} />
-      <Row title={"Data:"} value={renderDebug(event.data)} />
-    </Stack>
-  );
-}
-
 type EventsTabProps = {
   transaction: Types.Transaction;
 };
 
 export default function EventsTab({transaction}: EventsTabProps) {
-  const inGtm = useGetInGtmMode();
-
   const events: Types.Event[] =
     "events" in transaction ? transaction.events : [];
 
@@ -40,7 +23,7 @@ export default function EventsTab({transaction}: EventsTabProps) {
     return <EmptyTabContent />;
   }
 
-  return inGtm ? (
+  return (
     <CollapsibleCards
       expandedList={expandedList}
       expandAll={expandAll}
@@ -73,17 +56,5 @@ export default function EventsTab({transaction}: EventsTabProps) {
         </CollapsibleCard>
       ))}
     </CollapsibleCards>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack
-        direction="column"
-        spacing={3}
-        divider={<Divider variant="dotted" orientation="horizontal" />}
-      >
-        {events.map((event, i) => (
-          <Event event={event} key={i} />
-        ))}
-      </Stack>
-    </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -1,16 +1,10 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import Row from "./Components/Row";
+import {Box} from "@mui/material";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
-import {
-  OldTransactionStatus,
-  TransactionStatus,
-} from "../../../components/TransactionStatus";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
+import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 
 type GenesisTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -19,10 +13,9 @@ type GenesisTransactionOverviewTabProps = {
 export default function GenesisTransactionOverviewTab({
   transaction,
 }: GenesisTransactionOverviewTabProps) {
-  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_GenesisTransaction;
 
-  return inGtm ? (
+  return (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow
@@ -58,33 +51,6 @@ export default function GenesisTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack direction="column" spacing={3}>
-        <Row title={"Version:"} value={transactionData.version} />
-        <Row
-          title={"Status:"}
-          value={<OldTransactionStatus success={transactionData.success} />}
-        />
-        <Row
-          title={"State Change Hash:"}
-          value={transactionData.state_change_hash}
-        />
-        <Row
-          title={"Event Root Hash:"}
-          value={transactionData.event_root_hash}
-        />
-        <Row
-          title={"Gas Used:"}
-          value={<GasValue gas={transactionData.gas_used} />}
-        />
-        <Row title={"VM Status:"} value={transactionData.vm_status} />
-        <Row
-          title={"Accumulator Root Hash:"}
-          value={transactionData.accumulator_root_hash}
-        />
-      </Stack>
     </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/PayloadTab.tsx
+++ b/src/pages/Transaction/Tabs/PayloadTab.tsx
@@ -1,8 +1,6 @@
 import React, {useState} from "react";
 import {Types} from "aptos";
-import {Box, Typography} from "@mui/material";
-import {renderDebug} from "../../utils";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
+import {Box} from "@mui/material";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
@@ -12,7 +10,6 @@ type PayloadTabProps = {
 };
 
 export default function PayloadTab({transaction}: PayloadTabProps) {
-  const inGtm = useGetInGtmMode();
   const [expanded, setExpanded] = useState<boolean>(true);
 
   if (!("payload" in transaction)) {
@@ -23,7 +20,7 @@ export default function PayloadTab({transaction}: PayloadTabProps) {
     setExpanded(!expanded);
   };
 
-  return inGtm ? (
+  return (
     <Box marginTop={3}>
       <CollapsibleCard
         key={0}
@@ -34,14 +31,6 @@ export default function PayloadTab({transaction}: PayloadTabProps) {
       >
         <JsonCard data={transaction.payload} />
       </CollapsibleCard>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Typography
-        variant="body1"
-        marginBottom={3}
-      >{`TYPE: ${transaction.payload.type}`}</Typography>
-      {renderDebug(transaction.payload)}
     </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -1,12 +1,9 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import Row from "./Components/Row";
+import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
-import {getFormattedTimestamp, renderDebug} from "../../utils";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
 import {getLearnMoreTooltip} from "../helpers";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
@@ -20,10 +17,9 @@ type PendingTransactionOverviewTabProps = {
 export default function PendingTransactionOverviewTab({
   transaction,
 }: PendingTransactionOverviewTabProps) {
-  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_PendingTransaction;
 
-  return inGtm ? (
+  return (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow
@@ -63,39 +59,6 @@ export default function PendingTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("signature")}
         />
       </ContentBox>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack direction="column" spacing={3}>
-        <Row
-          title={"Sender:"}
-          value={
-            <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
-          }
-        />
-        <Row
-          title={"Sequence Number:"}
-          value={transactionData.sequence_number}
-        />
-        <Row
-          title={"Expiration Timestamp:"}
-          value={getFormattedTimestamp(
-            transactionData.expiration_timestamp_secs,
-          )}
-        />
-        <Row
-          title={"Max Gas Limit:"}
-          value={<GasValue gas={transactionData.max_gas_amount} />}
-        />
-        <Row
-          title={"Gas Unit Price:"}
-          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
-        />
-        <Row
-          title={"Signature:"}
-          value={renderDebug(transactionData.signature)}
-        />
-      </Stack>
     </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -1,18 +1,11 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import Row from "./Components/Row";
+import {Box} from "@mui/material";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
-import {
-  OldTransactionStatus,
-  TransactionStatus,
-} from "../../../components/TransactionStatus";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
+import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
-import {getFormattedTimestamp} from "../../utils";
 
 type StateCheckpointOverviewTabProps = {
   transaction: Types.Transaction;
@@ -21,11 +14,10 @@ type StateCheckpointOverviewTabProps = {
 export default function StateCheckpointOverviewTab({
   transaction,
 }: StateCheckpointOverviewTabProps) {
-  const inGtm = useGetInGtmMode();
   const transactionData =
     transaction as Types.Transaction_StateCheckpointTransaction;
 
-  return inGtm ? (
+  return (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow
@@ -68,39 +60,6 @@ export default function StateCheckpointOverviewTab({
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack direction="column" spacing={3}>
-        <Row title={"Version:"} value={transactionData.version} />
-        <Row
-          title={"Status:"}
-          value={<OldTransactionStatus success={transactionData.success} />}
-        />
-        <Row
-          title={"State Change Hash:"}
-          value={transactionData.state_change_hash}
-        />
-        <Row
-          title={"Event Root Hash:"}
-          value={transactionData.event_root_hash}
-        />
-        <Row
-          title={"Gas Used:"}
-          value={<GasValue gas={transactionData.gas_used} />}
-        />
-        <Row title={"VM Status:"} value={transactionData.vm_status} />
-        <Row
-          title={"Accumulator Root Hash:"}
-          value={transactionData.accumulator_root_hash}
-        />
-        {"timestamp" in transactionData && (
-          <Row
-            title={"Timestamp:"}
-            value={getFormattedTimestamp(transactionData.timestamp)}
-          />
-        )}
-      </Stack>
     </Box>
   );
 }

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -1,16 +1,10 @@
 import * as React from "react";
 import {Types} from "aptos";
-import {Stack, Box} from "@mui/material";
-import {getFormattedTimestamp, renderDebug} from "../../utils";
-import Row from "./Components/Row";
+import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
-import {
-  OldTransactionStatus,
-  TransactionStatus,
-} from "../../../components/TransactionStatus";
-import {useGetInGtmMode} from "../../../api/hooks/useGetInDevMode";
+import {TransactionStatus} from "../../../components/TransactionStatus";
 import JsonCard from "../../../components/IndividualPageContent/JsonCard";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
@@ -77,10 +71,9 @@ type UserTransactionOverviewTabProps = {
 export default function UserTransactionOverviewTab({
   transaction,
 }: UserTransactionOverviewTabProps) {
-  const inGtm = useGetInGtmMode();
   const transactionData = transaction as Types.Transaction_UserTransaction;
 
-  return inGtm ? (
+  return (
     <Box marginBottom={3}>
       <ContentBox padding={4}>
         <ContentRow
@@ -169,74 +162,6 @@ export default function UserTransactionOverviewTab({
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>
-    </Box>
-  ) : (
-    <Box marginX={2} marginTop={5}>
-      <Stack direction="column" spacing={3}>
-        <Row
-          title={"Sender:"}
-          value={
-            <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
-          }
-        />
-        <Row
-          title={"Sequence Number:"}
-          value={transactionData.sequence_number}
-        />
-        <Row
-          title={"Expiration Timestamp:"}
-          value={getFormattedTimestamp(
-            transactionData.expiration_timestamp_secs,
-          )}
-        />
-        <Row title={"Version:"} value={transactionData.version} />
-        <Row
-          title={"Status:"}
-          value={<OldTransactionStatus success={transactionData.success} />}
-        />
-        <Row
-          title={"State Change Hash:"}
-          value={transactionData.state_change_hash}
-        />
-        <Row
-          title={"Event Root Hash:"}
-          value={transactionData.event_root_hash}
-        />
-        <Row
-          title={"Gas Used:"}
-          value={<GasValue gas={transactionData.gas_used} />}
-        />
-        <Row
-          title={"Max Gas Limit:"}
-          value={<GasValue gas={transactionData.max_gas_amount} />}
-        />
-        <Row
-          title={"Gas Unit Price:"}
-          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
-        />
-        <Row
-          title={"Gas Fee:"}
-          value={
-            <APTCurrencyValue
-              amount={(
-                BigInt(transactionData.gas_unit_price) *
-                BigInt(transactionData.gas_used)
-              ).toString()}
-            />
-          }
-        />
-
-        <Row title={"VM Status:"} value={transactionData.vm_status} />
-        <Row
-          title={"Signature:"}
-          value={renderDebug(transactionData.signature)}
-        />
-        <Row
-          title={"Accumulator Root Hash:"}
-          value={transactionData.accumulator_root_hash}
-        />
-        <Row title={"Timestamp:"} value={transactionData.timestamp} />
-      </Stack>
     </Box>
   );
 }

--- a/src/pages/Transaction/Title.tsx
+++ b/src/pages/Transaction/Title.tsx
@@ -1,4 +1,4 @@
-import {Stack, Typography, useTheme, useMediaQuery} from "@mui/material";
+import {Stack, Typography} from "@mui/material";
 import React from "react";
 import {Types} from "aptos";
 import HashButtonCopyable from "../../components/HashButtonCopyable";
@@ -9,34 +9,11 @@ type TransactionTitleProps = {
 };
 
 export default function TransactionTitle({transaction}: TransactionTitleProps) {
-  const theme = useTheme();
-  const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
-
   return (
-    <Stack
-      direction={{xs: "column"}}
-      alignItems="flex-start"
-      spacing={2}
-      marginX={1}
-      marginBottom={2}
-    >
-      {isOnMobile ? (
-        <>
-          <Stack direction="column" spacing={2}>
-            <Typography variant="h3">Transaction</Typography>
-            <HashButtonCopyable hash={transaction.hash} />
-          </Stack>
-          <TransactionType type={transaction.type} />
-        </>
-      ) : (
-        <>
-          <Typography variant="h3">Transaction</Typography>
-          <Stack direction="column" alignItems="start" spacing={1}>
-            <HashButtonCopyable hash={transaction.hash} />
-            <TransactionType type={transaction.type} />
-          </Stack>
-        </>
-      )}
+    <Stack direction="column" spacing={2} marginX={1}>
+      <Typography variant="h3">Transaction</Typography>
+      <HashButtonCopyable hash={transaction.hash} />
+      <TransactionType type={transaction.type} />
     </Stack>
   );
 }

--- a/src/pages/Transaction/Title.tsx
+++ b/src/pages/Transaction/Title.tsx
@@ -3,18 +3,16 @@ import React from "react";
 import {Types} from "aptos";
 import HashButtonCopyable from "../../components/HashButtonCopyable";
 import {TransactionType} from "../../components/TransactionType";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 
 type TransactionTitleProps = {
   transaction: Types.Transaction;
 };
 
 export default function TransactionTitle({transaction}: TransactionTitleProps) {
-  const inGtm = useGetInGtmMode();
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
 
-  return inGtm ? (
+  return (
     <Stack
       direction={{xs: "column"}}
       alignItems="flex-start"
@@ -39,19 +37,6 @@ export default function TransactionTitle({transaction}: TransactionTitleProps) {
           </Stack>
         </>
       )}
-    </Stack>
-  ) : (
-    <Stack
-      direction={{xs: "column", md: "row"}}
-      alignItems={{xs: "flex-start", md: "center"}}
-      spacing={2}
-      marginX={1}
-    >
-      <Stack direction="row" alignItems="center" spacing={2}>
-        <Typography variant="h5">Transaction:</Typography>
-        <HashButtonCopyable hash={transaction.hash} />
-      </Stack>
-      <TransactionType type={transaction.type} />
     </Stack>
   );
 }

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -15,12 +15,10 @@ import HashButton, {HashType} from "../../components/HashButton";
 
 import {Types} from "aptos";
 import {assertNever} from "../../utils";
-import GasValue from "../../components/IndividualPageContent/ContentValue/GasValue";
 import {TableTransactionType} from "../../components/TransactionType";
 import {TableTransactionStatus} from "../../components/TransactionStatus";
 import {getFormattedTimestamp} from "../utils";
 import GasFeeValue from "../../components/IndividualPageContent/ContentValue/GasFeeValue";
-import {useGetInGtmMode} from "../../api/hooks/useGetInDevMode";
 import {useGetTransaction} from "../../api/hooks/useGetTransaction";
 
 type TransactionCellProps = {
@@ -81,9 +79,7 @@ function TransactionVersionCell({transaction}: TransactionCellProps) {
 }
 
 function TransactionGasCell({transaction}: TransactionCellProps) {
-  const inGtm = useGetInGtmMode();
-
-  return inGtm ? (
+  return (
     <TableCell sx={{textAlign: "right"}}>
       {"gas_used" in transaction && "gas_unit_price" in transaction ? (
         <GasFeeValue
@@ -91,10 +87,6 @@ function TransactionGasCell({transaction}: TransactionCellProps) {
           gasUnitPrice={transaction.gas_unit_price}
         />
       ) : null}
-    </TableCell>
-  ) : (
-    <TableCell sx={{textAlign: "right"}}>
-      {"gas_used" in transaction && <GasValue gas={transaction.gas_used} />}
     </TableCell>
   );
 }

--- a/src/pages/layout/FeatureBar.tsx
+++ b/src/pages/layout/FeatureBar.tsx
@@ -45,8 +45,8 @@ export default function FeatureBar() {
     if (feature_name) {
       maybeSetFeature(feature_name);
     } else {
-      // the "feature" param being null means that it's in mainnet production mode (gtm)
-      // so set feature to "gtm"
+      // the "feature" param being null means that it's in production mode
+      // so set feature to "prod"
       maybeSetFeature(defaultFeatureName);
     }
   });


### PR DESCRIPTION
This PR removes code for the old version Explorer. The new version Explorer has been launched under `feature=gtm` for a week. No notable regression. Therefore it's now safe to remove the deprecated code and make the new version `feature=prod`.