### PR TITLE
[Explorer] fix search bar

### DIFF
--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -11,11 +11,24 @@ import ResultLink from "./ResultLink";
 export default function HeaderSearch() {
   const navigate = useNavigate();
   const [inputValue, setInputValue] = useState<string>("");
+  const [searchValue, setSearchValue] = useState<string>("");
   const [open, setOpen] = useState(false);
   const [selectedOption, setSelectedOption] =
     useState<SearchResult>(NotFoundResult);
 
-  const options = useGetSearchResults(inputValue);
+  const options = useGetSearchResults(searchValue);
+
+  // inputValue is the value in the text field
+  // searchValue is the value that we search
+  // searchValue is updated 0.5s after the inputValue is changed
+  // this is to wait for users to stop typing then execute searching
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchValue(inputValue);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [inputValue]);
 
   useEffect(() => {
     if (options.length > 0) {


### PR DESCRIPTION
### The problem:
When user type in something in the search bar, for example "0x1", the search bar fetch data for "0", "0x", and "0x1". It's possible that the results of "0" get returned after the results of "0x1" get returned. And the search bar will show the latest results that got returned which is the results of "0". This is not what we want since the user meant to search for "0x1".

### The solution:
There could be potentially a couple of solutions. I decided to do the following based on the performance and complexity of the implementation: we wait for the users to stop typing before fetching the search results. This way "0" and "0x1" won't be searched at all therefore less network requests and better performance. 