### PR TITLE
[Explorer] update address format for indexer queries

### DIFF
--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -25,6 +25,9 @@ export default function AccountPage() {
   const address = useParams().address ?? "";
   const {data, error, isLoading} = useGetAccount(address);
 
+  // make sure that addresses will always start with "0X"
+  const addressHex = address.startsWith("0x") ? address : "0x" + address;
+
   return (
     <Grid container spacing={1}>
       <LoadingModal open={isLoading} />
@@ -32,17 +35,17 @@ export default function AccountPage() {
         <PageHeader />
       </Grid>
       <Grid item xs={12} md={8} lg={9} alignSelf="center">
-        <AccountTitle address={address} />
+        <AccountTitle address={addressHex} />
       </Grid>
       <Grid item xs={12} md={4} lg={3} marginTop={{md: 0, xs: 2}}>
-        <BalanceCard address={address} />
+        <BalanceCard address={addressHex} />
       </Grid>
       <Grid item xs={12} md={12} lg={12} marginTop={4}>
         {error ? (
-          <Error address={address} error={error} />
+          <Error address={addressHex} error={error} />
         ) : (
           <AccountTabs
-            address={address}
+            address={addressHex}
             accountData={data}
             tabValues={isGraphqlClientSupported ? TAB_VALUES_FULL : TAB_VALUES}
           />

--- a/src/pages/Account/Tabs/TokensTab.tsx
+++ b/src/pages/Account/Tabs/TokensTab.tsx
@@ -25,9 +25,13 @@ type TokenTabsProps = {
 };
 
 export default function TokenTabs({address}: TokenTabsProps) {
+  // whenever talking to the indexer, the address needs to fill in leading 0s
+  // for example: 0x123 => 0x000...000123  (61 0s before 123)
+  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+
   const {loading, error, data} = useQuery(TOKENS_QUERY, {
     variables: {
-      owner_address: address,
+      owner_address: addr64Hash,
     },
   });
 


### PR DESCRIPTION
When talking to the indexer, we should pass addresses as the format of `0x000...000123`. Before is `0x123` or `123`.