### PR TITLE
[Explorer] Account all transactions

### DIFF
--- a/src/api/hooks/useGetAccountAllTransactions.ts
+++ b/src/api/hooks/useGetAccountAllTransactions.ts
@@ -50,7 +50,7 @@ export function useGetAccountAllTransactionVersions(
   address: string,
   limit: number,
   offset?: number,
-): {loading: boolean; versions: number[]} {
+): number[] {
   // whenever talking to the indexer, the address needs to fill in leading 0s
   // for example: 0x123 => 0x000...000123  (61 0s before 123)
   const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
@@ -60,7 +60,7 @@ export function useGetAccountAllTransactionVersions(
   });
 
   if (loading || error || !data) {
-    return {loading: loading, versions: []};
+    return [];
   }
 
   const versions: number[] = data.move_resources.map(
@@ -69,5 +69,5 @@ export function useGetAccountAllTransactionVersions(
     },
   );
 
-  return {loading, versions};
+  return versions;
 }

--- a/src/api/hooks/useGetAccountAllTransactions.ts
+++ b/src/api/hooks/useGetAccountAllTransactions.ts
@@ -1,0 +1,73 @@
+import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+
+const ACCOUNT_TRANSACTIONS_COUNT_QUERY = gql`
+  query AccountTransactionsCount($address: String) {
+    move_resources_aggregate(
+      where: {address: {_eq: $address}}
+      distinct_on: transaction_version
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export function useGetAccountAllTransactionCount(
+  address: string,
+): number | undefined {
+  // whenever talking to the indexer, the address needs to fill in leading 0s
+  // for example: 0x123 => 0x000...000123  (61 0s before 123)
+  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+
+  const {loading, error, data} = useGraphqlQuery(
+    ACCOUNT_TRANSACTIONS_COUNT_QUERY,
+    {variables: {address: addr64Hash}},
+  );
+
+  if (loading || error || !data) {
+    return undefined;
+  }
+
+  return data.move_resources_aggregate?.aggregate?.count;
+}
+
+const ACCOUNT_TRANSACTIONS_QUERY = gql`
+  query AccountTransactionsData($address: String, $limit: Int, $offset: Int) {
+    move_resources(
+      where: {address: {_eq: $address}}
+      order_by: {transaction_version: desc}
+      distinct_on: transaction_version
+      limit: $limit
+      offset: $offset
+    ) {
+      transaction_version
+    }
+  }
+`;
+
+export function useGetAccountAllTransactionVersions(
+  address: string,
+  limit: number,
+  offset?: number,
+): {loading: boolean; versions: number[]} {
+  // whenever talking to the indexer, the address needs to fill in leading 0s
+  // for example: 0x123 => 0x000...000123  (61 0s before 123)
+  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+
+  const {loading, error, data} = useGraphqlQuery(ACCOUNT_TRANSACTIONS_QUERY, {
+    variables: {address: addr64Hash, limit: limit, offset: offset},
+  });
+
+  if (loading || error || !data) {
+    return {loading: loading, versions: []};
+  }
+
+  const versions: number[] = data.move_resources.map(
+    (resource: {transaction_version: number}) => {
+      return resource.transaction_version;
+    },
+  );
+
+  return {loading, versions};
+}

--- a/src/pages/Account/Components/AccountAllTransactions.tsx
+++ b/src/pages/Account/Components/AccountAllTransactions.tsx
@@ -1,0 +1,119 @@
+import React, {useEffect} from "react";
+import Box from "@mui/material/Box";
+import {useSearchParams} from "react-router-dom";
+import {Pagination, PaginationItem, Stack} from "@mui/material";
+import {UserTransactionsTable} from "../../Transactions/TransactionsTable";
+import {useGetAccountAllTransactionVersions} from "../../../api/hooks/useGetAccountAllTransactions";
+
+const LIMIT = 5;
+
+function RenderPagination({
+  currentPage,
+  numPages,
+  disableNext,
+}: {
+  currentPage: number;
+  numPages: number;
+  disableNext: boolean;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const goToPage = (newPageNum: number) => {
+    searchParams.set("page", newPageNum.toString());
+    setSearchParams(searchParams);
+
+    const numPages = parseInt(searchParams.get("numPages") ?? "1");
+    if (newPageNum > numPages) {
+      searchParams.set("numPages", newPageNum.toString());
+      setSearchParams(searchParams);
+    }
+  };
+
+  const handleChange = (
+    event: React.ChangeEvent<unknown>,
+    newPageNum: number,
+  ) => {
+    goToPage(newPageNum);
+  };
+
+  const handleNextPage = () => {
+    goToPage(currentPage + 1);
+  };
+
+  return (
+    <Stack direction="row" alignItems="end">
+      <Pagination
+        sx={{mt: 3}}
+        count={numPages}
+        variant="outlined"
+        shape="rounded"
+        hideNextButton
+        page={currentPage}
+        siblingCount={4}
+        boundaryCount={0}
+        onChange={handleChange}
+      />
+      <Box onClick={disableNext ? () => {} : handleNextPage}>
+        <PaginationItem
+          variant="outlined"
+          shape="rounded"
+          type="next"
+          disabled={disableNext}
+        />
+      </Box>
+    </Stack>
+  );
+}
+
+type AccountAllTransactionsProps = {
+  address: string;
+};
+
+export default function AccountAllTransactions({
+  address,
+}: AccountAllTransactionsProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = parseInt(searchParams.get("page") ?? "1");
+  const numPages = parseInt(searchParams.get("numPages") ?? "1");
+  const maxNumPages = parseInt(searchParams.get("maxNumPages") ?? "");
+  const offset = (currentPage - 1) * LIMIT;
+
+  const {loading, versions} = useGetAccountAllTransactionVersions(
+    address,
+    LIMIT,
+    offset,
+  );
+
+  useEffect(() => {
+    if (!loading && versions.length < LIMIT) {
+      if (versions.length === 0) {
+        searchParams.set("page", (currentPage - 1).toString());
+        searchParams.set("numPages", (currentPage - 1).toString());
+        searchParams.set("maxNumPages", (currentPage - 1).toString());
+        setSearchParams(searchParams);
+      } else {
+        searchParams.set("maxNumPages", currentPage.toString());
+        setSearchParams(searchParams);
+      }
+    }
+  }, [loading, versions.length]);
+
+  const disableNext = numPages === maxNumPages;
+
+  return (
+    <>
+      <Stack spacing={2}>
+        <Box sx={{width: "auto", overflowX: "auto"}}>
+          <UserTransactionsTable versions={versions} />
+        </Box>
+        <Box sx={{display: "flex", justifyContent: "center"}}>
+          <RenderPagination
+            currentPage={currentPage}
+            numPages={numPages}
+            disableNext={disableNext}
+          />
+        </Box>
+      </Stack>
+    </>
+  );
+}

--- a/src/pages/Account/Components/AccountTransactions.tsx
+++ b/src/pages/Account/Components/AccountTransactions.tsx
@@ -1,0 +1,121 @@
+import React, {useState} from "react";
+import {Pagination, Box} from "@mui/material";
+import TransactionsTable from "../../Transactions/TransactionsTable";
+import Error from "../Error";
+import {useGetAccountTransactions} from "../../../api/hooks/useGetAccountTransactions";
+import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {Types} from "aptos";
+
+const TXN_PER_PAGE = 25;
+
+function getPageStartSequenceNumbers(sequenceNum: number): number[] {
+  const pageStarts: number[] = [];
+
+  const numOfPages = Math.ceil(sequenceNum / TXN_PER_PAGE);
+  let num = sequenceNum;
+  for (let i = 0; i < numOfPages; i++) {
+    num = num - TXN_PER_PAGE;
+    num = num >= 0 ? num : 0;
+    pageStarts.push(num);
+  }
+
+  return pageStarts;
+}
+
+type TransactionsPaginationTableProps = {
+  address: string;
+  sequenceNum: number;
+};
+
+function TransactionsPaginationTable({
+  address,
+  sequenceNum,
+}: TransactionsPaginationTableProps) {
+  // TODO: make `start` a search param like the other transactions page
+  const [currentPageNum, setCurrentPageNum] = useState<number>(1);
+
+  const numOfPages = Math.ceil(sequenceNum / TXN_PER_PAGE);
+  const pageStarts = getPageStartSequenceNumbers(sequenceNum);
+
+  const start = pageStarts[currentPageNum - 1];
+  const limit =
+    currentPageNum > 1 && currentPageNum === numOfPages
+      ? pageStarts[currentPageNum - 2]
+      : TXN_PER_PAGE;
+
+  const {isLoading, data, error} = useGetAccountTransactions(
+    address,
+    start,
+    limit,
+  );
+
+  if (error) {
+    return <Error address={address} error={error} />;
+  }
+
+  const handleChange = (
+    event: React.ChangeEvent<unknown>,
+    newPageNum: number,
+  ) => {
+    setCurrentPageNum(newPageNum);
+  };
+
+  // TODO: add loading spinner
+  return (
+    <>
+      {(!data || data.length === 0) && !isLoading ? (
+        <EmptyTabContent />
+      ) : (
+        <TransactionsTable
+          transactions={data ?? []}
+          columns={[
+            "sequenceNum",
+            "version",
+            "status",
+            "type",
+            "hash",
+            "gas",
+            "timestamp",
+          ]}
+        />
+      )}
+      {numOfPages > 1 && (
+        <Box sx={{display: "flex", justifyContent: "center"}}>
+          <Pagination
+            sx={{mt: 3}}
+            count={numOfPages}
+            variant="outlined"
+            showFirstButton
+            showLastButton
+            page={currentPageNum}
+            siblingCount={4}
+            boundaryCount={0}
+            shape="rounded"
+            onChange={handleChange}
+          />
+        </Box>
+      )}
+    </>
+  );
+}
+
+type AccountTransactionsProps = {
+  address: string;
+  accountData: Types.AccountData | undefined;
+};
+
+export default function AccountTransactions({
+  address,
+  accountData,
+}: AccountTransactionsProps) {
+  if (!accountData) {
+    return <EmptyTabContent />;
+  }
+
+  return (
+    <TransactionsPaginationTable
+      address={address}
+      sequenceNum={parseInt(accountData.sequence_number)}
+    />
+  );
+}

--- a/src/pages/Account/Tabs/TransactionsTab.tsx
+++ b/src/pages/Account/Tabs/TransactionsTab.tsx
@@ -1,103 +1,8 @@
-import React, {useState} from "react";
-import {Pagination, Box} from "@mui/material";
-import TransactionsTable from "../../Transactions/TransactionsTable";
-import Error from "../Error";
-import {useGetAccountTransactions} from "../../../api/hooks/useGetAccountTransactions";
-import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import React from "react";
 import {Types} from "aptos";
-
-const TXN_PER_PAGE = 25;
-
-function getPageStartSequenceNumbers(sequenceNum: number): number[] {
-  const pageStarts: number[] = [];
-
-  const numOfPages = Math.ceil(sequenceNum / TXN_PER_PAGE);
-  let num = sequenceNum;
-  for (let i = 0; i < numOfPages; i++) {
-    num = num - TXN_PER_PAGE;
-    num = num >= 0 ? num : 0;
-    pageStarts.push(num);
-  }
-
-  return pageStarts;
-}
-
-type TransactionsPaginationTableProps = {
-  address: string;
-  sequenceNum: number;
-};
-
-function TransactionsPaginationTable({
-  address,
-  sequenceNum,
-}: TransactionsPaginationTableProps) {
-  // TODO: make `start` a search param like the other transactions page
-  const [currentPageNum, setCurrentPageNum] = useState<number>(1);
-
-  const numOfPages = Math.ceil(sequenceNum / TXN_PER_PAGE);
-  const pageStarts = getPageStartSequenceNumbers(sequenceNum);
-
-  const start = pageStarts[currentPageNum - 1];
-  const limit =
-    currentPageNum > 1 && currentPageNum === numOfPages
-      ? pageStarts[currentPageNum - 2]
-      : TXN_PER_PAGE;
-
-  const {isLoading, data, error} = useGetAccountTransactions(
-    address,
-    start,
-    limit,
-  );
-
-  if (error) {
-    return <Error address={address} error={error} />;
-  }
-
-  const handleChange = (
-    event: React.ChangeEvent<unknown>,
-    newPageNum: number,
-  ) => {
-    setCurrentPageNum(newPageNum);
-  };
-
-  // TODO: add loading spinner
-  return (
-    <>
-      {(!data || data.length === 0) && !isLoading ? (
-        <EmptyTabContent />
-      ) : (
-        <TransactionsTable
-          transactions={data ?? []}
-          columns={[
-            "sequenceNum",
-            "version",
-            "status",
-            "type",
-            "hash",
-            "gas",
-            "timestamp",
-          ]}
-        />
-      )}
-      {numOfPages > 1 && (
-        <Box sx={{display: "flex", justifyContent: "center"}}>
-          <Pagination
-            sx={{mt: 3}}
-            count={numOfPages}
-            variant="outlined"
-            showFirstButton
-            showLastButton
-            page={currentPageNum}
-            siblingCount={4}
-            boundaryCount={0}
-            shape="rounded"
-            onChange={handleChange}
-          />
-        </Box>
-      )}
-    </>
-  );
-}
+import AccountTransactions from "../Components/AccountTransactions";
+import {useGetIsGraphqlClientSupported} from "../../../api/hooks/useGraphqlClient";
+import AccountAllTransactions from "../Components/AccountAllTransactions";
 
 type TransactionsTabProps = {
   address: string;
@@ -108,14 +13,13 @@ export default function TransactionsTab({
   address,
   accountData,
 }: TransactionsTabProps) {
-  if (!accountData) {
-    return <EmptyTabContent />;
-  }
+  const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
 
-  return (
-    <TransactionsPaginationTable
-      address={address}
-      sequenceNum={parseInt(accountData.sequence_number)}
-    />
+  // AccountTransactions: render transactions where the account is the sender
+  // AccountAllTransactions: render all transactions where the account is involved
+  return isGraphqlClientSupported ? (
+    <AccountAllTransactions address={address} />
+  ) : (
+    <AccountTransactions address={address} accountData={accountData} />
   );
 }

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -149,9 +149,9 @@ type UserTransactionRowProps = {
 
 function UserTransactionRow({version, columns}: UserTransactionRowProps) {
   const navigate = useNavigate();
-  const {data: transaction} = useGetTransaction(version.toString());
+  const {data: transaction, isError} = useGetTransaction(version.toString());
 
-  if (!transaction) {
+  if (!transaction || isError) {
     return null;
   }
 


### PR DESCRIPTION
Previously, in the account page, we show the transactions where this account is the sender. Users won't be able to see the transactions where they receive coins from other accounts. This PR updates the account transactions table so that ALL transactions that this account is involved in will be shown. 

Next step: add columns like "Sender" and "Receiver"
<img width="1324" alt="Screen Shot 2022-10-21 at 3 31 05 PM" src="https://user-images.githubusercontent.com/109111707/197298161-90d6e86f-8d0f-49d2-a7f4-7e7904bd71c8.png">
