### PR TITLE
[Explorer] fix balance change

### DIFF
--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -1,7 +1,7 @@
 import {Types} from "aptos";
 import React from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
-import {getCoinBalanceChange} from "../utils";
+import {getCoinBalanceChanges} from "../utils";
 import {CoinBalanceChangeTable} from "./Components/CoinBalanceChangeTable";
 
 type BalanceChangeTabProps = {
@@ -9,7 +9,7 @@ type BalanceChangeTabProps = {
 };
 
 export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
-  const balanceChanges = getCoinBalanceChange(transaction);
+  const balanceChanges = getCoinBalanceChanges(transaction);
 
   if (balanceChanges.length === 0) {
     return <EmptyTabContent />;

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -23,8 +23,6 @@ export default function EventsTab({transaction}: EventsTabProps) {
     return <EmptyTabContent />;
   }
 
-  // console.log(events);
-
   return (
     <CollapsibleCards
       expandedList={expandedList}

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -23,6 +23,8 @@ export default function EventsTab({transaction}: EventsTabProps) {
     return <EmptyTabContent />;
   }
 
+  // console.log(events);
+
   return (
     <CollapsibleCards
       expandedList={expandedList}


### PR DESCRIPTION
This PR fixes the balance change bug reported in:
![image](https://user-images.githubusercontent.com/109111707/199362404-670f4988-d67a-4ef4-9120-a0e22a639290.png)
https://explorer.aptoslabs.com/txn/0x55db875837a67c9568d2481c0e4f9ff4c37b757a8ff2586b341622f2e933defb

The problem is that, in previous implementation, we check all coin Deposit and Withdraw events. But not all coin deposit/withdraw events are APT coins. In this PR, I added an APT check to filter out coin events that are not APT coins. 


| Before |<img width="1517" alt="Screen Shot 2022-11-01 at 4 46 33 PM" src="https://user-images.githubusercontent.com/109111707/199362838-39acfeaf-5555-4eb6-a916-8fd1ee5ef712.png">| After |<img width="1466" alt="Screen Shot 2022-11-01 at 4 46 42 PM" src="https://user-images.githubusercontent.com/109111707/199362836-5439af9e-7af6-4e29-a894-f390cc332814.png">|

