### PR TITLE
[Explorer] new validators table

### DIFF
--- a/src/api/hooks/useGetValidatorSet.ts
+++ b/src/api/hooks/useGetValidatorSet.ts
@@ -2,6 +2,9 @@ import {useGlobalState} from "../../GlobalState";
 import {useEffect, useState} from "react";
 import {useGetAccountResource} from "./useGetAccountResource";
 
+const MAINNET_VALIDATORS_DATA_URL =
+  "https://aptos-analytics-data-mainnet.s3.amazonaws.com/liveness.json";
+
 interface ValidatorSetData {
   active_validators: Validator[];
   total_voting_power: string;
@@ -41,4 +44,80 @@ export function useGetValidatorSet() {
   }, [validatorSet?.data, state]);
 
   return {totalVotingPower, numberOfActiveValidators, activeValidators};
+}
+
+export interface MainnetValidatorStatus {
+  governance_voting_record: string;
+  last_epoch: number;
+  last_epoch_performance: string;
+  liveness: number;
+  owner_address: string;
+  rewards_growth: number;
+}
+
+function useGetMainnetValidatorStatusSet() {
+  const [state, _] = useGlobalState();
+  const [validatorStatusSet, setValidatorStatusSet] = useState<
+    MainnetValidatorStatus[]
+  >([]);
+
+  useEffect(() => {
+    if (state.network_name === "mainnet") {
+      const fetchData = async () => {
+        const response = await fetch(MAINNET_VALIDATORS_DATA_URL);
+        const data = await response.json();
+        setValidatorStatusSet(data);
+      };
+
+      fetchData();
+    } else {
+      setValidatorStatusSet([]);
+    }
+  }, [state]);
+
+  return {validatorStatusSet};
+}
+
+export interface MainnetValidator {
+  address: string;
+  voting_power: string;
+  governance_voting_record: string | undefined;
+  last_epoch: number | undefined;
+  last_epoch_performance: string | undefined;
+  liveness: number | undefined;
+  rewards_growth: number | undefined;
+}
+
+export function useGetMainnetValidators() {
+  const {activeValidators} = useGetValidatorSet();
+  const {validatorStatusSet} = useGetMainnetValidatorStatusSet();
+  const [validators, setValidators] = useState<MainnetValidator[]>([]);
+
+  useEffect(() => {
+    if (
+      validatorStatusSet.length === activeValidators.length &&
+      validatorStatusSet.length > 0
+    ) {
+      const validators = activeValidators.map(
+        (activeValidator: Validator): MainnetValidator => {
+          const validatorStatus = validatorStatusSet.find(
+            (validatorStatus) =>
+              validatorStatus.owner_address === activeValidator.addr,
+          );
+          return {
+            address: activeValidator.addr,
+            voting_power: activeValidator.voting_power,
+            governance_voting_record: validatorStatus?.governance_voting_record,
+            last_epoch: validatorStatus?.last_epoch,
+            last_epoch_performance: validatorStatus?.last_epoch_performance,
+            liveness: validatorStatus?.liveness,
+            rewards_growth: validatorStatus?.rewards_growth,
+          };
+        },
+      );
+      setValidators(validators);
+    }
+  }, [activeValidators, validatorStatusSet]);
+
+  return {validators};
 }

--- a/src/components/Table/GeneralTableHeaderCell.tsx
+++ b/src/components/Table/GeneralTableHeaderCell.tsx
@@ -1,13 +1,24 @@
 import React from "react";
-import {Typography, TableCell, useTheme, Stack} from "@mui/material";
+import {
+  Typography,
+  TableCell,
+  useTheme,
+  Stack,
+  TableSortLabel,
+} from "@mui/material";
 import {SxProps} from "@mui/system";
 import {Theme} from "@mui/material/styles";
+import SouthIcon from "@mui/icons-material/South";
+import {primary} from "../../themes/colors/aptosColorPalette";
 
 interface GeneralTableHeaderCellProps {
   header: React.ReactNode;
   textAlignRight?: boolean;
   sx?: SxProps<Theme>;
   tooltip?: React.ReactNode;
+  sortable?: boolean;
+  direction?: "desc" | "asc";
+  selectAndSetDirection?: (dir: "desc" | "asc") => void;
 }
 
 export default function GeneralTableHeaderCell({
@@ -15,17 +26,67 @@ export default function GeneralTableHeaderCell({
   textAlignRight,
   sx = [],
   tooltip,
+  sortable,
+  direction,
+  selectAndSetDirection,
 }: GeneralTableHeaderCellProps) {
   const theme = useTheme();
   const tableCellBackgroundColor = "transparent";
   const tableCellTextColor = theme.palette.text.secondary;
 
+  const toggleDirection = () => {
+    if (selectAndSetDirection === undefined) {
+      return;
+    }
+    selectAndSetDirection(direction === "desc" ? "asc" : "desc");
+  };
+
+  const headerTextComponent = (
+    <Typography variant="subtitle1" sx={{fontSize: 15, lineHeight: "inherit"}}>
+      {header}
+    </Typography>
+  );
+
+  const headerSortLabel = sortable ? (
+    <TableSortLabel
+      active={direction !== undefined}
+      direction={direction === undefined ? "desc" : direction}
+      onClick={toggleDirection}
+      IconComponent={SouthIcon}
+      sx={{
+        "&.MuiTableSortLabel-root .MuiTableSortLabel-icon": {
+          marginLeft: 1,
+          marginRight: 0,
+          color: primary[600],
+        },
+      }}
+    >
+      {headerTextComponent}
+    </TableSortLabel>
+  ) : (
+    headerTextComponent
+  );
+
+  const headerContent = tooltip ? (
+    <Stack
+      direction="row"
+      spacing={0.2}
+      justifyContent={textAlignRight ? "flex-end" : "flex-start"}
+      alignItems="center"
+    >
+      {tooltip}
+      {headerSortLabel}
+    </Stack>
+  ) : (
+    headerSortLabel
+  );
+
   return (
     <TableCell
       sx={[
         {
-          paddingLeft: 1.5,
-          paddingRight: tooltip ? 0.5 : 1.5,
+          paddingLeft: tooltip ? 0.5 : 1.5,
+          paddingRight: 1.5,
           textAlign: textAlignRight ? "right" : "left",
           background: `${tableCellBackgroundColor}`,
           color: `${tableCellTextColor}`,
@@ -33,23 +94,7 @@ export default function GeneralTableHeaderCell({
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
     >
-      {tooltip ? (
-        <Stack
-          direction="row"
-          spacing={0.2}
-          justifyContent={textAlignRight ? "flex-end" : "flex-start"}
-          alignItems="center"
-        >
-          <Typography variant="subtitle1" sx={{fontSize: 15}}>
-            {header}
-          </Typography>
-          {tooltip}
-        </Stack>
-      ) : (
-        <Typography variant="subtitle1" sx={{fontSize: 15}}>
-          {header}
-        </Typography>
-      )}
+      {headerContent}
     </TableCell>
   );
 }

--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -76,7 +76,7 @@ export function TransactionType({type}: TransactionTypeProps) {
 
 export function TableTransactionType({type}: TransactionTypeProps) {
   return (
-    <Box sx={{display: "flex", alignItems: "center", marginLeft: 1.5}}>
+    <Box sx={{display: "flex", alignItems: "center", marginLeft: 2}}>
       {getTypeIcon(type, "inherit")}
     </Box>
   );

--- a/src/pages/Validators/Index.tsx
+++ b/src/pages/Validators/Index.tsx
@@ -1,18 +1,26 @@
 import {Box, Typography} from "@mui/material";
 import * as React from "react";
-import {useGetValidatorSet} from "../../api/hooks/useGetValidatorSet";
+import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+import {useGlobalState} from "../../GlobalState";
 import PageHeader from "../layout/PageHeader";
-import {ValidatorsTable} from "./Table";
+import {ValidatorsTable as OldValidatorsTable} from "./Table";
+import {ValidatorsTable} from "./ValidatorsTable";
 
 export default function ValidatorsPage() {
-  const {activeValidators} = useGetValidatorSet();
+  const inDevMode = useGetInDevMode();
+  const [state, _] = useGlobalState();
+
   return (
     <Box>
       <PageHeader />
       <Typography variant="h3" marginBottom={2}>
         Validators
       </Typography>
-      <ValidatorsTable validators={activeValidators} />
+      {inDevMode && state.network_name === "mainnet" ? (
+        <ValidatorsTable />
+      ) : (
+        <OldValidatorsTable />
+      )}
     </Box>
   );
 }

--- a/src/pages/Validators/Table.tsx
+++ b/src/pages/Validators/Table.tsx
@@ -3,7 +3,10 @@ import {Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../utils";
-import {Validator} from "../../api/hooks/useGetValidatorSet";
+import {
+  useGetValidatorSet,
+  Validator,
+} from "../../api/hooks/useGetValidatorSet";
 import HashButton, {HashType} from "../../components/HashButton";
 import {getFormattedBalanceStr} from "../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import GeneralTableBody from "../../components/Table/GeneralTableBody";
@@ -137,15 +140,17 @@ function ValidatorHeaderCell({column}: ValidatorHeaderCellProps) {
 }
 
 type ValidatorsTableProps = {
-  validators: Validator[];
   columns?: Column[];
 };
 
 export function ValidatorsTable({
-  validators,
   columns = DEFAULT_COLUMNS,
 }: ValidatorsTableProps) {
-  const validatorsCopy: Validator[] = JSON.parse(JSON.stringify(validators));
+  const {activeValidators} = useGetValidatorSet();
+
+  const validatorsCopy: Validator[] = JSON.parse(
+    JSON.stringify(activeValidators),
+  );
   const validatorsInOrder = validatorsCopy.sort(
     (validator1, validator2) =>
       parseInt(validator2.voting_power) - parseInt(validator1.voting_power),

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -1,0 +1,300 @@
+import React, {useState} from "react";
+import {Table, TableHead, TableRow} from "@mui/material";
+import GeneralTableRow from "../../components/Table/GeneralTableRow";
+import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
+import {assertNever} from "../../utils";
+import {
+  MainnetValidator,
+  useGetMainnetValidators,
+} from "../../api/hooks/useGetValidatorSet";
+import HashButton, {HashType} from "../../components/HashButton";
+import {getFormattedBalanceStr} from "../../components/IndividualPageContent/ContentValue/CurrencyValue";
+import GeneralTableBody from "../../components/Table/GeneralTableBody";
+import GeneralTableCell from "../../components/Table/GeneralTableCell";
+
+function getSortedValidators(
+  validators: MainnetValidator[],
+  column: Column,
+  direction: "desc" | "asc",
+) {
+  const validatorsCopy: MainnetValidator[] = JSON.parse(
+    JSON.stringify(validators),
+  );
+  const orderedValidators = getValidatorsOrderedBy(validatorsCopy, column);
+
+  return direction === "desc" ? orderedValidators : orderedValidators.reverse();
+}
+
+function getValidatorsOrderedBy(
+  validatorsCopy: MainnetValidator[],
+  column: Column,
+) {
+  switch (column) {
+    case "votingPower":
+      return validatorsCopy.sort(
+        (validator1, validator2) =>
+          parseInt(validator2.voting_power) - parseInt(validator1.voting_power),
+      );
+    case "liveness":
+      return validatorsCopy.sort(
+        (validator1, validator2) =>
+          (validator2.liveness ?? 0) - (validator1.liveness ?? 0),
+      );
+    case "rewardsPerf":
+      return validatorsCopy.sort(
+        (validator1, validator2) =>
+          (validator2.rewards_growth ?? 0) - (validator1.rewards_growth ?? 0),
+      );
+    case "lastEpochPerf":
+      return validatorsCopy.sort(
+        (validator1, validator2) =>
+          parseInt(validator2.last_epoch_performance ?? "") -
+          parseInt(validator1.last_epoch_performance ?? ""),
+      );
+    case "governanceVotes":
+      return validatorsCopy.sort(
+        (validator1, validator2) =>
+          parseInt(validator2.governance_voting_record ?? "") -
+          parseInt(validator1.governance_voting_record ?? ""),
+      );
+    default:
+      return validatorsCopy;
+  }
+}
+
+type SortableHeaderCellProps = {
+  header: string;
+  column: Column;
+  direction?: "desc" | "asc";
+  setDirection?: (dir: "desc" | "asc") => void;
+  setSortColumn: (col: Column) => void;
+};
+
+function SortableHeaderCell({
+  header,
+  column,
+  direction,
+  setDirection,
+  setSortColumn,
+}: SortableHeaderCellProps) {
+  return (
+    <GeneralTableHeaderCell
+      header={header}
+      textAlignRight
+      sortable
+      direction={direction}
+      selectAndSetDirection={(dir) => {
+        setSortColumn(column);
+        if (setDirection) {
+          setDirection(dir);
+        }
+      }}
+    />
+  );
+}
+
+type ValidatorHeaderCellProps = {
+  column: Column;
+  direction?: "desc" | "asc";
+  setDirection?: (dir: "desc" | "asc") => void;
+  setSortColumn: (col: Column) => void;
+};
+
+function ValidatorHeaderCell({
+  column,
+  direction,
+  setDirection,
+  setSortColumn,
+}: ValidatorHeaderCellProps) {
+  switch (column) {
+    case "addr":
+      return <GeneralTableHeaderCell header="Staking Pool Address" />;
+    case "votingPower":
+      return (
+        <SortableHeaderCell
+          header="Voting Power"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
+        />
+      );
+    case "liveness":
+      return (
+        <SortableHeaderCell
+          header="Liveness"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
+        />
+      );
+    case "rewardsPerf":
+      return (
+        <SortableHeaderCell
+          header="Rewards Perf"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
+        />
+      );
+    case "lastEpochPerf":
+      return (
+        <SortableHeaderCell
+          header="Last Epoch Perf"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
+        />
+      );
+    case "governanceVotes":
+      return (
+        <SortableHeaderCell
+          header="Governance Votes"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
+        />
+      );
+    default:
+      return assertNever(column);
+  }
+}
+
+type ValidatorCellProps = {
+  validator: MainnetValidator;
+};
+
+function ValidatorAddrCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "left"}}>
+      <HashButton hash={validator.address} type={HashType.ACCOUNT} />
+    </GeneralTableCell>
+  );
+}
+
+function VotingPowerCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+      {getFormattedBalanceStr(validator.voting_power.toString(), undefined, 0)}
+    </GeneralTableCell>
+  );
+}
+
+function LivenessCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+      {validator.liveness === undefined
+        ? null
+        : `${validator.liveness.toFixed(2)} %`}
+    </GeneralTableCell>
+  );
+}
+
+function RewardsPerformanceCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+      {validator.rewards_growth === undefined
+        ? null
+        : `${validator.rewards_growth.toFixed(2)} %`}
+    </GeneralTableCell>
+  );
+}
+
+function LastEpochPerformanceCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+      {validator.last_epoch_performance}
+    </GeneralTableCell>
+  );
+}
+
+function GovernanceVotesCell({validator}: ValidatorCellProps) {
+  return (
+    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+      {validator.governance_voting_record}
+    </GeneralTableCell>
+  );
+}
+
+const ValidatorCells = Object.freeze({
+  addr: ValidatorAddrCell,
+  votingPower: VotingPowerCell,
+  liveness: LivenessCell,
+  rewardsPerf: RewardsPerformanceCell,
+  lastEpochPerf: LastEpochPerformanceCell,
+  governanceVotes: GovernanceVotesCell,
+});
+
+type Column = keyof typeof ValidatorCells;
+
+const DEFAULT_COLUMNS: Column[] = [
+  "addr",
+  "votingPower",
+  "liveness",
+  "rewardsPerf",
+  "lastEpochPerf",
+  "governanceVotes",
+];
+
+type ValidatorRowProps = {
+  validator: MainnetValidator;
+  columns: Column[];
+};
+
+function ValidatorRow({validator, columns}: ValidatorRowProps) {
+  return (
+    <GeneralTableRow>
+      {columns.map((column) => {
+        const Cell = ValidatorCells[column];
+        return <Cell key={column} validator={validator} />;
+      })}
+    </GeneralTableRow>
+  );
+}
+
+type ValidatorsTableProps = {
+  columns?: Column[];
+};
+
+export function ValidatorsTable({
+  columns = DEFAULT_COLUMNS,
+}: ValidatorsTableProps) {
+  const {validators} = useGetMainnetValidators();
+  const [sortColumn, setSortColumn] = useState<Column>("votingPower");
+  const [sortDirection, setSortDirection] = useState<"desc" | "asc">("desc");
+
+  const sortedValidators = getSortedValidators(
+    validators,
+    sortColumn,
+    sortDirection,
+  );
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow sx={{verticalAlign: "bottom"}}>
+          {columns.map((column) => (
+            <ValidatorHeaderCell
+              key={column}
+              column={column}
+              direction={sortColumn === column ? sortDirection : undefined}
+              setDirection={setSortDirection}
+              setSortColumn={setSortColumn}
+            />
+          ))}
+        </TableRow>
+      </TableHead>
+      <GeneralTableBody>
+        {sortedValidators.map((validator: any, i: number) => {
+          return (
+            <ValidatorRow key={i} validator={validator} columns={columns} />
+          );
+        })}
+      </GeneralTableBody>
+    </Table>
+  );
+}


### PR DESCRIPTION
* new validators table for mainnet, including data from the leaderboard https://aptoslabs.com/leaderboard/mainnet?sort=-governance_voting_record
* make validators page sortable by columns
* this change is gated behind dev mode

Next step:
* add tooltips
* add status icons

https://user-images.githubusercontent.com/109111707/199644854-a0d1dec2-a768-4f87-85f6-8089820086f4.mov


