### PR TITLE
[Explorer] show "script" when the transaction is a script

### DIFF
--- a/src/components/TransactionStatus.tsx
+++ b/src/components/TransactionStatus.tsx
@@ -15,7 +15,7 @@ type TransactionStatusProps = {
 };
 
 export function TransactionStatus({success}: TransactionStatusProps) {
-  return !success ? (
+  return success ? (
     <Stack
       direction="row"
       spacing={1}

--- a/src/components/TransactionStatus.tsx
+++ b/src/components/TransactionStatus.tsx
@@ -15,16 +15,16 @@ type TransactionStatusProps = {
 };
 
 export function TransactionStatus({success}: TransactionStatusProps) {
-  return success ? (
+  return !success ? (
     <Stack
       direction="row"
       spacing={1}
-      padding={0.7}
+      paddingY={0.7}
       alignItems="center"
       justifyContent="center"
       sx={{
         backgroundColor: SUCCESS_BACKGROUND_COLOR,
-        width: 100,
+        width: 114,
       }}
       borderRadius={1}
     >
@@ -41,12 +41,12 @@ export function TransactionStatus({success}: TransactionStatusProps) {
     <Stack
       direction="row"
       spacing={1}
-      padding={0.7}
+      paddingY={0.7}
       alignItems="center"
       justifyContent="center"
       sx={{
         backgroundColor: ERROR_BACKGROUND_COLOR,
-        width: 80,
+        width: 90,
       }}
       borderRadius={1}
     >

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {Box, Stack, SxProps, Theme, useTheme} from "@mui/material";
 import {Types} from "aptos";
 import CurrencyExchangeOutlinedIcon from "@mui/icons-material/CurrencyExchangeOutlined";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";
@@ -64,6 +65,17 @@ function CoinTransferCodeLine({sx}: {sx?: SxProps<Theme>}): JSX.Element {
   );
 }
 
+function ScriptCodeLine({sx}: {sx?: SxProps<Theme>}): JSX.Element {
+  return (
+    <CodeLineBox sx={[...(Array.isArray(sx) ? sx : [sx])]}>
+      <Stack direction="row" alignItems="center" spacing={1.5}>
+        <DescriptionOutlinedIcon sx={{fontSize: 17, padding: 0}} />
+        <Box>{`Script`}</Box>
+      </Stack>
+    </CodeLineBox>
+  );
+}
+
 export default function TransactionFunction({
   transaction,
   sx,
@@ -71,7 +83,15 @@ export default function TransactionFunction({
   transaction: Types.Transaction;
   sx?: SxProps<Theme>;
 }) {
-  if (!("payload" in transaction) || !("function" in transaction.payload)) {
+  if (!("payload" in transaction)) {
+    return null;
+  }
+
+  if (transaction.payload.type === "script_payload") {
+    return <ScriptCodeLine sx={[...(Array.isArray(sx) ? sx : [sx])]} />;
+  }
+
+  if (!("function" in transaction.payload)) {
     return null;
   }
 

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -55,10 +55,6 @@ function TransactionFunctionRow({
 }: {
   transaction: Types.Transaction;
 }) {
-  if (!("payload" in transaction) || !("function" in transaction.payload)) {
-    return null;
-  }
-
   return (
     <ContentRow
       title="Function:"


### PR DESCRIPTION
* show "script" as function when applicable
* change the padding of transaction status component
<img width="832" alt="Screen Shot 2022-11-08 at 5 30 22 PM" src="https://user-images.githubusercontent.com/109111707/200714556-6112265b-8145-4663-96bd-45bb0fb862ba.png">
<img width="1542" alt="Screen Shot 2022-11-08 at 5 29 47 PM" src="https://user-images.githubusercontent.com/109111707/200714557-97c4183a-2aec-49dd-a957-c1e633afda60.png">
