### PR TITLE
[Explorer] move table header tooltip icon to the right

### DIFF
--- a/src/components/Table/GeneralTableHeaderCell.tsx
+++ b/src/components/Table/GeneralTableHeaderCell.tsx
@@ -55,10 +55,11 @@ export default function GeneralTableHeaderCell({
       IconComponent={SouthIcon}
       sx={{
         "&.MuiTableSortLabel-root .MuiTableSortLabel-icon": {
-          marginLeft: 1,
-          marginRight: 0,
+          marginLeft: 0,
+          marginRight: 0.5,
           color: aptosColor,
         },
+        flexDirection: "row-reverse",
       }}
     >
       {headerTextComponent}
@@ -74,8 +75,8 @@ export default function GeneralTableHeaderCell({
       justifyContent={textAlignRight ? "flex-end" : "flex-start"}
       alignItems="center"
     >
-      {tooltip}
       {headerSortLabel}
+      {tooltip}
     </Stack>
   ) : (
     headerSortLabel

--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -76,7 +76,7 @@ export function TransactionType({type}: TransactionTypeProps) {
 
 export function TableTransactionType({type}: TransactionTypeProps) {
   return (
-    <Box sx={{display: "flex", alignItems: "center", marginLeft: 2}}>
+    <Box sx={{display: "flex", alignItems: "center"}}>
       {getTypeIcon(type, "inherit")}
     </Box>
   );

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -169,7 +169,7 @@ function ValidatorAddrCell({validator}: ValidatorCellProps) {
 
 function VotingPowerCell({validator}: ValidatorCellProps) {
   return (
-    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+    <GeneralTableCell sx={{textAlign: "right"}}>
       {getFormattedBalanceStr(validator.voting_power.toString(), undefined, 0)}
     </GeneralTableCell>
   );
@@ -195,7 +195,7 @@ function RewardsPerformanceCell({validator}: ValidatorCellProps) {
 
 function LastEpochPerformanceCell({validator}: ValidatorCellProps) {
   return (
-    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+    <GeneralTableCell sx={{textAlign: "right"}}>
       {validator.last_epoch_performance}
     </GeneralTableCell>
   );
@@ -203,7 +203,7 @@ function LastEpochPerformanceCell({validator}: ValidatorCellProps) {
 
 function GovernanceVotesCell({validator}: ValidatorCellProps) {
   return (
-    <GeneralTableCell sx={{textAlign: "right", paddingRight: 5}}>
+    <GeneralTableCell sx={{textAlign: "right"}}>
       {validator.governance_voting_record}
     </GeneralTableCell>
   );


### PR DESCRIPTION
<img width="1298" alt="Screen Shot 2022-11-10 at 10 37 44 AM 1" src="https://user-images.githubusercontent.com/109111707/201179100-c77cba42-98bc-4dab-bb5f-d263e82f1c1e.png">
