### PR TITLE
Removes focus outline on CircularProgress container

### DIFF
--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -13,6 +13,7 @@ export default function LoadingModal({open}: LoadingModalProps) {
           position: "absolute",
           top: "50%",
           left: "50%",
+          outline: "0",
         }}
       >
         <CircularProgress />


### PR DESCRIPTION
`CircularProgress` component was displaying browser focus styling on its container:

https://user-images.githubusercontent.com/98909677/202533710-da657800-1e14-4178-bb1a-0ddefef3954a.mov

Fixed with `outline: '0';` on `div` container:

https://user-images.githubusercontent.com/98909677/202533806-28cc50f4-d6ca-4b5d-b37d-2a1da0647142.mov


