### PR TITLE
[ANS] better name search experience

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -40,31 +40,13 @@ function getFetchAddressUrl(network: NetworkName, name: string) {
   return `https://www.aptosnames.com/api/${network}/v1/address/${name}`;
 }
 
-export function useGetAddressFromName(name: string) {
-  const [state, _] = useGlobalState();
-  const [address, setAddress] = useState<string | undefined>();
-  const url = getFetchAddressUrl(state.network_name, name);
-
-  useEffect(() => {
-    if (url !== undefined) {
-      const fetchData = async () => {
-        const response = await fetch(url);
-        const {address} = await response.json();
-        setAddress(address);
-      };
-
-      fetchData();
-    }
-  }, [name, state]);
-
-  return address;
-}
-
 export async function getAddressFromName(
   name: string,
   network: NetworkName,
 ): Promise<string | undefined> {
-  const addressUrl = getFetchAddressUrl(network, name);
+  const searchableName = name.endsWith(".apt") ? name.slice(0, -4) : name;
+  const addressUrl = getFetchAddressUrl(network, searchableName);
+
   if (addressUrl === undefined) {
     return undefined;
   }
@@ -77,7 +59,7 @@ export async function getAddressFromName(
     const primaryNameResponse = await fetch(primaryNameUrl ?? "");
     const {name: primaryName} = await primaryNameResponse.json();
 
-    if (primaryName === name) {
+    if (primaryName === searchableName) {
       return address;
     } else {
       return undefined;

--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -10,6 +10,7 @@ import {
   isNumeric,
   isValidAccountAddress,
   isValidTxnHashOrVersion,
+  truncateAddress,
 } from "../../pages/utils";
 import {getAddressFromName} from "./useGetANS";
 
@@ -44,7 +45,9 @@ export default function useGetSearchResults(input: string) {
         .then((address): SearchResult | null => {
           if (address) {
             return {
-              label: `Account ${address}`,
+              label: `Account ${truncateAddress(address)} ${
+                searchText.endsWith(".apt") ? searchText : `${searchText}.apt`
+              }`,
               to: `/account/${address}`,
             };
           } else {

--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -45,7 +45,7 @@ export default function useGetSearchResults(input: string) {
         .then((address): SearchResult | null => {
           if (address) {
             return {
-              label: `Account ${truncateAddress(address)} ${
+              label: `Account ${truncateAddress(address)} | ${
                 searchText.endsWith(".apt") ? searchText : `${searchText}.apt`
               }`,
               to: `/account/${address}`,


### PR DESCRIPTION
* enable name search with `name.apt`. previously only `name` is supported
* show `name.apt` in the search result. previously only the address is shown
<img width="533" alt="Screen Shot 2022-12-12 at 1 55 19 PM" src="https://user-images.githubusercontent.com/109111707/207163486-23cf8a0c-4775-4785-9741-8992b142f8d4.png">
<img width="421" alt="Screen Shot 2022-12-12 at 1 52 12 PM" src="https://user-images.githubusercontent.com/109111707/207163488-0f22af86-a4d4-4272-99f4-c39c719b846c.png">
