### PR TITLE
Disable "Maintain Aspect Ratio" for Charts

### DIFF
--- a/src/pages/Analytics/Components/BarChart.tsx
+++ b/src/pages/Analytics/Components/BarChart.tsx
@@ -31,6 +31,7 @@ export default function BarChart({labels, dataset}: BarChartProps) {
   const options = {
     fill: false,
     responsive: true,
+    maintainAspectRatio: false,
     interaction: {
       intersect: false,
     },

--- a/src/pages/Analytics/Components/LineChart.tsx
+++ b/src/pages/Analytics/Components/LineChart.tsx
@@ -41,6 +41,7 @@ export default function LineChart({
 }: LineChartProps) {
   const options = {
     responsive: true,
+    maintainAspectRatio: false,
     interaction: {
       intersect: false,
     },


### PR DESCRIPTION
Disables `maintainAspectRatio` for Charts, providing more consistent results upon browser resize. 