### PR TITLE
[Nerwork Select] persistent url param

### DIFF
--- a/src/api/hooks/useNavigateWithParams.ts
+++ b/src/api/hooks/useNavigateWithParams.ts
@@ -1,0 +1,25 @@
+import {
+  createSearchParams,
+  generatePath,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
+import {defaultNetworkName} from "../../constants";
+
+export function useNavigateWithParams() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const networkName = searchParams.get("network") || defaultNetworkName;
+
+  const navigateWithParams = (url: string) => {
+    const params = {network: networkName};
+    const path = generatePath(":url?:queryString", {
+      url,
+      queryString: createSearchParams(params).toString(),
+    });
+    navigate(path);
+  };
+
+  return navigateWithParams;
+}

--- a/src/components/GoBack.tsx
+++ b/src/components/GoBack.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {useNavigate} from "react-router-dom";
 import Button from "@mui/material/Button";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import {useNavigateWithParams} from "../api/hooks/useNavigateWithParams";
 
 function BackButton(handleClick: () => void) {
   return (
@@ -31,6 +32,7 @@ type GoBackProps = {
 
 export default function GoBack({to}: GoBackProps): JSX.Element | null {
   const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   if (window.history.state && window.history.state.idx > 0) {
     return BackButton(() => {
@@ -39,7 +41,7 @@ export default function GoBack({to}: GoBackProps): JSX.Element | null {
   } else {
     if (to != null) {
       return BackButton(() => {
-        navigate(to);
+        navigateWithParams(to);
       });
     } else {
       return null;

--- a/src/components/WalletConnector/WalletMenu.tsx
+++ b/src/components/WalletConnector/WalletMenu.tsx
@@ -7,8 +7,8 @@ import {
   Tooltip,
 } from "@mui/material";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
-import {useNavigate} from "react-router-dom";
 import React, {useState} from "react";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 type WalletMenuProps = {
   popoverAnchor: HTMLButtonElement | null;
@@ -20,12 +20,12 @@ export default function WalletMenu({
   handlePopoverClose,
 }: WalletMenuProps): JSX.Element {
   const {account, disconnect} = useWallet();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const popoverOpen = Boolean(popoverAnchor);
   const id = popoverOpen ? "wallet-popover" : undefined;
 
   const onAccountOptionClicked = () => {
-    navigate(`/account/${account?.address}`);
+    navigateWithParams(`/account/${account?.address}`);
     handlePopoverClose();
   };
 

--- a/src/pages/Account/Components/TokensTable.tsx
+++ b/src/pages/Account/Components/TokensTable.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import {Box} from "@mui/material";
 import * as RRD from "react-router-dom";
 import {Link, Table, TableHead, TableRow} from "@mui/material";
-import {useNavigate} from "react-router-dom";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../../utils";
 import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
+import {useNavigateWithParams} from "../../../api/hooks/useNavigateWithParams";
 
 type TokenCellProps = {
   token: any; // TODO: add graphql data typing
@@ -107,10 +107,12 @@ type TokenRowProps = {
 };
 
 function TokenRow({token, columns}: TokenRowProps) {
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   const rowClick = () => {
-    navigate(`/token/${token?.token_data_id_hash}/${token?.property_version}`);
+    navigateWithParams(
+      `/token/${token?.token_data_id_hash}/${token?.property_version}`,
+    );
   };
 
   return (

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -16,7 +16,8 @@ import StyledTab from "../../components/StyledTab";
 import TokensTab from "./Tabs/TokensTab";
 import CoinsTab from "./Tabs/CoinsTab";
 import {Types} from "aptos";
-import {useNavigate, useParams} from "react-router-dom";
+import {useParams} from "react-router-dom";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
@@ -93,11 +94,11 @@ export default function AccountTabs({
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
   const {tab} = useParams();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const value = tab === undefined ? TAB_VALUES[0] : (tab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/account/${address}/${newValue}`);
+    navigateWithParams(`/account/${address}/${newValue}`);
   };
 
   return (

--- a/src/pages/Block/Tabs.tsx
+++ b/src/pages/Block/Tabs.tsx
@@ -8,7 +8,8 @@ import WysiwygIcon from "@mui/icons-material/Wysiwyg";
 import BarChartOutlinedIcon from "@mui/icons-material/BarChartOutlined";
 import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
-import {useNavigate, useParams} from "react-router-dom";
+import {useParams} from "react-router-dom";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 const TAB_VALUES: TabValue[] = ["overview", "transactions"];
 
@@ -61,11 +62,11 @@ export default function BlockTabs({
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
   const {height, tab} = useParams();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const value = tab === undefined ? TAB_VALUES[0] : (tab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/block/${height}/${newValue}`);
+    navigateWithParams(`/block/${height}/${newValue}`);
   };
 
   return (

--- a/src/pages/Token/Tabs.tsx
+++ b/src/pages/Token/Tabs.tsx
@@ -7,7 +7,8 @@ import WysiwygIcon from "@mui/icons-material/Wysiwyg";
 import BarChartOutlinedIcon from "@mui/icons-material/BarChartOutlined";
 import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
-import {useNavigate, useParams} from "react-router-dom";
+import {useParams} from "react-router-dom";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 const TAB_VALUES: TabValue[] = ["overview", "activities"];
 
@@ -60,11 +61,11 @@ export default function TokenTabs({
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
   const {tab, propertyVersion, tokenId} = useParams();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const value = tab === undefined ? TAB_VALUES[0] : (tab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/token/${tokenId}/${propertyVersion}/${newValue}`);
+    navigateWithParams(`/token/${tokenId}/${propertyVersion}/${newValue}`);
   };
 
   return (

--- a/src/pages/Transaction/Tabs.tsx
+++ b/src/pages/Transaction/Tabs.tsx
@@ -20,7 +20,8 @@ import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import BalanceChangeTab from "./Tabs/BalanceChangeTab";
-import {useNavigate, useParams} from "react-router-dom";
+import {useParams} from "react-router-dom";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 function getTabValues(transaction: Types.Transaction): TabValue[] {
   switch (transaction.type) {
@@ -126,12 +127,12 @@ export default function TransactionTabs({
   tabValues = getTabValues(transaction),
 }: TransactionTabsProps): JSX.Element {
   const {tab, txnHashOrVersion} = useParams();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const value =
     tab === undefined ? getTabValues(transaction)[0] : (tab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/txn/${txnHashOrVersion}/${newValue}`);
+    navigateWithParams(`/txn/${txnHashOrVersion}/${newValue}`);
   };
 
   return (

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -6,7 +6,7 @@ import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import {useNavigate, useParams} from "react-router-dom";
+import {useParams} from "react-router-dom";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import HashButton, {HashType} from "../../components/HashButton";
@@ -32,6 +32,7 @@ import {
   getTransactionAmount,
   getTransactionCounterparty,
 } from "../Transaction/utils";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 type TransactionCellProps = {
   transaction: Types.Transaction;
@@ -220,10 +221,12 @@ type TransactionRowProps = {
 };
 
 function TransactionRow({transaction, columns}: TransactionRowProps) {
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   const rowClick = () => {
-    navigate(`/txn/${"version" in transaction && transaction.version}`);
+    navigateWithParams(
+      `/txn/${"version" in transaction && transaction.version}`,
+    );
   };
 
   return (
@@ -242,7 +245,7 @@ type UserTransactionRowProps = {
 };
 
 function UserTransactionRow({version, columns}: UserTransactionRowProps) {
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const {data: transaction, isError} = useGetTransaction(version.toString());
 
   if (!transaction || isError) {
@@ -250,7 +253,7 @@ function UserTransactionRow({version, columns}: UserTransactionRowProps) {
   }
 
   const rowClick = () => {
-    navigate(`/txn/${version}`);
+    navigateWithParams(`/txn/${version}`);
   };
 
   return (

--- a/src/pages/Validators/Table.tsx
+++ b/src/pages/Validators/Table.tsx
@@ -13,8 +13,8 @@ import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import {CommissionCell, DelegatorCell, MyDepositCell} from "./ValidatorsTable";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
-import {useNavigate} from "react-router-dom";
 import {Types} from "aptos";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 type ValidatorCellProps = {
   validator: Validator;
@@ -119,10 +119,10 @@ type ValidatorRowProps = {
 
 function ValidatorRow({validator, columns}: ValidatorRowProps) {
   const inDev = useGetInDevMode();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   const rowClick = (address: Types.Address) => {
-    navigate(`/validator/${address}`);
+    navigateWithParams(`/validator/${address}`);
   };
 
   return (

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -9,13 +9,13 @@ import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import RewardsPerformanceTooltip from "./Components/RewardsPerformanceTooltip";
 import LastEpochPerformanceTooltip from "./Components/LastEpochPerformanceTooltip";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
-import {useNavigate} from "react-router-dom";
 import {Types} from "aptos";
 import {
   MainnetValidatorData,
   useGetMainnetValidators,
 } from "../../api/hooks/useGetMainnetValidators";
 import {getFormattedBalanceStr} from "../../components/IndividualPageContent/ContentValue/CurrencyValue";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 function getSortedValidators(
   validators: MainnetValidatorData[],
@@ -281,10 +281,10 @@ type ValidatorRowProps = {
 
 function ValidatorRow({validator, columns}: ValidatorRowProps) {
   const inDev = useGetInDevMode();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   const rowClick = (address: Types.Address) => {
-    navigate(`/validator/${address}`);
+    navigateWithParams(`/validator/${address}`);
   };
 
   return (

--- a/src/pages/layout/NavMobile.tsx
+++ b/src/pages/layout/NavMobile.tsx
@@ -8,13 +8,13 @@ import {ReactComponent as CloseIcon} from "../../assets/svg/icon_close.svg";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import Box from "@mui/material/Box";
 import {useTheme} from "@mui/material";
-import {useNavigate} from "react-router-dom";
 import {useGetInMainnet} from "../../api/hooks/useGetInMainnet";
+import {useNavigateWithParams} from "../../api/hooks/useNavigateWithParams";
 
 export default function NavMobile() {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const theme = useTheme();
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
 
   const inMainnet = useGetInMainnet();
 
@@ -29,7 +29,7 @@ export default function NavMobile() {
 
   const handleCloseAndNavigate = (to: string) => {
     setMenuAnchorEl(null);
-    navigate(to);
+    navigateWithParams(to);
   };
 
   return (

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -5,12 +5,7 @@ import {
   SelectChangeEvent,
   Typography,
 } from "@mui/material";
-import {
-  defaultFeatureName,
-  defaultNetworkName,
-  NetworkName,
-  networks,
-} from "../../constants";
+import {defaultNetworkName, NetworkName, networks} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useTheme} from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -5,7 +5,12 @@ import {
   SelectChangeEvent,
   Typography,
 } from "@mui/material";
-import {defaultFeatureName, NetworkName, networks} from "../../constants";
+import {
+  defaultFeatureName,
+  defaultNetworkName,
+  NetworkName,
+  networks,
+} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useTheme} from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";
@@ -72,21 +77,25 @@ export default function NetworkSelect() {
   const theme = useTheme();
 
   function maybeSetNetwork(networkNameString: string | null) {
-    if (!networkNameString || state.network_name === networkNameString) return;
-    if (!(networkNameString in networks)) return;
-    const feature_name = state.feature_name;
-    const network_name = networkNameString as NetworkName;
-    const network_value = networks[network_name];
-    if (network_value) {
-      // only show the "feature" param in the url when it's not "prod"
-      // we don't want the users to know the existence of the "feature" param
-      if (feature_name !== defaultFeatureName) {
-        setSearchParams({network: network_name, feature: feature_name});
-      } else {
-        setSearchParams({network: network_name});
-      }
-      dispatch({network_name, network_value, feature_name});
+    if (networkNameString === state.network_name) {
+      return;
     }
+
+    let newNetworkName;
+    if (!networkNameString || !(networkNameString in networks)) {
+      // set network to default if networkNameString is null or invalid
+      newNetworkName = defaultNetworkName;
+    } else {
+      // else, set network to networkNameString
+      newNetworkName = networkNameString;
+    }
+    searchParams.set("network", newNetworkName);
+    setSearchParams(searchParams);
+
+    const feature_name = state.feature_name;
+    const network_name = newNetworkName as NetworkName;
+    const network_value = networks[network_name];
+    dispatch({network_name, network_value, feature_name});
   }
 
   const handleChange = (event: SelectChangeEvent<string>) => {

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -1,15 +1,15 @@
 import React, {useEffect, useState} from "react";
 import {Autocomplete, AutocompleteInputChangeReason} from "@mui/material";
 import SearchInput from "./SearchInput";
-import {useNavigate} from "react-router-dom";
 import useGetSearchResults, {
   NotFoundResult,
   SearchResult,
 } from "../../../api/hooks/useGetSearchResults";
 import ResultLink from "./ResultLink";
+import {useNavigateWithParams} from "../../../api/hooks/useNavigateWithParams";
 
 export default function HeaderSearch() {
-  const navigate = useNavigate();
+  const navigateWithParams = useNavigateWithParams();
   const [inputValue, setInputValue] = useState<string>("");
   const [searchValue, setSearchValue] = useState<string>("");
   const [open, setOpen] = useState(false);
@@ -60,7 +60,7 @@ export default function HeaderSearch() {
 
   const handleSubmitSearch = async () => {
     if (selectedOption.to !== null) {
-      navigate(selectedOption.to);
+      navigateWithParams(selectedOption.to);
     }
   };
 


### PR DESCRIPTION
## Problem
The current network switching behaviour of explorer is a bit confusing. There is a URL parameter `?network=testnet` which designates the chosen network, but if one clicks a link that omits that it opens the explorer in whatever network the user had opened previously. This leads to some confusing link flows, esp when one opens links from different sources and may have mainnet and testnet explorer open in different tabs.

## Solution
Per @perryjrandall's suggestion, this PR makes it default to always include the `network` param in the url.