### PR TITLE
[Fix] revert content row UI

### DIFF
--- a/src/components/IndividualPageContent/ContentRow.tsx
+++ b/src/components/IndividualPageContent/ContentRow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Box, SxProps, Theme} from "@mui/material";
+import {Box} from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import EmptyValue from "./ContentValue/EmptyValue";
@@ -9,8 +9,6 @@ type ContentRowProps = {
   value: React.ReactNode;
   tooltip?: React.ReactNode;
   i?: any;
-  container?: boolean;
-  sx?: SxProps<Theme>;
 };
 
 export default function ContentRow({
@@ -18,18 +16,15 @@ export default function ContentRow({
   value,
   tooltip,
   i,
-  container,
-  sx,
 }: ContentRowProps) {
   return (
     <Box>
       <Grid
-        container={container && true}
+        container
         rowSpacing={0.5}
         columnSpacing={4}
         alignItems="start"
         key={i}
-        sx={sx}
       >
         <Grid xs={12} sm={3}>
           <Box sx={{fontSize: "0.875rem", color: grey[450]}}>

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -34,7 +34,6 @@ export default function ValidatorDetailCard({
   const operatorAddr = validator?.operator_address;
   const rewardGrowth = validator?.rewards_growth;
   const stakePoolAddress = validator?.owner_address;
-  const sx = {justifyContent: "space-between", display: "flex"};
 
   useEffect(() => {
     if (lockedUntilSecs && operatorAddr && rewardGrowth && stakePoolAddress) {

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -54,20 +54,13 @@ export default function ValidatorDetailCard({
               <HashButton hash={operatorAddr} type={HashType.ACCOUNT} />
             )
           }
-          sx={sx}
         />
-        <ContentRow
-          container={false}
-          title="Number of Delegators"
-          value={null}
-          sx={sx}
-        />
-        <ContentRow title="Compound Rewards" value={null} sx={sx} />
-        <ContentRow title="Operator Commission" value={null} sx={sx} />
+        <ContentRow title="Number of Delegators" value={null} />
+        <ContentRow title="Compound Rewards" value={null} />
+        <ContentRow title="Operator Commission" value={null} />
       </ContentBox>
       <ContentBox padding={4} width="50%">
         <ContentRow
-          sx={sx}
           title={"Stake Pool Address"}
           value={
             stakePoolAddress && (
@@ -76,19 +69,16 @@ export default function ValidatorDetailCard({
           }
         />
         <ContentRow
-          sx={sx}
           title="Rewards Performance"
           value={rewardGrowth ? `${rewardGrowth.toFixed(2)} %` : null}
           tooltip={<RewardsPerformanceTooltip />}
         />
         <ContentRow
-          sx={sx}
           title="Last Epoch Performance"
           value={validator ? validator.last_epoch_performance : null}
           tooltip={<LastEpochPerformanceTooltip />}
         />
         <ContentRow
-          sx={sx}
           title="Next Unlock"
           value={<TimestampValue timestamp={lockedUntilSecs?.toString()!} />}
         />


### PR DESCRIPTION
This is a hot fix to revert UI change in #314 that broke explorer content layout.

|Before|After|
|---|---|
|<img width="1263" alt="Screen Shot 2023-01-24 at 6 20 24 PM" src="https://user-images.githubusercontent.com/109111707/214466387-ece3f349-b33e-4143-af42-28ddb30bbf90.png">|<img width="1304" alt="Screen Shot 2023-01-24 at 6 20 14 PM" src="https://user-images.githubusercontent.com/109111707/214466409-81d1d3b4-32cf-4e8e-bf85-23b5f6a74591.png">|
