### PR TITLE
[explorer][delegation] add status tooltip stepper

### DIFF
--- a/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
+++ b/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
@@ -1,0 +1,106 @@
+import {
+  Chip,
+  Stack,
+  Step,
+  StepContent,
+  StepLabel,
+  Stepper,
+  useTheme,
+} from "@mui/material";
+import React from "react";
+import TableTooltip from "../../../components/Table/TableTooltip";
+import LockIcon from "@mui/icons-material/Lock";
+import TooltipTypography from "../../../components/TooltipTypography";
+import PendingIcon from "@mui/icons-material/Pending";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import {
+  STAKED_BACKGROUND_COLOR_DARK,
+  STAKED_BACKGROUND_COLOR_LIGHT,
+  STAKED_DESCRIPTION,
+  STAKED_LABEL,
+  STAKED_TEXT_COLOR_DARK,
+  STAKED_TEXT_COLOR_LIGHT,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_PENDING_DESCRIPTION,
+  WITHDRAW_PENDING_LABEL,
+  WITHDRAW_PENDING_TEXT_COLOR_DARK,
+  WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+  WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+  WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_READY_DESCRIPTION,
+  WITHDRAW_READY_LABEL,
+  WITHDRAW_READY_TEXT_COLOR_DARK,
+  WITHDRAW_READY_TEXT_COLOR_LIGHT,
+} from "../constants";
+
+export default function MyDepositsStatusTooltip() {
+  const theme = useTheme();
+  const steps = [
+    {
+      label: STAKED_LABEL,
+      description: STAKED_DESCRIPTION,
+      icon: <LockIcon />,
+      sxLight: {
+        color: STAKED_TEXT_COLOR_LIGHT,
+        backgroundColor: STAKED_BACKGROUND_COLOR_LIGHT,
+      },
+      sxDark: {
+        color: STAKED_TEXT_COLOR_DARK,
+        backgroundColor: STAKED_BACKGROUND_COLOR_DARK,
+      },
+    },
+    {
+      label: WITHDRAW_PENDING_LABEL,
+      description: WITHDRAW_PENDING_DESCRIPTION,
+      icon: <PendingIcon />,
+      sxLight: {
+        color: WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+        backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+      },
+      sxDark: {
+        color: WITHDRAW_PENDING_TEXT_COLOR_DARK,
+        backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+      },
+    },
+    {
+      label: WITHDRAW_READY_LABEL,
+      description: WITHDRAW_READY_DESCRIPTION,
+      icon: <CheckCircleIcon />,
+      sxLight: {
+        color: WITHDRAW_READY_TEXT_COLOR_LIGHT,
+        backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+      },
+      sxDark: {
+        color: WITHDRAW_READY_TEXT_COLOR_DARK,
+        backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+      },
+    },
+  ];
+
+  return (
+    <TableTooltip title="Deposit Status">
+      <Stack>
+        <Stepper orientation="vertical">
+          {steps.map((step) => (
+            <Step key={step.label} active={true}>
+              <StepLabel>
+                <Chip
+                  icon={step.icon}
+                  label={step.label}
+                  sx={
+                    theme.palette.mode === "dark" ? step.sxDark : step.sxLight
+                  }
+                  color="primary"
+                />
+              </StepLabel>
+              <StepContent>
+                <TooltipTypography>{step.description}</TooltipTypography>
+              </StepContent>
+            </Step>
+          ))}
+        </Stepper>
+      </Stack>
+    </TableTooltip>
+  );
+}

--- a/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
+++ b/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
@@ -34,6 +34,7 @@ import {
   WITHDRAW_READY_TEXT_COLOR_LIGHT,
 } from "../constants";
 
+// TODO(jill): refactor step icon color scheme to override the default
 export default function MyDepositsStatusTooltip() {
   const theme = useTheme();
   const steps = [

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -13,6 +13,7 @@ import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
+import MyDepositsStatusTooltip from "./Components/MyDepositsStatusTooltip";
 
 type MyDepositsSectionProps = {
   accountResource?: Types.MoveResource | undefined;
@@ -100,6 +101,7 @@ export default function MyDepositsSection({
               <GeneralTableHeaderCell
                 header={MyDepositsHeader[columnName]}
                 key={idx}
+                tooltip={columnName === "status" && <MyDepositsStatusTooltip />}
               />
             ))}
           </TableRow>

--- a/src/pages/DelegatoryValidator/constants.ts
+++ b/src/pages/DelegatoryValidator/constants.ts
@@ -1,27 +1,36 @@
 import {grey} from "../../themes/colors/aptosColorPalette";
 
+/* validator page -> my deposits section -> status column -> tooltip content & color scheme */
+
+// step 1 STAKED
 export const STAKED_TEXT_COLOR_LIGHT = "rgba(14, 165, 233, 1)";
 export const STAKED_TEXT_COLOR_DARK = "rgba(125, 211, 252, 1)";
 export const STAKED_BACKGROUND_COLOR_LIGHT = "rgba(14, 165, 233, 0.1)";
 export const STAKED_BACKGROUND_COLOR_DARK = "rgba(125, 211, 252, 0.1)";
+export const STAKED_LABEL = "Staked";
+export const STAKED_DESCRIPTION = `You are getting rewards for the staked deposit, but not able to
+withdraw it until the lock period. But you can initiate this process with an
+unstake option.`;
+
+// step 2 WITHDRAW PENDING
 export const WITHDRAW_PENDING_TEXT_COLOR_LIGHT = "rgba(202, 138, 4, 1)";
 export const WITHDRAW_PENDING_TEXT_COLOR_DARK = "rgba(234, 179, 8, 1)";
 export const WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT =
   "rgba(250, 204, 21, 0.2)";
 export const WITHDRAW_PENDING_BACKGROUND_COLOR_DARK = "rgba(252, 211, 77, 0.1)";
+export const WITHDRAW_PENDING_LABEL = "Withdraw pending";
+export const WITHDRAW_PENDING_DESCRIPTION =
+  "If you decided to unstake your deposit, it will be locked till the end of the lock period.";
+
+// step 3 WITHDRAW READY
 export const WITHDRAW_READY_TEXT_COLOR_LIGHT = "rgba(15, 118, 110, 1)";
 export const WITHDRAW_READY_TEXT_COLOR_DARK = "rgba(20, 184, 166, 1)";
 export const WITHDRAW_READY_BACKGROUND_COLOR_LIGHT = "rgba(20, 184, 166, 0.1)";
 export const WITHDRAW_READY_BACKGROUND_COLOR_DARK = "rgba(20, 184, 166, 0.1)";
-export const STAKED_LABEL = "Staked";
-export const STAKED_DESCRIPTION = `You are getting rewards for the staked deposit, but not able to
-withdraw it until the lock period. But you can initiate this process with an
-unstake option.`;
-export const WITHDRAW_PENDING_LABEL = "Withdraw pending";
-export const WITHDRAW_PENDING_DESCRIPTION =
-  "If you decided to unstake your deposit, it will be locked till the end of the lock period.";
 export const WITHDRAW_READY_LABEL = "Withdraw ready";
 export const WITHDRAW_READY_DESCRIPTION =
   "After the end of the lock period you will be able to withdraw your funds to your wallet.";
-export const STEP_CONNECTOR_DARK = "#818CF8";
-export const STEP_CONNECTOR_LIGHT = grey[300];
+
+// step icon color scheme
+export const STEP_ICON_DARK = "#818CF8";
+export const STEP_ICON_LIGHT = grey[300];

--- a/src/pages/DelegatoryValidator/constants.ts
+++ b/src/pages/DelegatoryValidator/constants.ts
@@ -1,0 +1,27 @@
+import {grey} from "../../themes/colors/aptosColorPalette";
+
+export const STAKED_TEXT_COLOR_LIGHT = "rgba(14, 165, 233, 1)";
+export const STAKED_TEXT_COLOR_DARK = "rgba(125, 211, 252, 1)";
+export const STAKED_BACKGROUND_COLOR_LIGHT = "rgba(14, 165, 233, 0.1)";
+export const STAKED_BACKGROUND_COLOR_DARK = "rgba(125, 211, 252, 0.1)";
+export const WITHDRAW_PENDING_TEXT_COLOR_LIGHT = "rgba(202, 138, 4, 1)";
+export const WITHDRAW_PENDING_TEXT_COLOR_DARK = "rgba(234, 179, 8, 1)";
+export const WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT =
+  "rgba(250, 204, 21, 0.2)";
+export const WITHDRAW_PENDING_BACKGROUND_COLOR_DARK = "rgba(252, 211, 77, 0.1)";
+export const WITHDRAW_READY_TEXT_COLOR_LIGHT = "rgba(15, 118, 110, 1)";
+export const WITHDRAW_READY_TEXT_COLOR_DARK = "rgba(20, 184, 166, 1)";
+export const WITHDRAW_READY_BACKGROUND_COLOR_LIGHT = "rgba(20, 184, 166, 0.1)";
+export const WITHDRAW_READY_BACKGROUND_COLOR_DARK = "rgba(20, 184, 166, 0.1)";
+export const STAKED_LABEL = "Staked";
+export const STAKED_DESCRIPTION = `You are getting rewards for the staked deposit, but not able to
+withdraw it until the lock period. But you can initiate this process with an
+unstake option.`;
+export const WITHDRAW_PENDING_LABEL = "Withdraw pending";
+export const WITHDRAW_PENDING_DESCRIPTION =
+  "If you decided to unstake your deposit, it will be locked till the end of the lock period.";
+export const WITHDRAW_READY_LABEL = "Withdraw ready";
+export const WITHDRAW_READY_DESCRIPTION =
+  "After the end of the lock period you will be able to withdraw your funds to your wallet.";
+export const STEP_CONNECTOR_DARK = "#818CF8";
+export const STEP_CONNECTOR_LIGHT = grey[300];


### PR DESCRIPTION
<img width="396" alt="Screenshot 2023-01-25 at 10 48 48 AM" src="https://user-images.githubusercontent.com/121921928/214655534-ffc54160-5708-40c4-b402-60a686e7ac12.png">
<img width="374" alt="Screenshot 2023-01-25 at 10 48 53 AM" src="https://user-images.githubusercontent.com/121921928/214655546-a70041df-2e70-4251-a777-a163f629bcc5.png">

had some issues to the step number icon color override. will refactor later.