### PR TITLE
[explorer][delegation] add status icon to my deposits section

### DIFF
--- a/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
+++ b/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
@@ -10,10 +10,10 @@ import {
 import React from "react";
 import TableTooltip from "../../../components/Table/TableTooltip";
 import TooltipTypography from "../../../components/TooltipTypography";
-import {StakingStatusStepInterface} from "../MyDepositsSection";
+import {StakingStatusStepInterface} from "./StakingStatusIcon";
 
 type MyDepositsSectionProps = {
-  steps: [StakingStatusStepInterface];
+  steps: StakingStatusStepInterface[];
 };
 
 // TODO(jill): refactor step icon color scheme to override the default

--- a/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
+++ b/src/pages/DelegatoryValidator/Components/MyDepositsStatusTooltip.tsx
@@ -9,75 +9,18 @@ import {
 } from "@mui/material";
 import React from "react";
 import TableTooltip from "../../../components/Table/TableTooltip";
-import LockIcon from "@mui/icons-material/Lock";
 import TooltipTypography from "../../../components/TooltipTypography";
-import PendingIcon from "@mui/icons-material/Pending";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import {
-  STAKED_BACKGROUND_COLOR_DARK,
-  STAKED_BACKGROUND_COLOR_LIGHT,
-  STAKED_DESCRIPTION,
-  STAKED_LABEL,
-  STAKED_TEXT_COLOR_DARK,
-  STAKED_TEXT_COLOR_LIGHT,
-  WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
-  WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
-  WITHDRAW_PENDING_DESCRIPTION,
-  WITHDRAW_PENDING_LABEL,
-  WITHDRAW_PENDING_TEXT_COLOR_DARK,
-  WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
-  WITHDRAW_READY_BACKGROUND_COLOR_DARK,
-  WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
-  WITHDRAW_READY_DESCRIPTION,
-  WITHDRAW_READY_LABEL,
-  WITHDRAW_READY_TEXT_COLOR_DARK,
-  WITHDRAW_READY_TEXT_COLOR_LIGHT,
-} from "../constants";
+import {StakingStatusStepInterface} from "../MyDepositsSection";
+
+type MyDepositsSectionProps = {
+  steps: [StakingStatusStepInterface];
+};
 
 // TODO(jill): refactor step icon color scheme to override the default
-export default function MyDepositsStatusTooltip() {
+export default function MyDepositsStatusTooltip({
+  steps,
+}: MyDepositsSectionProps) {
   const theme = useTheme();
-  const steps = [
-    {
-      label: STAKED_LABEL,
-      description: STAKED_DESCRIPTION,
-      icon: <LockIcon />,
-      sxLight: {
-        color: STAKED_TEXT_COLOR_LIGHT,
-        backgroundColor: STAKED_BACKGROUND_COLOR_LIGHT,
-      },
-      sxDark: {
-        color: STAKED_TEXT_COLOR_DARK,
-        backgroundColor: STAKED_BACKGROUND_COLOR_DARK,
-      },
-    },
-    {
-      label: WITHDRAW_PENDING_LABEL,
-      description: WITHDRAW_PENDING_DESCRIPTION,
-      icon: <PendingIcon />,
-      sxLight: {
-        color: WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
-        backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
-      },
-      sxDark: {
-        color: WITHDRAW_PENDING_TEXT_COLOR_DARK,
-        backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
-      },
-    },
-    {
-      label: WITHDRAW_READY_LABEL,
-      description: WITHDRAW_READY_DESCRIPTION,
-      icon: <CheckCircleIcon />,
-      sxLight: {
-        color: WITHDRAW_READY_TEXT_COLOR_LIGHT,
-        backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
-      },
-      sxDark: {
-        color: WITHDRAW_READY_TEXT_COLOR_DARK,
-        backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_DARK,
-      },
-    },
-  ];
 
   return (
     <TableTooltip title="Deposit Status">

--- a/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
+++ b/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
@@ -1,0 +1,106 @@
+import {Chip, useTheme} from "@mui/material";
+import React from "react";
+import {
+  STAKED_BACKGROUND_COLOR_DARK,
+  STAKED_BACKGROUND_COLOR_LIGHT,
+  STAKED_DESCRIPTION,
+  STAKED_LABEL,
+  STAKED_TEXT_COLOR_DARK,
+  STAKED_TEXT_COLOR_LIGHT,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_PENDING_DESCRIPTION,
+  WITHDRAW_PENDING_LABEL,
+  WITHDRAW_PENDING_TEXT_COLOR_DARK,
+  WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+  WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+  WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_READY_DESCRIPTION,
+  WITHDRAW_READY_LABEL,
+  WITHDRAW_READY_TEXT_COLOR_DARK,
+  WITHDRAW_READY_TEXT_COLOR_LIGHT,
+} from "./../constants";
+import LockIcon from "@mui/icons-material/Lock";
+import PendingIcon from "@mui/icons-material/Pending";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import GeneralTableCell from "../../../components/Table/GeneralTableCell";
+
+enum StakingStatusStep {
+  "staked",
+  "withdrawPending",
+  "withdrawReady",
+}
+type Steps = keyof typeof StakingStatusStep;
+
+export interface StakingStatusStepInterface {
+  label: string;
+  description: string;
+  icon: JSX.Element;
+  sxLight: {
+    color: string;
+    backgroundColor: string;
+  };
+  sxDark: {
+    color: string;
+    backgroundColor: string;
+  };
+}
+
+export const STAKING_STATUS_STEPS: StakingStatusStepInterface[] = [
+  {
+    label: STAKED_LABEL,
+    description: STAKED_DESCRIPTION,
+    icon: <LockIcon />,
+    sxLight: {
+      color: STAKED_TEXT_COLOR_LIGHT,
+      backgroundColor: STAKED_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: STAKED_TEXT_COLOR_DARK,
+      backgroundColor: STAKED_BACKGROUND_COLOR_DARK,
+    },
+  },
+  {
+    label: WITHDRAW_PENDING_LABEL,
+    description: WITHDRAW_PENDING_DESCRIPTION,
+    icon: <PendingIcon />,
+    sxLight: {
+      color: WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: WITHDRAW_PENDING_TEXT_COLOR_DARK,
+      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+    },
+  },
+  {
+    label: WITHDRAW_READY_LABEL,
+    description: WITHDRAW_READY_DESCRIPTION,
+    icon: <CheckCircleIcon />,
+    sxLight: {
+      color: WITHDRAW_READY_TEXT_COLOR_LIGHT,
+      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: WITHDRAW_READY_TEXT_COLOR_DARK,
+      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+    },
+  },
+];
+
+export default function StakingStatusIcon() {
+  const theme = useTheme();
+
+  // TODO(jill): temp workaround since we don't have status data yet
+  const step = STAKING_STATUS_STEPS[0];
+  return (
+    <GeneralTableCell>
+      <Chip
+        icon={step.icon}
+        label={step.label}
+        sx={theme.palette.mode === "dark" ? step.sxDark : step.sxLight}
+        color="primary"
+      />
+    </GeneralTableCell>
+  );
+}

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Chip,
   Stack,
   Table,
   TableHead,
@@ -18,97 +17,10 @@ import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import MyDepositsStatusTooltip from "./Components/MyDepositsStatusTooltip";
+import StakingStatusIcon, {
+  STAKING_STATUS_STEPS,
+} from "./Components/StakingStatusIcon";
 import {getLockedUtilSecs} from "./utils";
-import LockIcon from "@mui/icons-material/Lock";
-import PendingIcon from "@mui/icons-material/Pending";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import {
-  STAKED_BACKGROUND_COLOR_DARK,
-  STAKED_BACKGROUND_COLOR_LIGHT,
-  STAKED_DESCRIPTION,
-  STAKED_LABEL,
-  STAKED_TEXT_COLOR_DARK,
-  STAKED_TEXT_COLOR_LIGHT,
-  WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
-  WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
-  WITHDRAW_PENDING_DESCRIPTION,
-  WITHDRAW_PENDING_LABEL,
-  WITHDRAW_PENDING_TEXT_COLOR_DARK,
-  WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
-  WITHDRAW_READY_BACKGROUND_COLOR_DARK,
-  WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
-  WITHDRAW_READY_DESCRIPTION,
-  WITHDRAW_READY_LABEL,
-  WITHDRAW_READY_TEXT_COLOR_DARK,
-  WITHDRAW_READY_TEXT_COLOR_LIGHT,
-} from "./constants";
-
-enum StakingStatusStep {
-  "staked",
-  "withdrawPending",
-  "withdrawReady",
-}
-type Steps = keyof typeof StakingStatusStep;
-
-export interface StakingStatusStepInterface {
-  label: string;
-  description: string;
-  icon: JSX.Element;
-  sxLight: {
-    color: string;
-    backgroundColor: string;
-  };
-  sxDark: {
-    color: string;
-    backgroundColor: string;
-  };
-}
-
-const steps = [
-  {
-    label: STAKED_LABEL,
-    description: STAKED_DESCRIPTION,
-    icon: <LockIcon />,
-    sxLight: {
-      color: STAKED_TEXT_COLOR_LIGHT,
-      backgroundColor: STAKED_BACKGROUND_COLOR_LIGHT,
-    },
-    sxDark: {
-      color: STAKED_TEXT_COLOR_DARK,
-      backgroundColor: STAKED_BACKGROUND_COLOR_DARK,
-    },
-  },
-  {
-    label: WITHDRAW_PENDING_LABEL,
-    description: WITHDRAW_PENDING_DESCRIPTION,
-    icon: <PendingIcon />,
-    sxLight: {
-      color: WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
-      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
-    },
-    sxDark: {
-      color: WITHDRAW_PENDING_TEXT_COLOR_DARK,
-      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
-    },
-  },
-  {
-    label: WITHDRAW_READY_LABEL,
-    description: WITHDRAW_READY_DESCRIPTION,
-    icon: <CheckCircleIcon />,
-    sxLight: {
-      color: WITHDRAW_READY_TEXT_COLOR_LIGHT,
-      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
-    },
-    sxDark: {
-      color: WITHDRAW_READY_TEXT_COLOR_DARK,
-      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_DARK,
-    },
-  },
-];
-
-type MyDepositsSectionProps = {
-  accountResource?: Types.MoveResource | undefined;
-};
 
 const MyDepositsCells = Object.freeze({
   amount: AmountCell,
@@ -152,20 +64,7 @@ function AmountCell({}: MyDepositsSectionProps) {
 }
 
 function StatusCell({}: MyDepositsSectionProps) {
-  const theme = useTheme();
-
-  // TODO(jill): temp workaround since we don't have status data yet
-  const step = steps[0];
-  return (
-    <GeneralTableCell>
-      <Chip
-        icon={step.icon}
-        label={step.label}
-        sx={theme.palette.mode === "dark" ? step.sxDark : step.sxLight}
-        color="primary"
-      />
-    </GeneralTableCell>
-  );
+  return <StakingStatusIcon />;
 }
 
 function UnlockDateCell({accountResource}: MyDepositsSectionProps) {
@@ -195,6 +94,10 @@ function ActionsCell({}: MyDepositsSectionProps) {
   );
 }
 
+type MyDepositsSectionProps = {
+  accountResource?: Types.MoveResource | undefined;
+};
+
 export default function MyDepositsSection({
   accountResource,
 }: MyDepositsSectionProps) {
@@ -220,9 +123,7 @@ export default function MyDepositsSection({
                 key={idx}
                 tooltip={
                   columnName === "status" && (
-                    <MyDepositsStatusTooltip
-                      steps={steps as [StakingStatusStepInterface]}
-                    />
+                    <MyDepositsStatusTooltip steps={STAKING_STATUS_STEPS} />
                   )
                 }
               />

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   Stack,
   Table,
   TableHead,
@@ -18,6 +19,92 @@ import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCel
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import MyDepositsStatusTooltip from "./Components/MyDepositsStatusTooltip";
 import {getLockedUtilSecs} from "./utils";
+import LockIcon from "@mui/icons-material/Lock";
+import PendingIcon from "@mui/icons-material/Pending";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import {
+  STAKED_BACKGROUND_COLOR_DARK,
+  STAKED_BACKGROUND_COLOR_LIGHT,
+  STAKED_DESCRIPTION,
+  STAKED_LABEL,
+  STAKED_TEXT_COLOR_DARK,
+  STAKED_TEXT_COLOR_LIGHT,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+  WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_PENDING_DESCRIPTION,
+  WITHDRAW_PENDING_LABEL,
+  WITHDRAW_PENDING_TEXT_COLOR_DARK,
+  WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+  WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+  WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+  WITHDRAW_READY_DESCRIPTION,
+  WITHDRAW_READY_LABEL,
+  WITHDRAW_READY_TEXT_COLOR_DARK,
+  WITHDRAW_READY_TEXT_COLOR_LIGHT,
+} from "./constants";
+
+enum StakingStatusStep {
+  "staked",
+  "withdrawPending",
+  "withdrawReady",
+}
+type Steps = keyof typeof StakingStatusStep;
+
+export interface StakingStatusStepInterface {
+  label: string;
+  description: string;
+  icon: JSX.Element;
+  sxLight: {
+    color: string;
+    backgroundColor: string;
+  };
+  sxDark: {
+    color: string;
+    backgroundColor: string;
+  };
+}
+
+const steps = [
+  {
+    label: STAKED_LABEL,
+    description: STAKED_DESCRIPTION,
+    icon: <LockIcon />,
+    sxLight: {
+      color: STAKED_TEXT_COLOR_LIGHT,
+      backgroundColor: STAKED_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: STAKED_TEXT_COLOR_DARK,
+      backgroundColor: STAKED_BACKGROUND_COLOR_DARK,
+    },
+  },
+  {
+    label: WITHDRAW_PENDING_LABEL,
+    description: WITHDRAW_PENDING_DESCRIPTION,
+    icon: <PendingIcon />,
+    sxLight: {
+      color: WITHDRAW_PENDING_TEXT_COLOR_LIGHT,
+      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: WITHDRAW_PENDING_TEXT_COLOR_DARK,
+      backgroundColor: WITHDRAW_PENDING_BACKGROUND_COLOR_DARK,
+    },
+  },
+  {
+    label: WITHDRAW_READY_LABEL,
+    description: WITHDRAW_READY_DESCRIPTION,
+    icon: <CheckCircleIcon />,
+    sxLight: {
+      color: WITHDRAW_READY_TEXT_COLOR_LIGHT,
+      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_LIGHT,
+    },
+    sxDark: {
+      color: WITHDRAW_READY_TEXT_COLOR_DARK,
+      backgroundColor: WITHDRAW_READY_BACKGROUND_COLOR_DARK,
+    },
+  },
+];
 
 type MyDepositsSectionProps = {
   accountResource?: Types.MoveResource | undefined;
@@ -65,7 +152,20 @@ function AmountCell({}: MyDepositsSectionProps) {
 }
 
 function StatusCell({}: MyDepositsSectionProps) {
-  return <GeneralTableCell>Staked</GeneralTableCell>;
+  const theme = useTheme();
+
+  // TODO(jill): temp workaround since we don't have status data yet
+  const step = steps[0];
+  return (
+    <GeneralTableCell>
+      <Chip
+        icon={step.icon}
+        label={step.label}
+        sx={theme.palette.mode === "dark" ? step.sxDark : step.sxLight}
+        color="primary"
+      />
+    </GeneralTableCell>
+  );
 }
 
 function UnlockDateCell({accountResource}: MyDepositsSectionProps) {
@@ -118,7 +218,13 @@ export default function MyDepositsSection({
                 }}
                 header={MyDepositsHeader[columnName]}
                 key={idx}
-                tooltip={columnName === "status" && <MyDepositsStatusTooltip />}
+                tooltip={
+                  columnName === "status" && (
+                    <MyDepositsStatusTooltip
+                      steps={steps as [StakingStatusStepInterface]}
+                    />
+                  )
+                }
               />
             ))}
           </TableRow>


### PR DESCRIPTION
share this step status across tooltip and table row. 

<img width="113" alt="Screenshot 2023-01-27 at 11 36 53 AM" src="https://user-images.githubusercontent.com/121921928/215181608-8c96f66a-18ca-426a-b965-27802968aae8.png">
