### PR TITLE
[explorer][hot-fix] validators page geoData null issue

### DIFF
--- a/src/api/hooks/useGetMainnetValidatorsGeoData.ts
+++ b/src/api/hooks/useGetMainnetValidatorsGeoData.ts
@@ -40,7 +40,7 @@ export function useGetValidatorSetGeoData() {
     const groups: ValidatorGeoGroup[] = validators.reduce(
       (groups: ValidatorGeoGroup[], validatorData: MainnetValidatorData) => {
         const geoData = validatorData.location_stats;
-        const country = geoData.country;
+        const country = geoData?.country;
         if (!country) {
           return groups;
         }


### PR DESCRIPTION
<img width="370" alt="Screenshot 2023-01-30 at 11 20 06 AM" src="https://user-images.githubusercontent.com/121921928/215574542-4c56d203-45be-419b-a41c-8b32a1fe2eee.png">


validators page fail to load due to country potentially being null for this validator
<img width="1242" alt="Screenshot 2023-01-30 at 11 20 48 AM" src="https://user-images.githubusercontent.com/121921928/215574823-0b1e55d9-6c8c-4167-b2d6-1e646864ab0d.png">


