### PR TITLE
[explorer][delegation] address some nits

### DIFF
--- a/src/pages/DelegatoryValidator/Components/TimeDurationIntervalBar.tsx
+++ b/src/pages/DelegatoryValidator/Components/TimeDurationIntervalBar.tsx
@@ -6,8 +6,12 @@ import {parseTimestamp, timestampDisplay} from "../../utils";
 export default function TimeDurationIntervalBar({
   timestamp,
 }: {
-  timestamp: number;
+  timestamp?: number;
 }) {
+  if (!timestamp) {
+    return null;
+  }
+
   // the beginning of the unlock cycle
   const startTime = parseTimestamp(timestamp.toString()).subtract(30, "days");
 

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -1,4 +1,4 @@
-import {Box, Skeleton, Stack, useMediaQuery, useTheme} from "@mui/material";
+import {Skeleton, Stack, useMediaQuery, useTheme} from "@mui/material";
 import * as React from "react";
 import HashButton from "../../components/HashButton";
 import ContentBox from "../../components/IndividualPageContent/ContentBox";
@@ -48,10 +48,9 @@ export default function ValidatorDetailCard({
       setIsSkeletonLoading(false);
     }
   }, [lockedUntilSecs, operatorAddr, rewardGrowth, stakePoolAddress]);
-
-  // TODO: revisit layout for mobile
+  
   return isSkeletonLoading ? (
-    validatorDetailCardSkeleton()
+    validatorDetailCardSkeleton({isOnMobile})
   ) : (
     <Stack direction={isOnMobile ? "column" : "row"} spacing={4}>
       <ContentBox width={isOnMobile ? "100%" : "50%"} marginTop={0}>
@@ -106,22 +105,21 @@ export default function ValidatorDetailCard({
   );
 }
 
-// TODO: revisit skeleton for mobile
-function validatorDetailCardSkeleton() {
+function validatorDetailCardSkeleton({isOnMobile}: {isOnMobile: boolean}) {
   return (
-    <Box display="flex">
-      <ContentBox padding={4} width="50%">
+    <Stack direction={isOnMobile ? "column" : "row"} spacing={4}>
+      <ContentBox width={isOnMobile ? "100%" : "50%"} marginTop={0}>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
       </ContentBox>
-      <ContentBox padding={4} width="50%">
+      <ContentBox width={isOnMobile ? "100%" : "50%"} marginTop={0}>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
         <Skeleton></Skeleton>
       </ContentBox>
-    </Box>
+    </Stack>
   );
 }

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -48,7 +48,7 @@ export default function ValidatorDetailCard({
       setIsSkeletonLoading(false);
     }
   }, [lockedUntilSecs, operatorAddr, rewardGrowth, stakePoolAddress]);
-  
+
   return isSkeletonLoading ? (
     validatorDetailCardSkeleton({isOnMobile})
   ) : (

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -70,6 +70,9 @@ function StatusCell({}: MyDepositsSectionProps) {
 
 function UnlockDateCell({accountResource}: MyDepositsSectionProps) {
   const lockedUntilSecs = getLockedUtilSecs(accountResource);
+  if (!lockedUntilSecs) {
+    return null;
+  }
   return (
     <GeneralTableCell>
       <TimestampValue timestamp={lockedUntilSecs?.toString()!} />

--- a/src/pages/DelegatoryValidator/StakeDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeDialog.tsx
@@ -30,6 +30,7 @@ type StakeDialogProps = {
   accountResource?: Types.MoveResource | undefined;
 };
 
+// TODO(jill): pre-check whether wallet has enough APT to stake
 export default function StakeDialog({
   handleDialogClose,
   isDialogOpen,
@@ -38,7 +39,7 @@ export default function StakeDialog({
   const {rewardsRateYearly} = useGetStakingRewardsRate();
 
   const lockedUntilSecs = getLockedUtilSecs(accountResource);
-  const [stakedAmount, setStakedAmount] = useState<string>();
+  const [stakedAmount, setStakedAmount] = useState<string>("");
   const [stakedAmountError, setStakedAmountError] = useState<boolean>(false);
   const handleStakedAmountChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -50,10 +51,8 @@ export default function StakeDialog({
 
   return (
     <StyledDialog handleDialogClose={handleDialogClose} open={isDialogOpen}>
-      <DialogTitle>
-        <Typography variant="h5" textAlign="center">
-          Stake Into The Pool
-        </Typography>
+      <DialogTitle variant="h5" textAlign="center">
+        Stake Into The Pool
       </DialogTitle>
       <DialogContent>
         <Stack direction="column" spacing={2}>

--- a/src/pages/DelegatoryValidator/UnstakeDialog.tsx
+++ b/src/pages/DelegatoryValidator/UnstakeDialog.tsx
@@ -44,10 +44,8 @@ export default function UnstakeDialog({
 
   return (
     <StyledDialog handleDialogClose={handleDialogClose} open={isDialogOpen}>
-      <DialogTitle>
-        <Typography variant="h5" textAlign="center">
-          Unstake funds
-        </Typography>
+      <DialogTitle variant="h5" textAlign="center">
+        Unstake funds
       </DialogTitle>
       <DialogContent>
         <Stack direction="column" spacing={2}>

--- a/src/pages/DelegatoryValidator/WalletConnectionDialog.tsx
+++ b/src/pages/DelegatoryValidator/WalletConnectionDialog.tsx
@@ -29,10 +29,8 @@ export default function WalletConnectionDialog({
       <Box sx={{display: "flex", justifyContent: "center", marginY: 2}}>
         <ConnectWalletModalIcon />
       </Box>
-      <DialogTitle>
-        <Typography variant="h5" textAlign="center">
-          Please connect your wallet
-        </Typography>
+      <DialogTitle textAlign="center">
+        <div>Please connect your wallet</div>
         <Typography variant="caption" textAlign="center">
           You need to connect your wallet to be able to stake
         </Typography>

--- a/src/pages/Validators/Index.tsx
+++ b/src/pages/Validators/Index.tsx
@@ -30,16 +30,7 @@ export default function ValidatorsPage() {
     );
 
   const validatorsTabs = (
-    <StyledTabs
-      sx={{
-        width: "100%",
-        "@media screen and (min-width: 40em)": {
-          width: "40%",
-        },
-      }}
-      value={onDelegatory}
-      onChange={handleTabChange}
-    >
+    <StyledTabs value={onDelegatory} onChange={handleTabChange}>
       <StyledTab
         value={false}
         label={

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -9,7 +9,7 @@ import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import RewardsPerformanceTooltip from "./Components/RewardsPerformanceTooltip";
 import LastEpochPerformanceTooltip from "./Components/LastEpochPerformanceTooltip";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
-import {useNavigate, useSearchParams} from "react-router-dom";
+import {useNavigate} from "react-router-dom";
 import {Types} from "aptos";
 import {
   MainnetValidatorData,
@@ -321,16 +321,11 @@ type ValidatorRowProps = {
 function ValidatorRow({validator, columns}: ValidatorRowProps) {
   const inDev = useGetInDevMode();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
 
   const rowClick = (address: Types.Address) => {
     // TODO(jill) find long term to persist the url params
-    const isUsingDev = searchParams.get("feature");
-
     navigate(
-      isUsingDev
-        ? `/validator/${address}?feature=dev`
-        : `/validator/${address}`,
+      inDev ? `/validator/${address}?feature=dev` : `/validator/${address}`,
     );
   };
 

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, {useState} from "react";
 import {Box, Stack, Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
@@ -9,7 +9,7 @@ import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import RewardsPerformanceTooltip from "./Components/RewardsPerformanceTooltip";
 import LastEpochPerformanceTooltip from "./Components/LastEpochPerformanceTooltip";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
-import {useNavigate} from "react-router-dom";
+import {useNavigate, useSearchParams} from "react-router-dom";
 import {Types} from "aptos";
 import {
   MainnetValidatorData,
@@ -321,9 +321,17 @@ type ValidatorRowProps = {
 function ValidatorRow({validator, columns}: ValidatorRowProps) {
   const inDev = useGetInDevMode();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const rowClick = (address: Types.Address) => {
-    navigate(`/validator/${address}`);
+    // TODO(jill) find long term to persist the url params
+    const isUsingDev = searchParams.get("feature");
+
+    navigate(
+      isUsingDev
+        ? `/validator/${address}?feature=dev`
+        : `/validator/${address}`,
+    );
   };
 
   return (


### PR DESCRIPTION
https://user-images.githubusercontent.com/121921928/215843907-763aa198-e369-450d-88fe-7c06a22c04ac.mov

couple things this pr addressed:

1. on the validators page, the tab has underline colors previously. pr updated to get rid of the color and remain consistent with tab usages in other places
2. lockedUtilSecs could be nullable. check it whether it's null or not before hands. this eliminates the error in the react console.
3.  make details page skeleton mobile friendly
4. address react console warning on dialog font size complain: "h5 can't be in h2"
5. short term sol:  persist the dev param in the url from the validators page to the validator page


