### PR TITLE
WP-289 fix Epoch over 100% if page's not reloaded

### DIFF
--- a/src/pages/Validators/Components/Epoch.tsx
+++ b/src/pages/Validators/Components/Epoch.tsx
@@ -49,6 +49,7 @@ export default function Epoch({isSkeletonLoading}: EpochProps) {
 
     refresh();
     const refreshInterval = setInterval(refresh, 60 * 1000); // refresh every minute
+
     if (timeRemainingInMin !== undefined && parseInt(timeRemainingInMin) <= 0) {
       clearInterval(refreshInterval);
     }

--- a/src/pages/Validators/Components/Epoch.tsx
+++ b/src/pages/Validators/Components/Epoch.tsx
@@ -34,6 +34,9 @@ export default function Epoch({isSkeletonLoading}: EpochProps) {
           .asMinutes();
 
         const timeRemaining = (epochIntervalInMin - timePassedInMin).toFixed(0);
+        if (epochIntervalInMin <= timePassedInMin) {
+          window.location.reload();
+        }
         setTimeRemainingInMin(timeRemaining);
 
         const percentage = (
@@ -46,7 +49,6 @@ export default function Epoch({isSkeletonLoading}: EpochProps) {
 
     refresh();
     const refreshInterval = setInterval(refresh, 60 * 1000); // refresh every minute
-
     if (timeRemainingInMin !== undefined && parseInt(timeRemainingInMin) <= 0) {
       clearInterval(refreshInterval);
     }


### PR DESCRIPTION
WP-289


https://user-images.githubusercontent.com/121921928/215924185-ce220243-2f8f-45ad-938e-9b8a70d44918.mov


jsyk, me playing around with react inspector has nothing to do with the page reloading, its just the timing. 
