### PR TITLE
[explorer][analysis] fix the value format in Gas Consumption chart WP-296

### DIFF
--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -14,8 +14,8 @@ export function getFormattedBalanceStr(
   decimals?: number,
   fixedDecimalPlaces?: number,
 ): string {
-  // If it's zero, just return it
-  if (balance == "0") {
+  // If balance is zero or decimals is 0, just return it
+  if (balance == "0" || (decimals !== undefined && decimals === 0)) {
     return balance;
   }
 

--- a/src/pages/Analytics/Charts/DailyGasConsumptionChart.tsx
+++ b/src/pages/Analytics/Charts/DailyGasConsumptionChart.tsx
@@ -22,7 +22,6 @@ export default function DailyGasConsumptionChart({
 }: DailyGasConsumptionChartProps) {
   const labels = getLabels(data, days);
   const dataset = getDataset(data, days);
-
   return (
     <CardOutline>
       <ChartTitle
@@ -35,7 +34,7 @@ export default function DailyGasConsumptionChart({
         fill
         tooltipsLabelFunc={(context: any) => {
           const priceInteger = Math.round(context.parsed.y).toString();
-          const priceInAPT = getFormattedBalanceStr(priceInteger, 8);
+          const priceInAPT = getFormattedBalanceStr(priceInteger, 0);
           return `${priceInAPT} APT`;
         }}
       />


### PR DESCRIPTION
this value should be total daily gas consumed in APT. according to the data source from this [chat thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1675115093212439), we don't need to set decimal as 8 cuz its already pre-computed in 
```
select date(timestamp) ds, sum(t.gas_used*ut.gas_unit_price)/1e8 gas_cost
from `indexer_mainnet_gcp.transactions_view` t  
join `indexer_mainnet_gcp.user_transactions` ut 
on t.version = ut.version
where t.success = true
group by 1 order by 1
```

<img width="290" alt="Screenshot 2023-02-06 at 12 23 24 PM" src="https://user-images.githubusercontent.com/121921928/217077244-6658a0c8-8f51-4d50-b2f4-50940af6b79b.png">
