### PR TITLE
[explorer][delegation] fresh out my deposit sections with staking info

### DIFF
--- a/src/api/hooks/useGetDelegatorStakeInfo.ts
+++ b/src/api/hooks/useGetDelegatorStakeInfo.ts
@@ -1,4 +1,4 @@
-import {Types} from "aptos";
+import {AptosClient, Types} from "aptos";
 import {useState, useEffect} from "react";
 import {getStake} from "..";
 import {useGlobalState} from "../../GlobalState";
@@ -6,15 +6,16 @@ import {useGlobalState} from "../../GlobalState";
 export function useGetDelegatorStakeInfo(delegatorAddress: Types.Address) {
   const [state, _] = useGlobalState();
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [stake, setStake] = useState<Types.MoveValue[]>([]);
+  const [stakes, setStakes] = useState<Types.MoveValue[]>([]);
+  const client = new AptosClient(state.network_value);
 
   useEffect(() => {
     const fetchData = async () => {
-      setStake(await getStake(state.network_value, delegatorAddress));
+      setStakes(await getStake(client, delegatorAddress));
       setIsLoading(false);
     };
     fetchData();
-  }, [state]);
+  }, [state.network_value]);
 
-  return {stake, isLoading};
+  return {stakes, isLoading};
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -190,10 +190,9 @@ export async function getRecentBlocks(
 }
 
 export async function getStake(
-  nodeUrl: string,
+  client: AptosClient,
   delegatorAddress: Types.Address,
 ): Promise<Types.MoveValue[]> {
-  const client = new AptosClient(nodeUrl);
   const payload: Types.ViewRequest = {
     function: `${DELEGATION_POOL_ADDRESS}::delegation_pool::get_stake`,
     type_arguments: [],

--- a/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
+++ b/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
@@ -88,11 +88,14 @@ export const STAKING_STATUS_STEPS: StakingStatusStepInterface[] = [
   },
 ];
 
-export default function StakingStatusIcon() {
+type StakingStatusIconProps = {
+  status: number;
+};
+
+export default function StakingStatusIcon({status}: StakingStatusIconProps) {
   const theme = useTheme();
 
-  // TODO(jill): temp workaround since we don't have status data yet
-  const step = STAKING_STATUS_STEPS[0];
+  const step = STAKING_STATUS_STEPS[status];
   return (
     <GeneralTableCell>
       <Chip

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -9,11 +9,13 @@ import {HexString} from "aptos";
 import {useGetValidators} from "../../api/hooks/useGetValidators";
 import MyDepositsSection from "./MyDepositsSection";
 import {useGetAccountResource} from "../../api/hooks/useGetAccountResource";
+import {useWallet} from "@aptos-labs/wallet-adapter-react";
 
 export default function ValidatorPage() {
   const address = useParams().address ?? "";
   const addressHex = new HexString(address);
   const {validators} = useGetValidators();
+  const {connected} = useWallet();
   const validator = validators.find(
     (validator) => validator.owner_address === addressHex.hex(),
   );
@@ -40,7 +42,7 @@ export default function ValidatorPage() {
             address={address}
             accountResource={accountResource}
           />
-          <MyDepositsSection accountResource={accountResource} />
+          {connected && <MyDepositsSection accountResource={accountResource} />}
         </Stack>
       </Grid>
     </Grid>


### PR DESCRIPTION
| before | after |
| --------------- | --------------- |
| <img width="153" alt="Screenshot 2023-02-16 at 12 20 28 PM" src="https://user-images.githubusercontent.com/121921928/219478049-dc93f6fe-0a37-46c2-9756-ee5415630994.png"> | <img width="375" alt="Screenshot 2023-02-16 at 12 23 16 PM" src="https://user-images.githubusercontent.com/121921928/219478644-13369568-d872-4d4f-bb02-1d8327969abf.png"> |

### changes in pr
1. get the stake info from sc view functions so that now we have (active, inactive, pending_inactive) stake info for a delegator
2. modify the my deposit section to use this stake info