### PR TITLE
[explorer][delegation] add rewards earned computation

### DIFF
--- a/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
+++ b/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
@@ -1,0 +1,59 @@
+import {ApolloError, gql, useQuery as useGraphqlQuery} from "@apollo/client";
+import {Types} from "aptos";
+
+export interface DelegatedStakingActivity {
+  amount: number;
+  delegator_address: Types.Address;
+  event_index: number;
+  event_type: string;
+  pool_address: Types.Address;
+  transaction_version: bigint;
+}
+
+const DELEGATED_STAKING_ACTIVITY_QUERY = gql`
+  query delegatedStakingActivities(
+    $delegatorAddress: String
+    $poolAddress: String
+  ) {
+    delegated_staking_activities(
+      where: {
+        delegator_address: {_eq: $delegatorAddress}
+        pool_address: {_eq: $poolAddress}
+      }
+    ) {
+      amount
+      delegator_address
+      event_index
+      event_type
+      pool_address
+      transaction_version
+    }
+  }
+`;
+
+export function useGetDelegatedStakeOperationActivities(
+  delegatorAddress: Types.Address,
+  poolAddress: Types.Address,
+): {
+  activities: DelegatedStakingActivity[] | undefined;
+  loading: boolean;
+  error: ApolloError | undefined;
+} {
+  // whenever talking to the indexer, the address needs to fill in leading 0s
+  // for example: 0x123 => 0x000...000123  (61 0s before 123)
+  const delegatorAddress64Hash =
+    "0x" + delegatorAddress.substring(2).padStart(64, "0");
+  const poolAddress64Hash = "0x" + poolAddress.substring(2).padStart(64, "0");
+
+  const {loading, error, data} = useGraphqlQuery(
+    DELEGATED_STAKING_ACTIVITY_QUERY,
+    {
+      variables: {
+        delegatorAddress: delegatorAddress64Hash,
+        poolAddress: poolAddress64Hash,
+      },
+    },
+  );
+
+  return {activities: data?.delegated_staking_activities, loading, error};
+}

--- a/src/pages/DelegatoryValidator/utils.tsx
+++ b/src/pages/DelegatoryValidator/utils.tsx
@@ -1,4 +1,8 @@
 import {Types} from "aptos";
+import {
+  DelegatedStakingActivity,
+  useGetDelegatedStakeOperationActivities,
+} from "../../api/hooks/useGetDelegatedStakeOperationActivities";
 
 interface AccountResourceData {
   locked_until_secs: bigint;
@@ -11,4 +15,98 @@ export function getLockedUtilSecs(
   return accountResource
     ? BigInt((accountResource.data as AccountResourceData).locked_until_secs)
     : null;
+}
+
+export type StakePrincipals = {
+  activePrincipals: number;
+  pendingInactivePrincipals: number;
+};
+
+/**
+ *
+ * @param delegatorAddress
+ * @param poolAddress
+ * @returns stakePrincipals: active stake principal, pending_inactive stake principal
+ *          isLoading
+ *
+ * Step 1:
+ *    get total amount of (active, inactive, pending_inactive) from `get_stake` SC delegation_pool view function
+ *
+ * Step 2:
+ *    Calculate “principal”
+ *
+ *    Active_principal
+ *    Loop through all events in sequence (transaction_version asc, event_index asc)
+ *    Maintain a current active_principal variable, start with 0
+ *    Every time you see AddStakeEvent, add to active_principal
+ *    Every time you see UnlockStakeEvent, subtract from active_principal
+ *    Every time you see ReactivateStakeEvent, add to active_principal
+ *    If at any point during the loop active_principal < 0, reset to 0
+ *
+ *    Pending_inactive_principal
+ *    Loop through all events in sequence (transaction_version asc, event_index asc)
+ *    Maintain a current pending_inactive_principal variable, start with 0
+ *    Every time you see UnlockStakeEvent, add to pending_inactive_principal
+ *    Every time you see ReactivateStakeEvent, subtract from pending_inactive_principal
+ *    Every time you see WithdrawStakeEvent, subtract from pending_inactive_principal
+ *    If at any point during the loop pending_inactive_principal < 0, reset to 0
+ *
+ * Step 3
+ *    Active_rewards = active - Active_principal
+ *    Pending_inactive_rewards = pending_inactive - Pending_inactive_principal
+ */
+export function getStakeOperationPrincipals(
+  delegatorAddress: Types.Address,
+  poolAddress: Types.Address,
+): {stakePrincipals: StakePrincipals | undefined; isLoading: boolean} {
+  const result = useGetDelegatedStakeOperationActivities(
+    delegatorAddress,
+    poolAddress,
+  );
+
+  if (result.error) {
+    return {stakePrincipals: undefined, isLoading: false};
+  } else if (result.loading || !result.activities) {
+    return {stakePrincipals: undefined, isLoading: result.loading};
+  }
+
+  let activePrincipals = 0;
+  let pendingInactivePrincipals = 0;
+
+  const activitiesCopy: DelegatedStakingActivity[] = JSON.parse(
+    JSON.stringify(result.activities!),
+  );
+
+  activitiesCopy
+    .sort(
+      (a, b) => Number(a.transaction_version) - Number(b.transaction_version),
+    )
+    .map((activity: DelegatedStakingActivity) => {
+      const eventType = activity.event_type.split("::")[2];
+      const amount = activity.amount;
+      switch (eventType) {
+        case "AddStakeEvent":
+          activePrincipals += amount;
+          break;
+        case "UnlockStakeEvent":
+          activePrincipals -= amount;
+          pendingInactivePrincipals += amount;
+          break;
+        case "ReactivateStakeEvent":
+          activePrincipals += amount;
+          pendingInactivePrincipals -= amount;
+          break;
+        case "WithdrawStakeEvent":
+          pendingInactivePrincipals -= amount;
+          break;
+      }
+      activePrincipals = activePrincipals < 0 ? 0 : activePrincipals;
+      pendingInactivePrincipals =
+        pendingInactivePrincipals < 0 ? 0 : pendingInactivePrincipals;
+    });
+
+  return {
+    stakePrincipals: {activePrincipals, pendingInactivePrincipals},
+    isLoading: false,
+  };
 }


### PR DESCRIPTION
[gdoc that's helpful to understand the logic here](https://docs.google.com/document/d/1aTZv7su2FW0mNVDxz5b48-WsOkw3GhZ551Petr4-StM/edit#heading=h.bm8uprtpmfww)

[slack thread that discusses this in depth](https://aptos-org.slack.com/archives/C04EXV6UTR7/p1676623842397019)

```

Step 1: 
get total amount of (active, inactive, pending_inactive) from get_stake

Step 2:
Calculate “principal”

Active_principal
Loop through all events in sequence (transaction_version asc, event_index asc)
Maintain a current active_principal variable, start with 0
Every time you see AddStakeEvent, add to active_principal
Every time you see UnlockStakeEvent, subtract from active_principal
Every time you see ReactivateStakeEvent, add to active_principal
If at any point during the loop active_principal < 0, reset to 0

Pending_inactive_principal
Loop through all events in sequence (transaction_version asc, event_index asc)
Maintain a current pending_inactive_principal variable, start with 0
Every time you see UnlockStakeEvent, add to pending_inactive_principal
Every time you see ReactivateStakeEvent, subtract from pending_inactive_principal
Every time you see WithdrawStakeEvent, subtract from pending_inactive_principal
If at any point during the loop pending_inactive_principal < 0, reset to 0

Step 3
Active_rewards = active - Active_principal
Pending_inactive_rewards = pending_inactive - Pending_inactive_principal

```
https://user-images.githubusercontent.com/121921928/220226549-ca6c71ea-5945-4a71-9953-2aefcbdfb2e4.mov

