### PR TITLE
[explorer] update the primary color for explorer

### DIFF
--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -65,7 +65,7 @@ declare module "@mui/material/Divider" {
 }
 
 const primaryColor = primary["400"];
-const primaryColorToned = primary["600"];
+const primaryColorToned = primary["500"];
 
 const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   shape: {


### PR DESCRIPTION
# change
I notice that in explorer, we have different primaryColorToned. We used `primary[600]` but ANS uses `primary[500]`. to keep the consistency, i believe it makes sense to keep both of them as `primary[500]` so that all the components that's primary will show consistent color palette. 

| before | after |
| -- | -- |
| <img width="1726" alt="Screenshot 2023-02-20 at 5 48 34 PM" src="https://user-images.githubusercontent.com/121921928/220227252-d8dc2628-ac6a-4594-b458-2843e01a73c9.png"> | <img width="1726" alt="Screenshot 2023-02-20 at 5 48 16 PM" src="https://user-images.githubusercontent.com/121921928/220227249-4eaf61b2-01c0-45a5-99ab-b123f1a94af8.png"> |
