### PR TITLE
[explorer][delegation] handle bigint overflow when submitting txn

### DIFF
--- a/src/api/hooks/useSubmitStakeOperation.ts
+++ b/src/api/hooks/useSubmitStakeOperation.ts
@@ -1,5 +1,5 @@
 import {Types} from "aptos";
-import {DELEGATION_POOL_ADDRESS, OCTA} from "../../constants";
+import {DELEGATION_POOL_ADDRESS} from "../../constants";
 import useSubmitTransaction from "./useSubmitTransaction";
 
 // enum name => delegation pool smart contract view function name
@@ -27,7 +27,7 @@ const useSubmitStakeOperation = () => {
       type: "entry_function_payload",
       function: `${DELEGATION_POOL_ADDRESS}::delegation_pool::${stakeOperation}`,
       type_arguments: [],
-      arguments: [owner_address, amount * OCTA], // staking operation uses OCTA as amount basis
+      arguments: [owner_address, amount], // staking operation uses OCTA as amount basis
     };
 
     await submitTransaction(payload);

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -91,7 +91,7 @@ export default function StakeOperationDialog({
     if (isAmountValid) {
       await submitStakeOperation(
         validator.owner_address,
-        Number(Number(amount).toFixed(8)),
+        Number((Number(amount) * OCTA).toFixed(0)),
         stakeOperation,
       );
     }

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -27,7 +27,6 @@ import TransactionSucceededDialog from "./TransactionSucceededDialog";
 import useSubmitStakeOperation, {
   StakeOperation,
 } from "../../api/hooks/useSubmitStakeOperation";
-import {getFormattedBalanceStr} from "../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import {MIN_ADD_STAKE_AMOUNT, OCTA} from "../../constants";
 
 type StakeOperationDialogProps = {
@@ -92,7 +91,7 @@ export default function StakeOperationDialog({
     if (isAmountValid) {
       await submitStakeOperation(
         validator.owner_address,
-        Number(amount),
+        Number(Number(amount).toFixed(8)),
         stakeOperation,
       );
     }
@@ -198,13 +197,7 @@ export default function StakeOperationDialog({
                   key={idx}
                   variant="outlined"
                   onClick={() =>
-                    setAmount(
-                      (
-                        Number(
-                          getFormattedBalanceStr(Number(stake).toString()),
-                        ) * percentage
-                      ).toString(),
-                    )
+                    setAmount(((Number(stake) * percentage) / OCTA).toString())
                   }
                 >
                   {percentage === 1 ? "MAX" : `${percentage * 100}%`}


### PR DESCRIPTION
stake amount is bigint, it can only take amount thats in the signed bigint range. however, it's easy to exceed that limit and overflow. right now, this pr used `toFixed(8)` to handle the limit but its not ideal.  open for suggestions on how to better handle this situation. 

### before 
https://user-images.githubusercontent.com/121921928/220262873-83a21638-b7a3-472f-92b2-3fa76381a7e2.mov

### after
https://user-images.githubusercontent.com/121921928/220262878-ce6aa345-3d26-4357-a755-b2d6aca20299.mov

