### PR TITLE
[explorer] add source code to modules tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "date-fns": "^2.29.1",
     "fewcha-plugin-wallet-adapter": "^0.1.1",
     "graphql": "^16.6.0",
+    "highlight.js": "^11.7.0",
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
+    "pako": "^2.1.0",
     "petra-plugin-wallet-adapter": "^0.1.3",
     "prettier": "^2.6.2",
     "react": "latest",
@@ -68,5 +70,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/pako": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "date-fns": "^2.29.1",
     "fewcha-plugin-wallet-adapter": "^0.1.1",
     "graphql": "^16.6.0",
-    "highlight.js": "^11.7.0",
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
@@ -48,6 +47,7 @@
     "react-router-dom": "^6.2.1",
     "react-scripts": "latest",
     "react-simple-maps": "^3.0.0",
+    "react-syntax-highlighter": "^15.5.0",
     "recharts": "^2.1.9",
     "ts-results": "^3.3.0",
     "typescript": "latest"
@@ -72,6 +72,7 @@
     ]
   },
   "devDependencies": {
-    "@types/pako": "^2.0.0"
+    "@types/pako": "^2.0.0",
+    "@types/react-syntax-highlighter": "^15.5.6"
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -148,6 +148,27 @@ export function getAccountModules(
   );
 }
 
+export function getAccountModule(
+  requestParameters: {
+    address: string;
+    moduleName: string;
+    ledgerVersion?: number;
+  },
+  nodeUrl: string,
+): Promise<Types.MoveModuleBytecode> {
+  const client = new AptosClient(nodeUrl);
+  const {address, moduleName, ledgerVersion} = requestParameters;
+  let ledgerVersionBig;
+  if (ledgerVersion !== undefined) {
+    ledgerVersionBig = BigInt(ledgerVersion);
+  }
+  return withResponseError(
+    client.getAccountModule(address, moduleName, {
+      ledgerVersion: ledgerVersionBig,
+    }),
+  );
+}
+
 export function getTableItem(
   requestParameters: {tableHandle: string; data: Types.TableItemRequest},
   nodeUrl: string,

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -1,26 +1,72 @@
 import {Types} from "aptos";
-import {Box} from "@mui/material";
+import {Box, Grid, Stack, Typography, useTheme} from "@mui/material";
 import React from "react";
+import {orderBy} from "lodash";
+import "highlight.js/styles/github.css";
+import hljs from "highlight.js";
 import Error from "../Error";
 import {useGlobalState} from "../../../GlobalState";
 import {ResponseError} from "../../../api/client";
 import {useQuery} from "react-query";
-import {getAccountModules} from "../../../api";
+import {getAccountModules, getAccountModule} from "../../../api";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {useGetAccountResource} from "../../../api/hooks/useGetAccountResource";
+import {useGetInDevMode} from "../../../api/hooks/useGetInDevMode";
+import {transformCode} from "../../../utils";
+import {grey} from "../../../themes/colors/aptosColorPalette";
 
-function ModulesContent({
-  data,
-}: {
-  data: Types.MoveModuleBytecode[] | undefined;
-}): JSX.Element {
+type PackageMetadata = {
+  name: string;
+  modules: {
+    name: string;
+    source: string;
+  }[];
+};
+
+interface ModuleSidebarProps {
+  moduleNames: string[];
+  selectedModuleIndex: number;
+  setSelectedModuleIndex: (index: number) => void;
+}
+
+interface ModuleNameOptionProps {
+  handleClick: () => void;
+  selected: boolean;
+  name: string;
+}
+
+interface ModuleContentProps {
+  address: string;
+  moduleName: string;
+  sourceCode: string;
+}
+
+function ModulesContent({address}: {address: string}) {
+  const [state, _] = useGlobalState();
+
+  const {isLoading, data, error} = useQuery<
+    Array<Types.MoveModuleBytecode>,
+    ResponseError
+  >(["accountModules", {address}, state.network_value], () =>
+    getAccountModules({address}, state.network_value),
+  );
+
   const modules: Types.MoveModuleBytecode[] = data ?? [];
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(modules.length);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (error) {
+    return <Error address={address} error={error} />;
+  }
 
   if (modules.length === 0) {
     return <EmptyTabContent />;
@@ -55,19 +101,153 @@ function ModulesContent({
   );
 }
 
-type ModulesTabProps = {
-  address: string;
-  accountData: Types.AccountData | undefined;
-};
+function ModulesContentReworked({address}: {address: string}): JSX.Element {
+  const {data: registry} = useGetAccountResource(
+    address,
+    "0x1::code::PackageRegistry",
+  );
 
-export default function ModulesTab({address}: ModulesTabProps) {
+  const [selectedModuleIndex, setSelectedModuleIndex] =
+    React.useState<number>(0);
+
+  const packages: PackageMetadata[] =
+    registry === undefined ? [] : (registry.data as any).packages;
+  const modules = orderBy(
+    packages.flatMap((p) => p.modules),
+    "name",
+  );
+
+  if (modules.length === 0) {
+    return <EmptyTabContent />;
+  }
+
+  return (
+    <Grid container spacing={2} marginTop="24px">
+      <Grid
+        item
+        md={3}
+        sx={{
+          maxHeight: "500px",
+          overflowY: "auto",
+        }}
+      >
+        <ModuleSidebar
+          moduleNames={modules.map((m) => m.name)}
+          selectedModuleIndex={selectedModuleIndex}
+          setSelectedModuleIndex={setSelectedModuleIndex}
+        />
+      </Grid>
+      <Grid item md={9}>
+        <ModuleContent
+          address={address}
+          moduleName={modules[selectedModuleIndex].name}
+          sourceCode={modules[selectedModuleIndex].source}
+        />
+      </Grid>
+    </Grid>
+  );
+}
+
+function ModuleSidebar({
+  moduleNames,
+  selectedModuleIndex,
+  setSelectedModuleIndex,
+}: ModuleSidebarProps) {
+  return (
+    <Box sx={{padding: "24px"}}>
+      <Typography fontSize={16} fontWeight={500} marginBottom={"24px"}>
+        Modules
+      </Typography>
+      {moduleNames.map((moduleName, i) => (
+        <ModuleNameOption
+          key={i}
+          handleClick={() => setSelectedModuleIndex(i)}
+          selected={i === selectedModuleIndex}
+          name={moduleName}
+        />
+      ))}
+    </Box>
+  );
+}
+
+function ModuleNameOption({
+  handleClick,
+  selected,
+  name,
+}: ModuleNameOptionProps) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      key={name}
+      onClick={handleClick}
+      sx={{
+        fontSize: 12,
+        fontWeight: 500,
+        padding: "8px",
+        bgcolor: !selected
+          ? "transparent"
+          : theme.palette.mode === "dark"
+          ? grey[500]
+          : grey[200],
+        ":hover": {
+          cursor: "pointer",
+        },
+      }}
+    >
+      {name}
+    </Box>
+  );
+}
+
+function ModuleContent({address, moduleName, sourceCode}: ModuleContentProps) {
+  React.useEffect(() => {
+    hljs.highlightAll();
+  });
+
+  return (
+    <Stack direction="column" spacing={2} padding={"24px"}>
+      <Typography fontSize={28} fontWeight={700}>
+        {moduleName}
+      </Typography>
+      <Code sourceCode={sourceCode} />
+      <ABI address={address} moduleName={moduleName} />
+    </Stack>
+  );
+}
+
+function Code({sourceCode}: {sourceCode: string}) {
+  return (
+    <Box>
+      <Typography fontSize={24} fontWeight={700} marginY={"16px"}>
+        Code
+      </Typography>
+      <Box
+        sx={{
+          maxHeight: "500px",
+          overflowY: "auto",
+          border: "1px solid",
+          borderRadius: 1,
+        }}
+      >
+        <pre>
+          <code className="language-rust">{transformCode(sourceCode)}</code>
+        </pre>
+      </Box>
+    </Box>
+  );
+}
+
+function ABI({address, moduleName}: {address: string; moduleName: string}) {
   const [state, _] = useGlobalState();
 
-  const {isLoading, data, error} = useQuery<
-    Array<Types.MoveModuleBytecode>,
-    ResponseError
-  >(["accountModules", {address}, state.network_value], () =>
-    getAccountModules({address}, state.network_value),
+  const {
+    isLoading,
+    data: module,
+    error,
+  } = useQuery<Types.MoveModuleBytecode, ResponseError>(
+    ["accountModule", {address, moduleName}, state.network_value],
+    () => getAccountModule({address, moduleName}, state.network_value),
   );
 
   if (isLoading) {
@@ -78,5 +258,30 @@ export default function ModulesTab({address}: ModulesTabProps) {
     return <Error address={address} error={error} />;
   }
 
-  return <ModulesContent data={data} />;
+  if (!module) {
+    return <EmptyTabContent />;
+  }
+
+  return (
+    <Box>
+      <Typography fontSize={24} fontWeight={700} marginY={"16px"}>
+        ABI
+      </Typography>
+      <JsonViewCard data={module.abi} />
+    </Box>
+  );
+}
+
+type ModulesTabProps = {
+  address: string;
+  accountData: Types.AccountData | undefined;
+};
+
+export default function ModulesTab({address}: ModulesTabProps) {
+  const inDev = useGetInDevMode();
+  return inDev ? (
+    <ModulesContentReworked address={address} />
+  ) : (
+    <ModulesContent address={address} />
+  );
 }

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -2,8 +2,11 @@ import {Types} from "aptos";
 import {Box, Grid, Stack, Typography, useTheme} from "@mui/material";
 import React from "react";
 import {orderBy} from "lodash";
-import "highlight.js/styles/github.css";
-import hljs from "highlight.js";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import {
+  solarizedLight,
+  solarizedDark,
+} from "react-syntax-highlighter/dist/esm/styles/hljs";
 import Error from "../Error";
 import {useGlobalState} from "../../../GlobalState";
 import {ResponseError} from "../../../api/client";
@@ -201,10 +204,6 @@ function ModuleNameOption({
 }
 
 function ModuleContent({address, moduleName, sourceCode}: ModuleContentProps) {
-  React.useEffect(() => {
-    hljs.highlightAll();
-  });
-
   return (
     <Stack direction="column" spacing={2} padding={"24px"}>
       <Typography fontSize={28} fontWeight={700}>
@@ -217,6 +216,8 @@ function ModuleContent({address, moduleName, sourceCode}: ModuleContentProps) {
 }
 
 function Code({sourceCode}: {sourceCode: string}) {
+  const theme = useTheme();
+  const codeString = transformCode(sourceCode);
   return (
     <Box>
       <Typography fontSize={24} fontWeight={700} marginY={"16px"}>
@@ -226,13 +227,17 @@ function Code({sourceCode}: {sourceCode: string}) {
         sx={{
           maxHeight: "500px",
           overflowY: "auto",
-          border: "1px solid",
           borderRadius: 1,
         }}
       >
-        <pre>
-          <code className="language-rust">{transformCode(sourceCode)}</code>
-        </pre>
+        <SyntaxHighlighter
+          language="rust"
+          style={
+            theme.palette.mode === "light" ? solarizedLight : solarizedDark
+          }
+        >
+          {codeString}
+        </SyntaxHighlighter>
       </Box>
     </Box>
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import {Types} from "aptos";
+import {HexString, Types} from "aptos";
+import pako from "pako";
 
 /**
  * Helper function for exhaustiveness checks.
@@ -76,4 +77,13 @@ export function getLocalStorageWithExpiry(key: string) {
 export async function fetchJsonResponse(url: string) {
   const response = await fetch(url);
   return await response.json();
+}
+
+/**
+ * Convert a module source code in gzipped hex string to plain text
+ * @param source module source code in gzipped hex string
+ * @returns original source code in plain text
+ */
+export function transformCode(source: string): string {
+  return pako.ungzip(new HexString(source).toUint8Array(), {to: "string"});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,6 +2529,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/pako@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-2.0.0.tgz#12ab4c19107528452e73ac99132c875ccd43bdfb"
+  integrity sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -5704,6 +5709,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
+  integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
+
 hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -7572,6 +7582,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 param-case@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,7 +1092,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -2468,6 +2468,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hast@^2.0.0":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
+  integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -2588,6 +2595,13 @@
     "@types/geojson" "*"
     "@types/react" "*"
 
+"@types/react-syntax-highlighter@^15.5.6":
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.6.tgz#77c95e6b74d2be23208fcdcf187b93b47025f1b1"
+  integrity sha512-i7wFuLbIAFlabTeD2I1cLjEOrG/xdMa/rpx2zwzAoGHuXJDhSqp9BSfDlMHSh9JSuNfxHk9eEmMX6D55GiyjGg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.5":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
@@ -2657,6 +2671,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
+
+"@types/unist@*":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
 "@types/ws@^7.4.4":
   version "7.4.7"
@@ -3677,6 +3696,21 @@ char-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.1.tgz#6dafdb25f9d3349914079f010ba8d0e6ff9cd01e"
   integrity sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chart.js@^4.0.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.2.1.tgz#d2bd5c98e9a0ae35408975b638f40513b067ba1d"
@@ -3804,6 +3838,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
+  integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
 commander@2, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -5221,6 +5260,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 faye-websocket@^0.11.3:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
@@ -5422,6 +5468,11 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5704,15 +5755,31 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
+  integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^11.7.0:
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
-  integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -5979,6 +6046,19 @@ ipaddr.js@^2.0.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
   integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arguments@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
@@ -6042,6 +6122,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
@@ -6068,6 +6153,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"
@@ -7081,6 +7171,14 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -7602,6 +7700,18 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
@@ -8322,6 +8432,16 @@ pretty-format@^28.1.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+prismjs@^1.27.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -8357,6 +8477,13 @@ prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^5.0.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
+  integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
+  dependencies:
+    xtend "^4.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -8675,6 +8802,17 @@ react-smooth@^2.0.1:
     fast-equals "^2.0.0"
     react-transition-group "2.9.0"
 
+react-syntax-highlighter@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"
+  integrity sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
+
 react-textarea-autosize@^8.3.2:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz#4d0244d6a50caa897806b8c44abc0540a69bfc8c"
@@ -8783,6 +8921,15 @@ reduce-css-calc@^2.1.8:
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
+
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
@@ -9293,6 +9440,11 @@ sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
+  integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -10533,7 +10685,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.2:
+xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
I suggest visiting https://deploy-preview-362--aptos-explorer.netlify.app/account/0x1/modules?feature=dev before reviewing this PR. This should give you a good understanding of what the current PR does.

Summary:

1. Add `ModulesContentReworked` that implements the new view code design
2. In `ModulesTab`, display `ModulesContentReworked` only if `inDev`
3. In `ModulesContentReworked`, display both source code and ABI

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/222372507-6a8711b7-c891-4221-a012-7104d00fd26d.png">
