### PR TITLE
[explorer][delegation] fix delegatedStakeAmount

### DIFF
--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -1,14 +1,23 @@
 import {AptosClient, Types} from "aptos";
 import {useState, useMemo} from "react";
 import {getValidatorCommission} from "..";
+import {DELEGATION_POOL_ADDRESS} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
+import {useGetAccountResources} from "./useGetAccountResources";
 import {ValidatorData} from "./useGetValidators";
 import {useGetValidatorSet, Validator} from "./useGetValidatorSet";
 
+interface DelegationPool {
+  active_shares: {
+    total_coins: string;
+  };
+}
+
 type DelegationNodeInfoResponse = {
-  delegatedStakeAmount: string;
+  delegatedStakeAmount: string | undefined;
   networkPercentage?: string;
   commission: number | undefined;
+  isLoading: boolean;
 };
 
 type DelegationNodeInfoProps = {
@@ -21,27 +30,46 @@ export function useGetDelegationNodeInfo({
   validator,
 }: DelegationNodeInfoProps): DelegationNodeInfoResponse {
   const [state, _] = useGlobalState();
-  const [commission, setCommission] = useState<Types.MoveValue>();
-  const client = new AptosClient(state.network_value);
   const {totalVotingPower} = useGetValidatorSet();
+  const {data, isLoading} = useGetAccountResources(validatorAddress);
+  const client = new AptosClient(state.network_value);
+  const [commission, setCommission] = useState<Types.MoveValue>();
+  const [delegatedStakeAmount, setDelegatedStakeAmount] =
+    useState<Types.MoveValue>();
   const [networkPercentage, setNetworkPercentage] = useState<string>();
 
   useMemo(() => {
-    const fetchData = async () => {
-      setCommission(await getValidatorCommission(client, validatorAddress));
-    };
-    fetchData();
-    setNetworkPercentage(
-      (
-        (parseInt(validator.voting_power) / parseInt(totalVotingPower!)) *
-        100
-      ).toFixed(2),
-    );
-  }, [state.network_value, totalVotingPower]);
+    if (!isLoading) {
+      const fetchData = async () => {
+        setCommission(await getValidatorCommission(client, validatorAddress));
+      };
+      fetchData();
+      setNetworkPercentage(
+        (
+          (parseInt(validator.voting_power) / parseInt(totalVotingPower!)) *
+          100
+        ).toFixed(2),
+      );
+
+      const delegationPool = data?.find(
+        (resource) =>
+          resource.type ===
+          `${DELEGATION_POOL_ADDRESS}::delegation_pool::DelegationPool`,
+      );
+
+      const delegationPoolData: DelegationPool | undefined =
+        delegationPool?.data as DelegationPool;
+
+      setDelegatedStakeAmount(delegationPoolData?.active_shares?.total_coins);
+    }
+  }, [state.network_value, totalVotingPower, isLoading, data]);
 
   return {
     commission: commission ? Number(commission) / 100 : undefined, // commission rate: 22.85% is represented as 2285
     networkPercentage,
-    delegatedStakeAmount: validator.voting_power,
+    delegatedStakeAmount: delegatedStakeAmount
+      ? Number(delegatedStakeAmount).toString()
+      : undefined,
+    isLoading,
   };
 }

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -38,7 +38,7 @@ export default function StakingBar({
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
   const {connected} = useWallet();
-  const {delegatedStakeAmount, networkPercentage, commission, isLoading} =
+  const {delegatedStakeAmount, networkPercentage, commission, isQueryLoading} =
     useGetDelegationNodeInfo({
       validatorAddress: validator.owner_address,
       validator,
@@ -55,10 +55,10 @@ export default function StakingBar({
   };
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isQueryLoading) {
       setIsStakingBarSkeletonLoading(false);
     }
-  }, [isLoading]);
+  }, [isQueryLoading]);
 
   const stakeAmount = (
     <Stack direction="column" spacing={0.5}>

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -38,7 +38,7 @@ export default function StakingBar({
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
   const {connected} = useWallet();
-  const {delegatedStakeAmount, networkPercentage, commission} =
+  const {delegatedStakeAmount, networkPercentage, commission, isLoading} =
     useGetDelegationNodeInfo({
       validatorAddress: validator.owner_address,
       validator,
@@ -55,21 +55,16 @@ export default function StakingBar({
   };
 
   useEffect(() => {
-    if (
-      rewardsRateYearly &&
-      delegatedStakeAmount &&
-      networkPercentage &&
-      commission
-    ) {
+    if (!isLoading) {
       setIsStakingBarSkeletonLoading(false);
     }
-  }, [rewardsRateYearly, delegatedStakeAmount, networkPercentage, commission]);
+  }, [isLoading]);
 
   const stakeAmount = (
     <Stack direction="column" spacing={0.5}>
       <Typography sx={{fontWeight: 600}}>
         <APTCurrencyValue
-          amount={delegatedStakeAmount}
+          amount={delegatedStakeAmount ?? ""}
           fixedDecimalPlaces={0}
         />
       </Typography>

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -238,7 +238,7 @@ function DelegatedStakeAmountCell({validator}: ValidatorCellProps) {
     <GeneralTableCell sx={{textAlign: "right"}}>
       <Box>
         <APTCurrencyValue
-          amount={delegatedStakeAmount}
+          amount={delegatedStakeAmount ?? ""}
           fixedDecimalPlaces={0}
         />
       </Box>

--- a/src/pages/Validators/Table.tsx
+++ b/src/pages/Validators/Table.tsx
@@ -95,7 +95,7 @@ function DelegatedStakeAmountCell({validator}: ValidatorCellProps) {
     <GeneralTableCell sx={{textAlign: "right"}}>
       <Box>
         <APTCurrencyValue
-          amount={delegatedStakeAmount}
+          amount={delegatedStakeAmount ?? ""}
           fixedDecimalPlaces={0}
         />
       </Box>

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -317,7 +317,7 @@ export function DelegatedStakeAmountCell({validator}: ValidatorCellProps) {
     <GeneralTableCell sx={{textAlign: "right"}}>
       <Box>
         <APTCurrencyValue
-          amount={delegatedStakeAmount}
+          amount={delegatedStakeAmount ?? ""}
           fixedDecimalPlaces={0}
         />
       </Box>


### PR DESCRIPTION
before, we were using validator voting power for delegatedStakeAmount, which is wrong. now we get the right amount for staking from [account resources](https://fullnode.testnet.aptoslabs.com/v1/accounts/0x5df905f817adf39293c596e83512ab8a9dc5a19980e11bd4ce44b6e749d33a0d/resources) delegation pool's total coins. 
<img width="462" alt="Screenshot 2023-02-22 at 10 42 17 AM" src="https://user-images.githubusercontent.com/121921928/220728009-191af30d-b832-4191-9f87-62c83a09f548.png">

<img width="229" alt="Screenshot 2023-02-22 at 10 42 10 AM" src="https://user-images.githubusercontent.com/121921928/220728017-8bd44c6d-9734-41cd-8880-310db0ec979d.png">
