### PR TITLE
[explorer][delegation] fix negative rewards issue

### DIFF
--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -149,9 +149,10 @@ function RewardEarnedCell({
       ? stakePrincipals?.pendingInactivePrincipals
       : undefined;
 
-  const rewardsEarned = principalsAmount
-    ? Number(stake) - principalsAmount
-    : undefined;
+  const rewardsEarned =
+    principalsAmount && Number(stake) > principalsAmount
+      ? Number(stake) - principalsAmount
+      : undefined;
 
   return (
     <GeneralTableCell>


### PR DESCRIPTION
so when users stake, they will be charged with `add_stakes` fee which will make their amount less than their stakes. when computing rewards, its possible that `amount - principal < 0`. in this case, return `N/A`

https://user-images.githubusercontent.com/121921928/221298157-88dc3842-b786-4060-90f9-6a925fc47509.mov

