### PR TITLE
[ANS] show primary name

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -1,6 +1,7 @@
 import {useEffect, useState} from "react";
 import {NetworkName} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
+import {fetchJsonResponse} from "../../utils";
 
 function getFetchNameUrl(
   network: NetworkName,
@@ -24,16 +25,14 @@ export function useGetNameFromAddress(address: string) {
     const primaryNameUrl = getFetchNameUrl(state.network_name, address, true);
     if (primaryNameUrl !== undefined) {
       const fetchData = async () => {
-        const primaryNameResponse = await fetch(primaryNameUrl);
-        const {name: primaryName} = await primaryNameResponse.json();
+        const {name: primaryName} = await fetchJsonResponse(primaryNameUrl);
 
         if (primaryName) {
           setName(primaryName);
         } else {
           const nameUrl =
             getFetchNameUrl(state.network_name, address, false) ?? "";
-          const nameResponse = await fetch(nameUrl);
-          const {name} = await nameResponse.json();
+          const {name} = await fetchJsonResponse(nameUrl);
           setName(name);
         }
       };
@@ -68,8 +67,7 @@ export async function getAddressFromName(
   }
 
   try {
-    const addressResponse = await fetch(addressUrl);
-    const {address} = await addressResponse.json();
+    const {address} = await fetchJsonResponse(addressUrl);
 
     const primaryNameUrl = getFetchNameUrl(network, address, true);
     const primaryNameResponse = await fetch(primaryNameUrl ?? "");

--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -2,25 +2,40 @@ import {useEffect, useState} from "react";
 import {NetworkName} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 
-function getFetchNameUrl(network: NetworkName, address: string) {
+function getFetchNameUrl(
+  network: NetworkName,
+  address: string,
+  isPrimary: boolean,
+) {
   if (network !== "testnet" && network !== "mainnet") {
     return undefined;
   }
 
-  return `https://www.aptosnames.com/api/${network}/v1/name/${address}`;
+  return isPrimary
+    ? `https://www.aptosnames.com/api/${network}/v1/primary-name/${address}`
+    : `https://www.aptosnames.com/api/${network}/v1/name/${address}`;
 }
 
 export function useGetNameFromAddress(address: string) {
   const [state, _] = useGlobalState();
   const [name, setName] = useState<string | undefined>();
-  const url = getFetchNameUrl(state.network_name, address);
 
   useEffect(() => {
-    if (url !== undefined) {
+    const primaryNameUrl = getFetchNameUrl(state.network_name, address, true);
+    if (primaryNameUrl !== undefined) {
       const fetchData = async () => {
-        const response = await fetch(url);
-        const {name} = await response.json();
-        setName(name);
+        const primaryNameResponse = await fetch(primaryNameUrl);
+        const {name: primaryName} = await primaryNameResponse.json();
+
+        if (primaryName) {
+          setName(primaryName);
+        } else {
+          const nameUrl =
+            getFetchNameUrl(state.network_name, address, false) ?? "";
+          const nameResponse = await fetch(nameUrl);
+          const {name} = await nameResponse.json();
+          setName(name);
+        }
       };
 
       fetchData().catch((error) => {
@@ -43,28 +58,25 @@ function getFetchAddressUrl(network: NetworkName, name: string) {
 export async function getAddressFromName(
   name: string,
   network: NetworkName,
-): Promise<string | undefined> {
+): Promise<{address: string | undefined; primaryName: string | undefined}> {
   const searchableName = name.endsWith(".apt") ? name.slice(0, -4) : name;
   const addressUrl = getFetchAddressUrl(network, searchableName);
 
+  const notFoundResult = {address: undefined, primaryName: undefined};
   if (addressUrl === undefined) {
-    return undefined;
+    return notFoundResult;
   }
 
   try {
     const addressResponse = await fetch(addressUrl);
     const {address} = await addressResponse.json();
 
-    const primaryNameUrl = getFetchNameUrl(network, address);
+    const primaryNameUrl = getFetchNameUrl(network, address, true);
     const primaryNameResponse = await fetch(primaryNameUrl ?? "");
     const {name: primaryName} = await primaryNameResponse.json();
 
-    if (primaryName === searchableName) {
-      return address;
-    } else {
-      return undefined;
-    }
+    return {address: address, primaryName: primaryName};
   } catch {
-    return undefined;
+    return notFoundResult;
   }
 }

--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -42,11 +42,11 @@ export default function useGetSearchResults(input: string) {
       const isValidBlockHeightOrVer = isNumeric(searchText);
 
       const namePromise = getAddressFromName(searchText, state.network_name)
-        .then((address): SearchResult | null => {
+        .then(({address, primaryName}): SearchResult | null => {
           if (address) {
             return {
-              label: `Account ${truncateAddress(address)} | ${
-                searchText.endsWith(".apt") ? searchText : `${searchText}.apt`
+              label: `Account ${truncateAddress(address)}${
+                primaryName ? ` | ${primaryName}` : ``
               }`,
               to: `/account/${address}`,
             };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,3 +72,8 @@ export function getLocalStorageWithExpiry(key: string) {
 
   return item.value;
 }
+
+export async function fetchJsonResponse(url: string) {
+  const response = await fetch(url);
+  return await response.json();
+}


### PR DESCRIPTION
With ANS primary name launching, we want to show primary names for the accounts instead of a random name when there're multiple names under one account.

* when you have a primary name, show the primary name
<img width="475" alt="Screen Shot 2023-02-24 at 3 38 35 PM" src="https://user-images.githubusercontent.com/109111707/221321516-b9454748-a781-4cad-8aff-366fdda1f9ab.png">
* when you don't have a primary name, just show one of the names you own
<img width="390" alt="Screen Shot 2023-02-24 at 3 39 04 PM" src="https://user-images.githubusercontent.com/109111707/221321513-cb9f1c7c-0f03-461c-b26a-23d0a5482c15.png">
* when you own multiple names, you can search with any of the name, but the primary name will be attached on the side of address in the search result
<img width="463" alt="Screen Shot 2023-02-24 at 3 38 56 PM" src="https://user-images.githubusercontent.com/109111707/221321515-d6ac8ceb-046a-4d24-a09d-41b5573c6451.png">

