### PR TITLE
[ANS] show .apt after names in account title and search result

### DIFF
--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -46,7 +46,7 @@ export default function useGetSearchResults(input: string) {
           if (address) {
             return {
               label: `Account ${truncateAddress(address)}${
-                primaryName ? ` | ${primaryName}` : ``
+                primaryName ? ` | ${primaryName}.apt` : ``
               }`,
               to: `/account/${address}`,
             };

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -134,7 +134,7 @@ function Name({address}: {address: string}) {
           target="_blank"
           underline="none"
         >
-          {name}
+          {`${name}.apt`}
         </Link>
       </Stack>
     </Box>


### PR DESCRIPTION
<img width="436" alt="Screen Shot 2023-02-24 at 4 36 46 PM" src="https://user-images.githubusercontent.com/109111707/221325612-4ddb886f-1025-4435-b2b6-39414efb797b.png">
<img width="618" alt="Screen Shot 2023-02-24 at 4 36 35 PM" src="https://user-images.githubusercontent.com/109111707/221325614-5bcf3577-337f-4b50-be1f-53bef2004977.png">
