### PR TITLE
[contract] fix missing EXPAND | COLLAPSE on modules tab

### DIFF
--- a/src/components/hooks/useExpandedList.ts
+++ b/src/components/hooks/useExpandedList.ts
@@ -1,9 +1,13 @@
-import {useState} from "react";
+import {useEffect, useState} from "react";
 
 const useExpandedList = (count: number) => {
   const [expandedList, setExpandedList] = useState<boolean[]>(
     new Array(count).fill(true),
   );
+
+  useEffect(() => {
+    setExpandedList(new Array(count).fill(true));
+  }, [count]);
 
   const toggleExpandedAt = (i: number) => {
     const expandedListCopy = [...expandedList];


### PR DESCRIPTION
the issue here is that we the initial value provided to `useEffect` is not reflected without the first render, by using `useEffect`, it's essentially enforcing to update the  `expandedList` when `count` changes.

but it's slightly anti-pattern cuz we use props as the change factor to trigger `useEffect`. open to other suggestions. 
[reference](https://thewebdev.info/2021/03/14/how-to-fix-the-react-usestate-hook-not-setting-initial-value-problem/)


https://user-images.githubusercontent.com/121921928/223313036-4c48c056-7bf5-4562-9d01-414aadb50639.mov

