### PR TITLE
[explorer] show no-code msg if source code unavailable

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -252,28 +252,34 @@ function ModuleContent({address, moduleName, sourceCode}: ModuleContentProps) {
 
 function Code({sourceCode}: {sourceCode: string}) {
   const theme = useTheme();
-  const codeString = transformCode(sourceCode);
   return (
     <Box>
       <Typography fontSize={24} fontWeight={700} marginY={"16px"}>
         Code
       </Typography>
-      <Box
-        sx={{
-          maxHeight: "500px",
-          overflowY: "auto",
-          borderRadius: 1,
-        }}
-      >
-        <SyntaxHighlighter
-          language="rust"
-          style={
-            theme.palette.mode === "light" ? solarizedLight : solarizedDark
-          }
+      {sourceCode === "0x" ? (
+        <Box>
+          Unfortunately, the source code cannot be shown because the package
+          publisher has chosen not to make it available
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            maxHeight: "500px",
+            overflowY: "auto",
+            borderRadius: 1,
+          }}
         >
-          {codeString}
-        </SyntaxHighlighter>
-      </Box>
+          <SyntaxHighlighter
+            language="rust"
+            style={
+              theme.palette.mode === "light" ? solarizedLight : solarizedDark
+            }
+          >
+            {transformCode(sourceCode)}
+          </SyntaxHighlighter>
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/223879588-b235b908-d6b3-431a-82c8-3a982344b50a.png">

after
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/223879625-1bd58230-cd79-446b-8ba0-1cb9183a603f.png">
