### PR TITLE
[delegation] make changes to comply with 10 min apt enforcement

### DIFF
--- a/src/api/hooks/useGetDelegationState.tsx
+++ b/src/api/hooks/useGetDelegationState.tsx
@@ -1,0 +1,32 @@
+import {Types} from "aptos";
+import {ValidatorData} from "./useGetValidators";
+import {useWallet} from "@aptos-labs/wallet-adapter-react";
+import {getLockedUtilSecs} from "../../pages/DelegatoryValidator/utils";
+import {useGetAccountAPTBalance} from "./useGetAccountAPTBalance";
+import {useGetNumberOfDelegators} from "./useGetNumberOfDelegators";
+import {useGetStakingRewardsRate} from "./useGetStakingRewardsRate";
+
+export type DelegationState = {
+  lockedUntilSecs: bigint | null;
+  balance: string | null;
+  delegatorBalance: any;
+  rewardsRateYearly: string | undefined;
+};
+
+export function useGetDelegationState(
+  accountResource: Types.MoveResource,
+  validator: ValidatorData,
+): DelegationState {
+  const {account} = useWallet();
+  const lockedUntilSecs = getLockedUtilSecs(accountResource);
+  const balance = useGetAccountAPTBalance(account?.address!);
+  const {delegatorBalance} = useGetNumberOfDelegators(validator.owner_address);
+  const {rewardsRateYearly} = useGetStakingRewardsRate();
+
+  return {
+    lockedUntilSecs,
+    balance,
+    delegatorBalance,
+    rewardsRateYearly,
+  };
+}

--- a/src/components/AmountTextField.tsx
+++ b/src/components/AmountTextField.tsx
@@ -12,6 +12,7 @@ interface AmountTextFieldProps {
   amount: string;
   amountIsValid: boolean;
   errorMessage: string;
+  warnMessage: string | undefined;
   onAmountChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   balance?: string | null;
 }
@@ -20,6 +21,7 @@ export default function AmountTextField({
   amount,
   amountIsValid,
   errorMessage,
+  warnMessage,
   onAmountChange,
   balance,
 }: AmountTextFieldProps): JSX.Element {
@@ -39,6 +41,7 @@ export default function AmountTextField({
             : ""
         }
       />
+      {warnMessage && <FormHelperText>{warnMessage}</FormHelperText>}
     </FormControl>
   ) : (
     <FormControl fullWidth>

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -7,15 +7,13 @@ import {HashType} from "../../components/HashButton";
 import RewardsPerformanceTooltip from "../Validators/Components/RewardsPerformanceTooltip";
 import LastEpochPerformanceTooltip from "../Validators/Components/LastEpochPerformanceTooltip";
 import TimeDurationIntervalBar from "./Components/TimeDurationIntervalBar";
-import {getLockedUtilSecs} from "./utils";
-import {useGetStakingRewardsRate} from "../../api/hooks/useGetStakingRewardsRate";
 import {StyledLearnMoreTooltip} from "../../components/StyledTooltip";
 import {
   REWARDS_LEARN_MORE_LINK,
   REWARDS_TOOLTIP_TEXT,
 } from "../Validators/Components/Staking";
+import {useGetDelegationState} from "../../api/hooks/useGetDelegationState";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
-import {useGetNumberOfDelegators} from "../../api/hooks/useGetNumberOfDelegators";
 import {DelegationStateContext} from "./context/DelegationContext";
 import {useContext} from "react";
 
@@ -26,22 +24,21 @@ type ValidatorDetailProps = {
 export default function ValidatorDetailCard({
   isSkeletonLoading,
 }: ValidatorDetailProps) {
-  const {rewardsRateYearly} = useGetStakingRewardsRate();
   const {accountResource, validator} = useContext(DelegationStateContext);
 
   if (!validator || !accountResource) {
     return null;
   }
 
+  const {delegatorBalance, lockedUntilSecs, rewardsRateYearly} =
+    useGetDelegationState(accountResource, validator);
   const {commission} = useGetDelegationNodeInfo({
     validatorAddress: validator.owner_address,
     validator,
   });
-  const {delegatorBalance} = useGetNumberOfDelegators(validator.owner_address);
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
 
-  const lockedUntilSecs = getLockedUtilSecs(accountResource);
   const operatorAddr = validator?.operator_address;
   const rewardGrowth = validator?.rewards_growth;
   const stakePoolAddress = validator?.owner_address;

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -17,7 +17,6 @@ import WalletConnectionDialog from "./WalletConnectionDialog";
 import {StyledLearnMoreTooltip} from "../../components/StyledTooltip";
 import StakeOperationDialog from "./StakeOperationDialog";
 import {StakeOperation} from "../../api/hooks/useSubmitStakeOperation";
-import {useGetStakingRewardsRate} from "../../api/hooks/useGetStakingRewardsRate";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
 import {DelegationStateContext} from "./context/DelegationContext";
 
@@ -44,7 +43,6 @@ export default function StakingBar({
       validatorAddress: validator.owner_address,
       validator,
     });
-  const {rewardsRateYearly} = useGetStakingRewardsRate();
 
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
@@ -144,7 +142,6 @@ export default function StakingBar({
       handleDialogClose={handleDialogClose}
       isDialogOpen={dialogOpen}
       stakeOperation={StakeOperation.STAKE}
-      rewardsRateYearly={rewardsRateYearly}
       commission={commission}
     />
   );

--- a/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
+++ b/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from "@mui/material";
 import React, {useState} from "react";
 import StyledDialog from "../../components/StyledDialog";
-import {useNavigate} from "react-router-dom";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import {StakeOperation} from "../../api/hooks/useSubmitStakeOperation";
@@ -32,7 +31,6 @@ export default function TransactionSucceededDialog({
   transactionHash,
   stakeOperation,
 }: TransactionSucceededDialogProps) {
-  const navigate = useNavigate();
   const theme = useTheme();
 
   const [copyTooltipOpen, setCopyTooltipOpen] = useState<boolean>(false);

--- a/src/pages/DelegatoryValidator/constants.ts
+++ b/src/pages/DelegatoryValidator/constants.ts
@@ -34,3 +34,12 @@ export const WITHDRAW_READY_DESCRIPTION =
 // step icon color scheme
 export const STEP_ICON_DARK = "#818CF8";
 export const STEP_ICON_LIGHT = grey[300];
+
+/**
+ * In theory, minimum is 10 APT, but this 10 APT doesn't include the initial add_stake fee.
+ * Without confusing delegators with decimals, we set limit to be 11 for staking.
+ * For unlock and reactivate, we set it to 11 as well to mitigate the rounding error where
+ * 1.0000000 is rounded to 0.9999999
+ */
+export const MINIMUM_APT_IN_POOL_FOR_EXPLORER = 11;
+export const MINIMUM_APT_IN_POOL = 10;

--- a/src/pages/DelegatoryValidator/utils.tsx
+++ b/src/pages/DelegatoryValidator/utils.tsx
@@ -3,6 +3,12 @@ import {
   DelegatedStakingActivity,
   useGetDelegatedStakeOperationActivities,
 } from "../../api/hooks/useGetDelegatedStakeOperationActivities";
+import {StakeOperation} from "../../api/hooks/useSubmitStakeOperation";
+import {OCTA} from "../../constants";
+import {
+  MINIMUM_APT_IN_POOL_FOR_EXPLORER,
+  MINIMUM_APT_IN_POOL,
+} from "./constants";
 
 interface AccountResourceData {
   locked_until_secs: bigint;
@@ -109,4 +115,99 @@ export function getStakeOperationPrincipals(
     stakePrincipals: {activePrincipals, pendingInactivePrincipals},
     isLoading: false,
   };
+}
+
+/**
+ * There are two pools we’re enforcing this restriction, active pool and pending_inactive pool. When we stake, our fund will eventually move to active pool, when we unlock, our fund will move to pending_inactive pool.
+ * The general theme is that if it’s adding APT to the pool, 10 min APT is hard enforced; if it’s taking APT out of the pool, 10 min APT is soft enforced, meaning that if 10min APT’s not met, we will forcefully take every APT out and pool balance is 0.
+ *
+ * STAKE (fund moves to active pool):
+ * We need to hard enforce 10 min APT in active pool. On UX, the enforced APT amount will certainly change every time, since we are enforcing the 10 APT at the active pool level. i.e. when there’s 0 in active pool, user has to stake at least 10 APT after add_stake fee, meaning that the limit we wanna display on UX could be 11 APT. Then next time user decides to stake again, there’s no limit at all because active pool already has 10 APTs in it.
+ *
+ * UNLOCK (fund moves from active to pending_inactive pool):
+ * We need to hard enforce the 10 minimum APT in the pending_inactive pool. The min APT users can unlock will need to meet the following condition:
+ * condition 1: current APT in active pool - unlock amount “should” be greater than 10. I use “should” here because if condition 1’s not met, all funds in the active pool will be unlocked.
+ * condition 2: current APT in pending_inactive pool + unlock amount has to be greater than 10 APT
+ * One example here to make it clear: Bob has 26 APT in active and has not unlocked anything. If Bob wants to unlock, they have to unlock at least 10 APT and at most 16 APT. If they unlock > 16 APT, all 26 APT will become unlocked (because there'd be < 10 APT remaining in active balances)
+ *
+ * REACTIVATE (fund moves from pending_inactive to active pool):
+ * We need to hard enforce the 10 minimum APT in the pending_inactive as well as active pool. Similar to unlock, the min APT users can reactivate will need to meet the following condition
+ * condition 1: current APT in pending_inactive pool - reactivate amount “should” be greater than 10 APT. If condition 1’s not met, all funds in pending_inactive pool will be reactivated.
+ * condition 2: current APT in active pool + reactivate amount has to be greater than 10 APT.
+ */
+
+export type APTRequirement = {
+  min: number | null;
+  suggestedMax: number | null;
+  max: number | null;
+  disabled: boolean;
+};
+
+export function getStakeOperationAPTRequirement(
+  stakes: Types.MoveValue[],
+  stakeOperation: StakeOperation,
+  balance: number,
+): APTRequirement {
+  const active = Number(stakes[0]) / OCTA;
+  const pending_inactive = Number(stakes[2]) / OCTA;
+
+  switch (stakeOperation) {
+    case StakeOperation.STAKE: {
+      const min =
+        MINIMUM_APT_IN_POOL_FOR_EXPLORER - active <= 0
+          ? 0
+          : MINIMUM_APT_IN_POOL_FOR_EXPLORER - active;
+      const suggestedMax = null;
+      const max = balance / OCTA;
+      return {
+        min,
+        suggestedMax,
+        max,
+        disabled: min > max || max < MINIMUM_APT_IN_POOL,
+      };
+    }
+    case StakeOperation.UNLOCK: {
+      const min =
+        pending_inactive < MINIMUM_APT_IN_POOL_FOR_EXPLORER
+          ? MINIMUM_APT_IN_POOL_FOR_EXPLORER - pending_inactive
+          : 0;
+      const suggestedMax =
+        active > MINIMUM_APT_IN_POOL_FOR_EXPLORER &&
+        active - MINIMUM_APT_IN_POOL_FOR_EXPLORER > min
+          ? active - MINIMUM_APT_IN_POOL_FOR_EXPLORER
+          : null;
+      const max = active;
+      return {
+        min,
+        suggestedMax,
+        max,
+        disabled: min > max || max < MINIMUM_APT_IN_POOL,
+      };
+    }
+    case StakeOperation.REACTIVATE: {
+      const min =
+        MINIMUM_APT_IN_POOL_FOR_EXPLORER > active
+          ? MINIMUM_APT_IN_POOL_FOR_EXPLORER - active
+          : 0;
+      const suggestedMax =
+        MINIMUM_APT_IN_POOL_FOR_EXPLORER < pending_inactive &&
+        pending_inactive - MINIMUM_APT_IN_POOL_FOR_EXPLORER > min
+          ? pending_inactive - MINIMUM_APT_IN_POOL_FOR_EXPLORER
+          : null;
+      const max = pending_inactive;
+      return {
+        min,
+        suggestedMax,
+        max,
+        disabled: min > max || max < MINIMUM_APT_IN_POOL,
+      };
+    }
+    default:
+      return {
+        min: null,
+        suggestedMax: null,
+        max: null,
+        disabled: false,
+      };
+  }
 }


### PR DESCRIPTION
# DISCLAIMER: 
*0x1 delegation_pool contract is not deployed to testnet yet, so in the testing, we can't actually see what's gonna happen if 10apt min requirement's not met at the pool level. will perform more real testing once 0x1's actually released.*

## changes
1. create a new hook to consolidate some delegation state that are used in multiple places
2. create the util function to compute for min, max, suggested max per stake operation
2.1. **min**: minimum APT to move around, hard enforced
2.2. **suggested max**: suggested maximum APT to move around in order to not enforcefully move all funds away from the pool, soft enforced
2.3. **max**: max APT to move around, hard enforced
3. use **11** APT as the UI minimum for operations, because we have two scenarios that will make 10 APT enforcement on UX difficult: 1) add_stake fee 2) rounding error when unlock and reactivate that will loose 1 OCTA in precision
4. separate withdraw dialog out, because withdraw is not limited with 10 min APT requirement, so its implementation is different from others.


## stake
https://user-images.githubusercontent.com/121921928/224841045-2a76c48b-6c9e-4d19-b5f3-990cd6420650.mov


## unlock
https://user-images.githubusercontent.com/121921928/224841038-0e518573-1124-46f1-900f-f50fde185498.mov

## reactivate
https://user-images.githubusercontent.com/121921928/224841018-32f4608e-c524-41d6-849b-9ba6dde8d73a.mov

