### PR TITLE
[nit] change decimal

### DIFF
--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -91,7 +91,7 @@ export default function StakingBar({
     <Stack direction="column" spacing={0.5}>
       <Typography sx={{fontWeight: 600}}>
         <APTCurrencyValue
-          amount={Number(validator.apt_rewards_distributed).toFixed(2)}
+          amount={Number(validator.apt_rewards_distributed).toFixed(0)}
           decimals={0}
         />
       </Typography>


### PR DESCRIPTION
to make it consistant in the staking bar with another APT amount

<img width="1006" alt="Screenshot 2023-03-13 at 3 15 24 PM" src="https://user-images.githubusercontent.com/121921928/224844778-6c64fe57-2062-4e2a-bb28-072548a925b5.png">
