### PR TITLE
[explorer] Set default color scheme to system if not specified

### DIFF
--- a/src/context/color-mode/ProvideColorMode.State.ts
+++ b/src/context/color-mode/ProvideColorMode.State.ts
@@ -7,34 +7,43 @@ export interface ColorModeContext {
   toggleColorMode: () => void;
 }
 
-type Mode = "light" | "dark";
+type Mode = "light" | "dark" | "system";
 
 const useProvideColorMode = () => {
-  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)", {
-    noSsr: true,
-  })
+  const systemColorScheme = useMediaQuery("(prefers-color-scheme: dark)")
     ? "dark"
     : "light";
 
-  const [mode, setMode] = useState<Mode>(
-    (localStorage.getItem("color_scheme") as Mode) || prefersDarkMode,
-  );
+  const [mode, setMode] = useState<Mode>(() => {
+    const storedMode = localStorage.getItem("color_scheme") as Mode;
+    return storedMode === "light" || storedMode === "dark"
+      ? storedMode
+      : "system";
+  });
 
   const toggleColorMode = () => {
     setMode((prevMode) => {
       if (prevMode === "light") {
         localStorage.setItem("color_scheme", "dark");
         return "dark";
-      } else {
+      } else if (prevMode === "dark") {
         localStorage.setItem("color_scheme", "light");
         return "light";
+      } else {
+        localStorage.removeItem("color_scheme");
+        return systemColorScheme;
       }
     });
   };
 
   let theme = useMemo(
-    () => responsiveFontSizes(createTheme(getDesignTokens(mode))),
-    [mode],
+    () =>
+      responsiveFontSizes(
+        createTheme(
+          getDesignTokens(mode === "system" ? systemColorScheme : mode),
+        ),
+      ),
+    [mode, systemColorScheme],
   );
 
   theme = createTheme(theme, {


### PR DESCRIPTION
### Color mode should be decentralized. 

This fix sets the default color scheme to the user's system settings if not previously toggled. 

You can test in Dev Tools by clearing all LocalStorage and making a selection under `Emulate CSS media feature prefers-color-scheme` within the Rendering tab. 

<img width="1589" alt="image" src="https://user-images.githubusercontent.com/98909677/224912764-307a379a-592a-4634-b6d9-e15482212123.png">

