### PR TITLE
[explorer] Set initial color scheme to utilize window.matchmedia API

### DIFF
--- a/src/context/color-mode/ProvideColorMode.State.ts
+++ b/src/context/color-mode/ProvideColorMode.State.ts
@@ -1,5 +1,5 @@
-import {useMemo, useState} from "react";
-import {createTheme, responsiveFontSizes} from "@mui/material";
+import { useMemo, useState, useEffect, useLayoutEffect } from "react";
+import { createTheme, responsiveFontSizes } from "@mui/material";
 import getDesignTokens from "../../themes/theme";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
@@ -7,43 +7,52 @@ export interface ColorModeContext {
   toggleColorMode: () => void;
 }
 
-type Mode = "light" | "dark" | "system";
+type Mode = "light" | "dark";
 
 const useProvideColorMode = () => {
-  const systemColorScheme = useMediaQuery("(prefers-color-scheme: dark)")
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)", {
+    noSsr: true,
+  })
     ? "dark"
     : "light";
 
-  const [mode, setMode] = useState<Mode>(() => {
-    const storedMode = localStorage.getItem("color_scheme") as Mode;
-    return storedMode === "light" || storedMode === "dark"
-      ? storedMode
-      : "system";
-  });
+  const [mode, setMode] = useState<Mode>("light");
+
+  useLayoutEffect(() => {
+    const savedMode = localStorage.getItem("color_scheme") as Mode | null;
+    if (savedMode !== null) {
+      setMode(savedMode);
+    } else {
+      setMode(prefersDarkMode);
+    }
+  }, [prefersDarkMode]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (e: MediaQueryListEvent) => {
+      setMode(e.matches ? "dark" : "light");
+    };
+    mediaQuery.addEventListener("change", handleChange);
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, []);
 
   const toggleColorMode = () => {
     setMode((prevMode) => {
       if (prevMode === "light") {
         localStorage.setItem("color_scheme", "dark");
         return "dark";
-      } else if (prevMode === "dark") {
+      } else {
         localStorage.setItem("color_scheme", "light");
         return "light";
-      } else {
-        localStorage.removeItem("color_scheme");
-        return systemColorScheme;
       }
     });
   };
 
   let theme = useMemo(
-    () =>
-      responsiveFontSizes(
-        createTheme(
-          getDesignTokens(mode === "system" ? systemColorScheme : mode),
-        ),
-      ),
-    [mode, systemColorScheme],
+    () => responsiveFontSizes(createTheme(getDesignTokens(mode))),
+    [mode]
   );
 
   theme = createTheme(theme, {
@@ -63,7 +72,7 @@ const useProvideColorMode = () => {
     },
   });
 
-  return {toggleColorMode, theme};
+  return { toggleColorMode, theme };
 };
 
 export default useProvideColorMode;


### PR DESCRIPTION
Update logic for initial color scheme to utilize `window.matchmedia` API + fix for needing to click toggle twice upon initial interaction.