### PR TITLE
[WIP] Introduce Code-Splitting, LazyLoad components, Lighthouse Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "@spika/aptos-plugin": "^0.1.2",
     "@trustwallet/aptos-wallet-adapter": "^0.1.6",
     "@types/lodash": "^4.14.191",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
     "@types/react-simple-maps": "^3.0.0",
     "aptos": "^1.7.1",
     "aptos-node-checker-client": "0.0.2",
@@ -29,9 +29,9 @@
     "fewcha-plugin-wallet-adapter": "^0.1.1",
     "graphql": "^16.6.0",
     "js-sha3": "^0.8.0",
-    "lodash": "^4.17.21",
-    "pako": "^2.1.0",
+    "lodash-es": "^4.17.21",
     "moment": "^2.29.4",
+    "pako": "^2.1.0",
     "petra-plugin-wallet-adapter": "^0.1.3",
     "prettier": "^2.8.4",
     "react": "latest",
@@ -40,6 +40,7 @@
     "react-dom": "latest",
     "react-ga4": "^1.4.1",
     "react-gtm-module": "^2.0.11",
+    "react-helmet-async": "^1.3.0",
     "react-intersection-observer": "^9.4.3",
     "react-json-view": "^1.21.3",
     "react-loading-skeleton": "^3.1.1",
@@ -74,9 +75,10 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.7",
     "@types/pako": "^2.0.0",
-    "@types/react-syntax-highlighter": "^15.5.6",
     "@types/react-addons-perf": "^15.4.0",
-    "@types/react-gtm-module": "^2.0.1"
+    "@types/react-gtm-module": "^2.0.1",
+    "@types/react-syntax-highlighter": "^15.5.6"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -23,30 +23,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Aptos Explorer</title>
-    <!-- 
-      Custom Fonts from Adobe Typekit. Please enter license key within the
-      REACT_APP_ADOBE_FONTS .env variable. 
-
-      LFT Etica Mono - Light, Book, Regular
-      Apparat SemiCond Light - Light
-
-      TODO: purchase font license(s) and integrate directly via @font-face
-    -->
-    <link
-      rel="stylesheet"
-      href="https://use.typekit.net/%REACT_APP_ADOBE_FONTS%.css"
-    />
-    <!-- Hotjar Tracking Code for https://explorer.aptoslabs.com/ -->
-    <script>
-      (function(h,o,t,j,a,r){
-          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-          h._hjSettings={hjid:3271013,hjsv:6};
-          a=o.getElementsByTagName('head')[0];
-          r=o.createElement('script');r.async=1;
-          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-          a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -1,53 +1,59 @@
-import React from "react";
+import React, {Suspense, lazy} from "react";
 import {Route, Routes} from "react-router-dom";
-import LandingPage from "./pages/LandingPage/Index";
-import NotFoundPage from "./pages/layout/NotFoundPage";
-import ExplorerLayout from "./pages/layout";
-import TransactionPage from "./pages/Transaction/Index";
-import AccountPage from "./pages/Account/Index";
-import BlockPage from "./pages/Block/Index";
-import TokenPage from "./pages/Token/Index";
-import TransactionsPage from "./pages/Transactions/Index";
-import BlocksPage from "./pages/Blocks/Index";
-import ValidatorsPage from "./pages/Validators/Index";
-import ValidatorPage from "./pages/DelegatoryValidator";
-import AnalyticsPage from "./pages/Analytics/Index";
+
+const LandingPage = lazy(() => import("./pages/LandingPage/Index"));
+const NotFoundPage = lazy(() => import("./pages/layout/NotFoundPage"));
+const ExplorerLayout = lazy(() => import("./pages/layout"));
+const TransactionPage = lazy(() => import("./pages/Transaction/Index"));
+const AccountPage = lazy(() => import("./pages/Account/Index"));
+const BlockPage = lazy(() => import("./pages/Block/Index"));
+const TokenPage = lazy(() => import("./pages/Token/Index"));
+const TransactionsPage = lazy(() => import("./pages/Transactions/Index"));
+const BlocksPage = lazy(() => import("./pages/Blocks/Index"));
+const ValidatorsPage = lazy(() => import("./pages/Validators/Index"));
+const ValidatorPage = lazy(() => import("./pages/DelegatoryValidator"));
+const AnalyticsPage = lazy(() => import("./pages/Analytics/Index"));
 
 export default function ExplorerRoutes() {
   return (
     <ExplorerLayout>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/transactions" element={<TransactionsPage />} />
-        <Route path="/validators" element={<ValidatorsPage />}>
-          <Route path=":tab" element={<ValidatorsPage />} />
-        </Route>
-        <Route path="/validator">
-          <Route path=":address" element={<ValidatorPage />} />
-        </Route>
-        <Route path="/txn">
-          <Route path=":txnHashOrVersion" element={<TransactionPage />} />
-          <Route path=":txnHashOrVersion/:tab" element={<TransactionPage />} />
-        </Route>
-        <Route path="/account">
-          <Route path=":address" element={<AccountPage />} />
-          <Route path=":address/:tab" element={<AccountPage />} />
-        </Route>
-        <Route path="/blocks" element={<BlocksPage />} />
-        <Route path="/block">
-          <Route path=":height" element={<BlockPage />} />
-          <Route path=":height/:tab" element={<BlockPage />} />
-        </Route>
-        <Route path="/token">
-          <Route path=":tokenId/:propertyVersion" element={<TokenPage />} />
-          <Route
-            path=":tokenId/:propertyVersion/:tab"
-            element={<TokenPage />}
-          />
-        </Route>
-        <Route path="/analytics" element={<AnalyticsPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/transactions" element={<TransactionsPage />} />
+          <Route path="/validators" element={<ValidatorsPage />}>
+            <Route path=":tab" element={<ValidatorsPage />} />
+          </Route>
+          <Route path="/validator">
+            <Route path=":address" element={<ValidatorPage />} />
+          </Route>
+          <Route path="/txn">
+            <Route path=":txnHashOrVersion" element={<TransactionPage />} />
+            <Route
+              path=":txnHashOrVersion/:tab"
+              element={<TransactionPage />}
+            />
+          </Route>
+          <Route path="/account">
+            <Route path=":address" element={<AccountPage />} />
+            <Route path=":address/:tab" element={<AccountPage />} />
+          </Route>
+          <Route path="/blocks" element={<BlocksPage />} />
+          <Route path="/block">
+            <Route path=":height" element={<BlockPage />} />
+            <Route path=":height/:tab" element={<BlockPage />} />
+          </Route>
+          <Route path="/token">
+            <Route path=":tokenId/:propertyVersion" element={<TokenPage />} />
+            <Route
+              path=":tokenId/:propertyVersion/:tab"
+              element={<TokenPage />}
+            />
+          </Route>
+          <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
     </ExplorerLayout>
   );
 }

--- a/src/components/Table/GeneralTableHeaderCell.tsx
+++ b/src/components/Table/GeneralTableHeaderCell.tsx
@@ -44,7 +44,10 @@ export default function GeneralTableHeaderCell({
   };
 
   const headerTextComponent = (
-    <Typography variant="subtitle1" sx={{fontSize: 15, lineHeight: "inherit"}}>
+    <Typography
+      variant="tableHeading"
+      sx={{fontSize: 15, lineHeight: "inherit"}}
+    >
       {header}
     </Typography>
   );

--- a/src/components/Table/TableTooltip.tsx
+++ b/src/components/Table/TableTooltip.tsx
@@ -22,7 +22,11 @@ export default function TableTooltip({children, title}: TableTooltipProps) {
 
   return (
     <>
-      <IconButton onClick={handleOpen} sx={{padding: 0.5}}>
+      <IconButton
+        aria-label="More Info"
+        onClick={handleOpen}
+        sx={{padding: 0.5}}
+      >
         <InfoOutlinedIcon sx={{fontSize: 15, color: "inherit"}} />
       </IconButton>
       <Modal open={open} onClose={handleClose}>

--- a/src/context/color-mode/ProvideColorMode.State.ts
+++ b/src/context/color-mode/ProvideColorMode.State.ts
@@ -1,5 +1,5 @@
-import { useMemo, useState, useEffect, useLayoutEffect } from "react";
-import { createTheme, responsiveFontSizes } from "@mui/material";
+import {useMemo, useState, useEffect, useLayoutEffect} from "react";
+import {createTheme, responsiveFontSizes} from "@mui/material";
 import getDesignTokens from "../../themes/theme";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
@@ -52,7 +52,7 @@ const useProvideColorMode = () => {
 
   let theme = useMemo(
     () => responsiveFontSizes(createTheme(getDesignTokens(mode))),
-    [mode]
+    [mode],
   );
 
   theme = createTheme(theme, {
@@ -72,7 +72,7 @@ const useProvideColorMode = () => {
     },
   });
 
-  return { toggleColorMode, theme };
+  return {toggleColorMode, theme};
 };
 
 export default useProvideColorMode;

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -1,7 +1,7 @@
 import {Types} from "aptos";
 import {Box, Grid, Stack, Typography, useTheme} from "@mui/material";
 import React, {useState} from "react";
-import {orderBy} from "lodash";
+import {orderBy} from "lodash-es";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import {
   solarizedLight,

--- a/src/pages/layout/Footer.tsx
+++ b/src/pages/layout/Footer.tsx
@@ -50,6 +50,7 @@ export default function Footer() {
         >
           <Grid xs="auto" container justifyContent="start">
             <Link
+              aria-label="Aptos Labs"
               color="inherit"
               href="https://aptoslabs.com/"
               target="_blank"

--- a/src/pages/layout/Header.tsx
+++ b/src/pages/layout/Header.tsx
@@ -108,6 +108,7 @@ export default function Header() {
             disableGutters
           >
             <Link
+              aria-label="Aptos Explorer"
               onClick={scrollTop}
               component={RRD.Link}
               to="/"
@@ -125,6 +126,7 @@ export default function Header() {
             <Nav />
             <NetworkSelect />
             <Button
+              aria-label="Toggle Dark / Light Mode"
               onClick={toggleColorMode}
               sx={{
                 width: "30px",

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -1,9 +1,8 @@
-import React, {useState} from "react";
+import React, {lazy, useState} from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import Header from "./Header";
-import Footer from "./Footer";
+
 import {GlobalStateProvider} from "../../GlobalState";
 import {ProvideColorMode} from "../../context";
 import {GraphqlClientProvider} from "../../api/hooks/useGraphqlClient";
@@ -21,6 +20,10 @@ import CloseIcon from "@mui/icons-material/Close";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import {primary} from "../../themes/colors/aptosColorPalette";
 import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
+
+const Header = lazy(() => import("./Header"));
+
+const Footer = lazy(() => import("./Footer"));
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -27,10 +27,12 @@ declare module "@mui/material/Divider" {
 declare module "@mui/material/styles" {
   interface TypographyVariants {
     stats: React.CSSProperties;
+    tableHeading: React.CSSProperties;
   }
   // allow configuration using `createTheme`
   interface TypographyVariantsOptions {
     stats?: React.CSSProperties;
+    tableHeading?: React.CSSProperties;
   }
 }
 
@@ -51,6 +53,7 @@ declare module "@mui/material/styles/createPalette" {
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
     stats: true;
+    tableHeading: true;
   }
 }
 
@@ -116,6 +119,10 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
       fontSize: "1rem",
       textTransform: "capitalize",
       lineHeight: "1.25",
+    },
+    tableHeading: {
+      fontFamily: `lft-etica-mono,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace`,
+      fontWeight: "400",
     },
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,7 +2521,14 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.191":
+"@types/lodash-es@^4.17.7":
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.7.tgz#22edcae9f44aff08546e71db8925f05b33c7cc40"
+  integrity sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.191":
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
@@ -2581,7 +2588,7 @@
   resolved "https://registry.yarnpkg.com/@types/react-addons-perf/-/react-addons-perf-15.4.0.tgz#5e15e74d31d16278fc445cda7975cfb50e586b8a"
   integrity sha512-5nwNZcVSsftqNj6kl/s48yKFL2VDQBPCPC1wkEeD430s9g/p80ysAYUOxCPBo7OU5OX7Ofo3KMrJzml5Jw8Now==
 
-"@types/react-dom@latest":
+"@types/react-dom@^18.0.11":
   version "18.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.11.tgz#321351c1459bc9ca3d216aefc8a167beec334e33"
   integrity sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==
@@ -2624,7 +2631,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@latest":
+"@types/react@*", "@types/react@^18.0.28":
   version "18.0.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
   integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
@@ -6063,6 +6070,13 @@ internmap@^1.0.0:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -7143,6 +7157,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.curry@^4.0.1:
   version "4.1.1"
@@ -8673,6 +8692,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-fast-compare@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-ga4@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-1.4.1.tgz#6ee2a2db115ed235b2f2092bc746b4eeeca9e206"
@@ -8682,6 +8706,17 @@ react-gtm-module@^2.0.11:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
   integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+
+react-helmet-async@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.3.0.tgz#7bd5bf8c5c69ea9f02f6083f14ce33ef545c222e"
+  integrity sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    invariant "^2.2.4"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.2.0"
+    shallowequal "^1.1.0"
 
 react-intersection-observer@^9.4.3:
   version "9.4.3"
@@ -9368,6 +9403,11 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Code Splitting

- Integrate basic [code splitting](https://reactjs.org/docs/code-splitting.html) using [React.Lazy](https://reactjs.org/docs/code-splitting.html#reactlazy) dynamic imports mostly on a route-centric approach for testing. This results in a reduction of `main.js` by `-749.01 kB`. Ideally, the dynamic imports should be done on a container component basis (with skeleton loaders as placeholder), rather than the entire route. 

Breaking a large JavaScript file into smaller chunks results in a reduction of initial load time, improved caching, parallelism can be leveraged with HTTP/2, and critical files can be prioritized.

Before:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/98909677/225205857-0061a81a-4652-4884-9da3-70fae4618527.png">

After:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/98909677/225205574-4d446bdf-d1e0-45ed-b8cb-9f7432204019.png">

Before:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/98909677/225212194-b9437983-9fe4-4cf0-a2be-fd82500843ca.png">

After:
<img width="690" alt="image" src="https://user-images.githubusercontent.com/98909677/225212330-6369909a-51a3-4c97-aa4d-d71159eb1caa.png">


### Dependencies / 3rd Party JS

- Switch from [Lodash](https://www.npmjs.com/package/lodash) to [Lodash-es](https://www.npmjs.com/package/lodash-es), which is a modularized version of the library optimized for modern ES6 modules and tree-shaking capabilities. Regular Lodash is not optimized for tree-shaking and may include unnecessary code in the final bundle (saves about 30kb).
- Incorporate [react-helmet-async](https://www.npmjs.com/package/react-helmet-async) to manage 3rd-party scripts, eliminate render-blocking resources, and provide a simple method for page metadata on all routes

- TODO: Clean things up by moving individual inline scripts into their own components


### Replace ReactDOM.render with createRoot()

- ReactDOM.render is no longer supported in React 18 and is considered legacy, switch to [createRoot()](https://beta.reactjs.org/reference/react-dom/client/createRoot)


### Remove unused fonts loaded from Adobe Typekit

- We had about 6 unused font weights significantly adding to overall page size


### Additional Lighthouse Tweaks

- Table Headings are no longer `h6` elements, as this results in a score drop as headings being used out of order. Using heading tags in the correct order improves the user experience for screen readers and helps search engines better understand page content.

- Incorporate `aria-label` for links to improve accessibility score
