### PR TITLE
[delegation] Fix Safari blank screen due to regular expression error

### DIFF
--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -134,7 +134,7 @@ export default function StakeOperationDialog({
     handleDialogClose();
     setAmount("");
   };
-  
+
   const stakeDialog = (
     <StyledDialog handleDialogClose={handleClose} open={isDialogOpen}>
       <DialogTitle variant="h5" textAlign="center">

--- a/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
+++ b/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
@@ -7,6 +7,14 @@ import {MINIMUM_APT_IN_POOL_FOR_EXPLORER} from "../constants";
 import {OCTA} from "../../../constants";
 import {Types} from "aptos";
 
+function sanitizeInput(input: string): string {
+  const digitsAndDecimals = /[0-9.]/g;
+  const multipleDecimals = /\.(?=.*\.)/g;
+
+  const sanitizedInput = input.match(digitsAndDecimals)?.join("");
+  return sanitizedInput?.replace(multipleDecimals, "") ?? "";
+}
+
 function isValidAmount(
   amount: string,
   minimumAmount: number | null,
@@ -33,7 +41,8 @@ const useAmountInput = (stakeOperation: StakeOperation) => {
   }, [amount]);
 
   const onAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAmount(event.target.value.replace(/(?<=^[^.]*\.[^.]*)\.|[^0-9.]/g, ""));
+    const sanitizedInput = sanitizeInput(event.target.value);
+    setAmount(sanitizedInput);
   };
 
   function clearAmount() {


### PR DESCRIPTION
Safari was showing blank screen with the syntax error: `Invalid regular expression: invalid group specifier name` most likely due to positive lookbehind assertion `(?<=...)` used in the regular expression within `replace()`, which doesn't seem supported in Safari.

Modified with a function to separate the logic of removing non-digit characters from the logic of removing extra decimal points. 

Before:
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/98909677/225274679-706fa920-69e2-4f64-bbbf-fec0ef74402f.png">

After:
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/98909677/225276489-a0c1240e-612d-46f0-bbbd-8fa8a6143844.png">

