### PR TITLE
[explorer] fix code block circle radius

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -614,6 +614,7 @@ function Code({bytecode}: {bytecode: string}) {
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
+            customStyle={{margin: 0}}
             showLineNumbers
           >
             {sourceCode}


### PR DESCRIPTION
before
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/101405096/226485066-1149cd94-95aa-4356-ad18-038d5de9f402.png">

after
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/101405096/226485036-d7a8cc5b-0864-4d46-9905-93dafd34e833.png">
