### PR TITLE
[explorer] fix circle radius in expanded code block

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -663,6 +663,7 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
+            customStyle={{margin: 0}}
             showLineNumbers
           >
             {sourceCode!}


### PR DESCRIPTION
before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226496721-be5da926-1a18-4279-89ca-128bfcab7fbf.png">

after
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226496691-d00d0454-913d-4315-b9ac-da9a8faee791.png">
