### PR TITLE
[explorer] refactor modules tabs to reuse existing pattern

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -30,8 +30,12 @@ export default function ExplorerRoutes() {
           <Route path=":txnHashOrVersion/:tab" element={<TransactionPage />} />
         </Route>
         <Route path="/account">
-          <Route path=":address" element={<AccountPage />} />
+          <Route
+            path=":address/modules/:modulesTab"
+            element={<AccountPage />}
+          />
           <Route path=":address/:tab" element={<AccountPage />} />
+          <Route path=":address" element={<AccountPage />} />
         </Route>
         <Route path="/blocks" element={<BlocksPage />} />
         <Route path="/block">

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -92,9 +92,14 @@ export default function AccountTabs({
   accountData,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
-  const {tab} = useParams();
+  const {modulesTab, tab} = useParams();
   const navigate = useNavigate();
-  const value = tab === undefined ? TAB_VALUES[0] : (tab as TabValue);
+  const value =
+    tab === undefined
+      ? modulesTab === undefined
+        ? TAB_VALUES[0]
+        : "modules"
+      : (tab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
     navigate(`/account/${address}/${newValue}`);

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -30,7 +30,7 @@ import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {useGetAccountResource} from "../../../api/hooks/useGetAccountResource";
-import {getBytecodeSizeInKB, transformCode} from "../../../utils";
+import {assertNever, getBytecodeSizeInKB, transformCode} from "../../../utils";
 import {grey} from "../../../themes/colors/aptosColorPalette";
 import StyledTabs from "../../../components/StyledTabs";
 import StyledTab from "../../../components/StyledTab";
@@ -43,6 +43,75 @@ import {Controller, SubmitHandler, useForm} from "react-hook-form";
 import useSubmitTransaction from "../../../api/hooks/useSubmitTransaction";
 import StyledTooltip from "../../../components/StyledTooltip";
 import {OpenInFull} from "@mui/icons-material";
+import {useNavigate, useParams} from "react-router-dom";
+
+const TabComponents = Object.freeze({
+  code: ViewCode,
+  write: WriteContract,
+});
+
+type TabValue = keyof typeof TabComponents;
+
+function getTabLabel(value: TabValue): string {
+  switch (value) {
+    case "code":
+      return "View Code";
+    case "write":
+      return "Write";
+    default:
+      return assertNever(value);
+  }
+}
+
+type TabPanelProps = {
+  value: TabValue;
+  address: string;
+};
+
+function TabPanel({value, address}: TabPanelProps): JSX.Element {
+  const TabComponent = TabComponents[value];
+  return <TabComponent address={address} />;
+}
+
+function ModulesTabs({address}: {address: string}): JSX.Element {
+  const theme = useTheme();
+  const tabValues = Object.keys(TabComponents) as TabValue[];
+  const {modulesTab} = useParams();
+  const navigate = useNavigate();
+  const value =
+    modulesTab === undefined ? tabValues[0] : (modulesTab as TabValue);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
+    navigate(`/account/${address}/modules/${newValue}`);
+  };
+
+  return (
+    <Box sx={{width: "100%"}}>
+      <Box
+        padding={2}
+        marginY={4}
+        borderColor="red"
+        borderRadius={1}
+        bgcolor={theme.palette.mode === "dark" ? grey[800] : grey[100]}
+      >
+        <StyledTabs value={value} onChange={handleChange}>
+          {tabValues.map((value, i) => (
+            <StyledTab
+              key={i}
+              value={value}
+              label={getTabLabel(value)}
+              isFirst={i === 0}
+              isLast={i === tabValues.length - 1}
+            />
+          ))}
+        </StyledTabs>
+      </Box>
+      <Box>
+        <TabPanel value={value} address={address} />
+      </Box>
+    </Box>
+  );
+}
 
 type PackageMetadata = {
   name: string;
@@ -129,47 +198,6 @@ function ModulesContent({address}: {address: string}) {
         </CollapsibleCard>
       ))}
     </CollapsibleCards>
-  );
-}
-
-function ModulesReworked({address}: {address: string}): JSX.Element {
-  const [action, setAction] = useState<ContractAction>("View code");
-  return (
-    <Box>
-      <ModulesActionTabs
-        options={CONTRACT_ACTIONS}
-        action={action}
-        setAction={setAction}
-      />
-      {action === "View code" && <ViewCode address={address} />}
-      {action === "Write" && <WriteContract address={address} />}
-    </Box>
-  );
-}
-
-function ModulesActionTabs({
-  options,
-  action,
-  setAction,
-}: {
-  options: readonly ContractAction[];
-  action: ContractAction;
-  setAction: (action: ContractAction) => void;
-}) {
-  return (
-    <Box padding={2} marginY={4} borderRadius={1}>
-      <StyledTabs value={action} onChange={(e, v) => setAction(v)}>
-        {options.map((value, i) => (
-          <StyledTab
-            key={i}
-            value={value}
-            label={value}
-            isFirst={i === 0}
-            isLast={i === options.length - 1}
-          />
-        ))}
-      </StyledTabs>
-    </Box>
   );
 }
 
@@ -726,13 +754,12 @@ function ABI({address, moduleName}: {address: string; moduleName: string}) {
 
 type ModulesTabProps = {
   address: string;
-  accountData: Types.AccountData | undefined;
 };
 
 export default function ModulesTab({address}: ModulesTabProps) {
   const [state, _] = useGlobalState();
   if (state.feature_name === "earlydev")
-    return <ModulesReworked address={address} />;
+    return <ModulesTabs address={address} />;
   if (state.feature_name === "dev")
     return (
       <Box marginTop={4}>


### PR DESCRIPTION
/account/0x1/modules/code
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226785576-d567c2a8-cdc3-4d2b-99ad-7f5690cc72bf.png">

/account/0x1/modules/write
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226785632-bdf60d0f-d49f-4c57-ad23-c996db497e1f.png">

/account/0x1/modules
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226785686-0b51c133-1414-4af4-a65a-a8da3105a877.png">

/account/0x1/resources (still working)
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/226785738-98a73134-8b7f-4963-8c7e-9af18df9b15b.png">
