### PR TITLE
[delegation] update testnet delegation address to 0x1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Local Netlify folder
+.netlify

--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -35,7 +35,7 @@ export function useGetDelegationNodeInfo({
     "0x1::delegation_pool::DelegationPool",
   );
   const client = new AptosClient(state.network_value);
-  const [commission, setCommission] = useState<Types.MoveValue>();
+  const [commission, setCommission] = useState<Types.MoveValue[]>();
   const [delegatedStakeAmount, setDelegatedStakeAmount] = useState<string>();
   const [networkPercentage, setNetworkPercentage] = useState<string>();
   const [isQueryLoading, setIsQueryLoading] = useState<boolean>(true);
@@ -61,7 +61,7 @@ export function useGetDelegationNodeInfo({
   }, [state.network_value, totalVotingPower, isLoading, delegationPool]);
 
   return {
-    commission: commission ? Number(commission) / 100 : undefined, // commission rate: 22.85% is represented as 2285
+    commission: commission ? Number(commission[0]) / 100 : undefined, // commission rate: 22.85% is represented as 2285
     networkPercentage,
     delegatedStakeAmount,
     isQueryLoading,

--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -1,7 +1,6 @@
 import {AptosClient, Types} from "aptos";
 import {useState, useMemo} from "react";
 import {getValidatorCommission} from "..";
-import {DELEGATION_POOL_ADDRESS} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
 import {useGetAccountResource} from "./useGetAccountResource";
 import {ValidatorData} from "./useGetValidators";
@@ -15,7 +14,7 @@ interface DelegationPool {
 
 type DelegationNodeInfoResponse = {
   delegatedStakeAmount: string | undefined;
-  networkPercentage?: string;
+  networkPercentage: string | undefined;
   commission: number | undefined;
   isQueryLoading: boolean;
 };
@@ -33,7 +32,7 @@ export function useGetDelegationNodeInfo({
   const {totalVotingPower} = useGetValidatorSet();
   const {data: delegationPool, isLoading} = useGetAccountResource(
     validatorAddress,
-    `${DELEGATION_POOL_ADDRESS}::delegation_pool::DelegationPool`,
+    "0x1::delegation_pool::DelegationPool",
   );
   const client = new AptosClient(state.network_value);
   const [commission, setCommission] = useState<Types.MoveValue>();

--- a/src/api/hooks/useSubmitStakeOperation.ts
+++ b/src/api/hooks/useSubmitStakeOperation.ts
@@ -1,5 +1,4 @@
 import {Types} from "aptos";
-import {DELEGATION_POOL_ADDRESS} from "../../constants";
 import useSubmitTransaction from "./useSubmitTransaction";
 
 // enum name => delegation pool smart contract view function name
@@ -25,7 +24,7 @@ const useSubmitStakeOperation = () => {
   ) {
     const payload: Types.TransactionPayload = {
       type: "entry_function_payload",
-      function: `${DELEGATION_POOL_ADDRESS}::delegation_pool::${stakeOperation}`,
+      function: `0x1::delegation_pool::${stakeOperation}`,
       type_arguments: [],
       arguments: [owner_address, amount], // staking operation uses OCTA as amount basis
     };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -225,7 +225,7 @@ export async function getStake(
 export async function getValidatorCommission(
   client: AptosClient,
   validatorAddress: Types.Address,
-): Promise<Types.MoveValue> {
+): Promise<Types.MoveValue[]> {
   const payload: Types.ViewRequest = {
     function: "0x1::delegation_pool::operator_commission_percentage",
     type_arguments: [],
@@ -237,7 +237,7 @@ export async function getValidatorCommission(
 export async function getDelegationPoolExist(
   client: AptosClient,
   validatorAddress: Types.Address,
-): Promise<Types.MoveValue> {
+): Promise<Types.MoveValue[]> {
   const payload: Types.ViewRequest = {
     function: "0x1::delegation_pool::delegation_pool_exists",
     type_arguments: [],

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,4 @@
 import {AptosClient, Types} from "aptos";
-import {DELEGATION_POOL_ADDRESS} from "../constants";
 import {isNumeric} from "../pages/utils";
 import {sortTransactions} from "../utils";
 import {withResponseError} from "./client";
@@ -216,11 +215,11 @@ export async function getStake(
   validatorAddress: Types.Address,
 ): Promise<Types.MoveValue[]> {
   const payload: Types.ViewRequest = {
-    function: `${DELEGATION_POOL_ADDRESS}::delegation_pool::get_stake`,
+    function: "0x1::delegation_pool::get_stake",
     type_arguments: [],
     arguments: [validatorAddress, delegatorAddress],
   };
-  return await client.view(payload);
+  return withResponseError(client.view(payload));
 }
 
 export async function getValidatorCommission(
@@ -228,9 +227,21 @@ export async function getValidatorCommission(
   validatorAddress: Types.Address,
 ): Promise<Types.MoveValue> {
   const payload: Types.ViewRequest = {
-    function: `${DELEGATION_POOL_ADDRESS}::delegation_pool::operator_commission_percentage`,
+    function: "0x1::delegation_pool::operator_commission_percentage",
     type_arguments: [],
     arguments: [validatorAddress],
   };
-  return await client.view(payload);
+  return withResponseError(client.view(payload));
+}
+
+export async function getDelegationPoolExist(
+  client: AptosClient,
+  validatorAddress: Types.Address,
+): Promise<Types.MoveValue> {
+  const payload: Types.ViewRequest = {
+    function: "0x1::delegation_pool::delegation_pool_exists",
+    type_arguments: [],
+    arguments: [validatorAddress],
+  };
+  return withResponseError(client.view(payload));
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -68,17 +68,4 @@ export const defaultFeature = features[defaultFeatureName];
 /**
  * Delegation Service
  */
-
-// TODO(jill): update this function name once in mainnet
-export const DELEGATION_POOL_ADDRESS =
-  process.env.REACT_APP_DELEGATION_POOL_ADDRESS ??
-  "0x1310dc820487f24755e6e06747f6582118597a48868e2a98260fa8c3ee945cbd";
 export const OCTA = 100000000;
-export const MIN_ADD_STAKE_AMOUNT = 1; // min stake amount is 1 APT
-export const WHILTELISTED_TESTNET_DELEGATION_NODES = process.env
-  .REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES
-  ? process.env.REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES.split(",")
-  : [
-      "0x5df905f817adf39293c596e83512ab8a9dc5a19980e11bd4ce44b6e749d33a0d",
-      "0xa396d898018d6892b148789ed8a95e0bd6af05e0974cef3d5a1197ee2fa4519e",
-    ];

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -69,3 +69,7 @@ export const defaultFeature = features[defaultFeatureName];
  * Delegation Service
  */
 export const OCTA = 100000000;
+export const WHILTELISTED_TESTNET_DELEGATION_NODES = process.env
+  .REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES
+  ? process.env.REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES.split(",")
+  : null;

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -1,13 +1,12 @@
-import React, {useEffect, useState} from "react";
+import React, {useEffect, useMemo, useState} from "react";
 import {alpha, Box, Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../utils";
 import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
-import {useGetInDevMode} from "../../api/hooks/useGetInDevMode";
 import {useNavigate} from "react-router-dom";
-import {Types} from "aptos";
+import {AptosClient, Types} from "aptos";
 import {
   ValidatorData,
   useGetValidators,
@@ -19,12 +18,7 @@ import {aptosColor, grey, primary} from "../../themes/colors/aptosColorPalette";
 import {useGlobalState} from "../../GlobalState";
 import {StyledLearnMoreTooltip} from "../../components/StyledTooltip";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
-import {Network, WHILTELISTED_TESTNET_DELEGATION_NODES} from "../../constants";
-import {
-  OperatorAddrCell,
-  ValidatorAddrCell,
-  ValidatorCellProps,
-} from "./ValidatorsTable";
+import {OperatorAddrCell, ValidatorAddrCell} from "./ValidatorsTable";
 import {useGetNumberOfDelegators} from "../../api/hooks/useGetNumberOfDelegators";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
@@ -32,6 +26,7 @@ import {Button} from "@mui/material";
 import {useGetDelegatorStakeInfo} from "../../api/hooks/useGetDelegatorStakeInfo";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import {Stack} from "@mui/material";
+import {getDelegationPoolExist} from "../../api";
 
 function getSortedValidators(
   validators: ValidatorData[],
@@ -105,6 +100,7 @@ type ValidatorHeaderCellProps = {
   direction?: "desc" | "asc";
   setDirection?: (dir: "desc" | "asc") => void;
   setSortColumn: (col: Column) => void;
+  connected: boolean;
 };
 
 function ValidatorHeaderCell({
@@ -112,6 +108,7 @@ function ValidatorHeaderCell({
   direction,
   setDirection,
   setSortColumn,
+  connected,
 }: ValidatorHeaderCellProps) {
   switch (column) {
     case "addr":
@@ -154,6 +151,7 @@ function ValidatorHeaderCell({
             <StyledLearnMoreTooltip text="Amount of rewards earned by this stake pool to date" />
           }
           isTableTooltip={false}
+          textAlignRight={!connected}
         />
       );
     case "commission":
@@ -207,16 +205,31 @@ const DEFAULT_COLUMNS: Column[] = [
   "myDeposit",
 ];
 
+const COLUMNS_WITHOUT_WALLET_CONNECTION: Column[] = [
+  "view",
+  "addr",
+  "operatorAddr",
+  "delegatedAmount",
+  "commission",
+  "delegator",
+  "rewardsEarned",
+];
+
 type ValidatorRowProps = {
   validator: ValidatorData;
   columns: Column[];
+  connected: boolean;
 };
 
-function CommissionCell({validator}: ValidatorCellProps) {
-  const {commission} = useGetDelegationNodeInfo({
-    validatorAddress: validator.owner_address,
-    validator,
-  });
+type ValidatorCellProps = {
+  validator: ValidatorData;
+  delegatedStakeAmount: string | undefined;
+  networkPercentage?: string;
+  commission: number | undefined;
+  connected: boolean;
+};
+
+function CommissionCell({commission}: ValidatorCellProps) {
   return (
     <GeneralTableCell sx={{paddingRight: 10, textAlign: "right"}}>
       {commission && `${commission}%`}
@@ -227,15 +240,21 @@ function CommissionCell({validator}: ValidatorCellProps) {
 function DelegatorCell({validator}: ValidatorCellProps) {
   const {delegatorBalance} = useGetNumberOfDelegators(validator.owner_address);
   return (
-    <GeneralTableCell sx={{paddingRight: 10, textAlign: "right"}}>
+    <GeneralTableCell sx={{paddingRight: 15, textAlign: "right"}}>
       {delegatorBalance}
     </GeneralTableCell>
   );
 }
 
-function RewardsEarnedCell({validator}: ValidatorCellProps) {
+function RewardsEarnedCell({validator, connected}: ValidatorCellProps) {
   return (
-    <GeneralTableCell sx={{paddingRight: 10, textAlign: "right"}}>
+    <GeneralTableCell
+      sx={
+        connected
+          ? {paddingRight: 10, textAlign: "right"}
+          : {textAlign: "right"}
+      }
+    >
       <APTCurrencyValue
         amount={Number(validator.apt_rewards_distributed).toFixed(2)}
         decimals={0}
@@ -244,14 +263,12 @@ function RewardsEarnedCell({validator}: ValidatorCellProps) {
   );
 }
 
-function DelegatedAmountCell({validator}: ValidatorCellProps) {
-  const {delegatedStakeAmount, networkPercentage} = useGetDelegationNodeInfo({
-    validatorAddress: validator.owner_address,
-    validator,
-  });
-
+function DelegatedAmountCell({
+  delegatedStakeAmount,
+  networkPercentage,
+}: ValidatorCellProps) {
   return (
-    <GeneralTableCell sx={{paddingRight: 10, textAlign: "right"}}>
+    <GeneralTableCell sx={{paddingRight: 15, textAlign: "right"}}>
       <Box>
         <APTCurrencyValue
           amount={delegatedStakeAmount ?? ""}
@@ -283,13 +300,13 @@ function ViewCell() {
 
 function MyDepositCell({validator}: ValidatorCellProps) {
   const [totalDeposit, setTotalDeposit] = useState<Types.MoveValue>();
-  const {connected, account} = useWallet();
+  const {account} = useWallet();
   const {stakes} = useGetDelegatorStakeInfo(
     account?.address!,
     validator.owner_address,
   );
 
-  useEffect(() => {
+  useMemo(() => {
     setTotalDeposit(
       stakes.reduce(
         (prev, current) =>
@@ -298,11 +315,11 @@ function MyDepositCell({validator}: ValidatorCellProps) {
         0,
       ),
     );
-  }, [stakes, account, connected]);
+  }, [stakes, account]);
 
   return (
     <GeneralTableCell sx={{paddingRight: 5, textAlign: "right"}}>
-      {connected && Number(totalDeposit) !== 0 ? (
+      {Number(totalDeposit) !== 0 ? (
         <Stack direction="row" spacing={1.5}>
           <CheckCircleIcon sx={{color: aptosColor}} fontSize="small" />
           <CurrencyValue
@@ -318,21 +335,32 @@ function MyDepositCell({validator}: ValidatorCellProps) {
   );
 }
 
-function ValidatorRow({validator, columns}: ValidatorRowProps) {
-  const inDev = useGetInDevMode();
+function ValidatorRow({validator, columns, connected}: ValidatorRowProps) {
   const navigate = useNavigate();
-
   const rowClick = (address: Types.Address) => {
     navigate(`/validator/${address}`);
   };
 
+  const {commission, delegatedStakeAmount, networkPercentage} =
+    useGetDelegationNodeInfo({
+      validatorAddress: validator.owner_address,
+      validator,
+    });
+
   return (
-    <GeneralTableRow
-      onClick={inDev ? () => rowClick(validator.owner_address) : undefined}
-    >
+    <GeneralTableRow onClick={() => rowClick(validator.owner_address)}>
       {columns.map((column) => {
         const Cell = DelegationValidatorCells[column];
-        return <Cell key={column} validator={validator} />;
+        return (
+          <Cell
+            key={column}
+            validator={validator}
+            commission={commission}
+            delegatedStakeAmount={delegatedStakeAmount}
+            networkPercentage={networkPercentage}
+            connected={connected}
+          />
+        );
       })}
     </GeneralTableRow>
   );
@@ -341,43 +369,67 @@ function ValidatorRow({validator, columns}: ValidatorRowProps) {
 export function DelegationValidatorsTable() {
   const [state, _] = useGlobalState();
   const {validators} = useGetValidators(state.network_name);
-
+  const {connected} = useWallet();
+  const columns = connected
+    ? DEFAULT_COLUMNS
+    : COLUMNS_WITHOUT_WALLET_CONNECTION;
   const [sortColumn, setSortColumn] = useState<Column>("delegatedAmount");
   const [sortDirection, setSortDirection] = useState<"desc" | "asc">("desc");
-  const whitelistedTestnetDelegationValidators: ValidatorData[] =
-    validators.filter((validator) =>
-      WHILTELISTED_TESTNET_DELEGATION_NODES.includes(validator.owner_address),
-    );
   const sortedValidators = getSortedValidators(
-    state.network_name === Network.TESTNET
-      ? whitelistedTestnetDelegationValidators
-      : [],
+    validators,
     sortColumn,
     sortDirection,
   );
+  const client = new AptosClient(state.network_value);
+  const [delegationValidators, setDelegationValidators] = useState<
+    ValidatorData[]
+  >([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      const promises = sortedValidators.map(async (validator) => {
+        const delegationPoolExist = await getDelegationPoolExist(
+          client,
+          validator.owner_address,
+        );
+        if (delegationPoolExist.toString() === "true") {
+          return validator;
+        }
+      });
+      const filteredValidators = await Promise.all(promises);
+      setDelegationValidators(
+        filteredValidators.filter(
+          (validator) => validator !== undefined,
+        ) as ValidatorData[],
+      );
+    }
+    fetchData();
+  }, []);
 
   return (
     <Table>
       <TableHead>
         <TableRow sx={{verticalAlign: "bottom"}}>
-          {DEFAULT_COLUMNS.map((column) => (
+          {columns.map((column) => (
             <ValidatorHeaderCell
               key={column}
               column={column}
               direction={sortColumn === column ? sortDirection : undefined}
               setDirection={setSortDirection}
               setSortColumn={setSortColumn}
+              connected={connected}
             />
           ))}
         </TableRow>
       </TableHead>
       <GeneralTableBody>
-        {sortedValidators.map((validator: any, i: number) => {
+        {delegationValidators.map((validator: any, i: number) => {
           return (
             <ValidatorRow
               key={i}
               validator={validator}
-              columns={DEFAULT_COLUMNS}
+              columns={columns}
+              connected={connected}
             />
           );
         })}

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -27,6 +27,7 @@ import {useGetDelegatorStakeInfo} from "../../api/hooks/useGetDelegatorStakeInfo
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import {Stack} from "@mui/material";
 import {getDelegationPoolExist} from "../../api";
+import {WHILTELISTED_TESTNET_DELEGATION_NODES} from "../../constants";
 
 function getSortedValidators(
   validators: ValidatorData[],
@@ -392,7 +393,7 @@ export function DelegationValidatorsTable() {
           client,
           validator.owner_address,
         );
-        if (delegationPoolExist.toString() === "true") {
+        if (delegationPoolExist[0]) {
           return validator;
         }
       });
@@ -403,8 +404,18 @@ export function DelegationValidatorsTable() {
         ) as ValidatorData[],
       );
     }
-    fetchData();
-  }, []);
+    if (WHILTELISTED_TESTNET_DELEGATION_NODES) {
+      setDelegationValidators(
+        validators.filter((validator) =>
+          WHILTELISTED_TESTNET_DELEGATION_NODES!.includes(
+            validator.owner_address,
+          ),
+        ),
+      );
+    } else {
+      fetchData();
+    }
+  }, [validators, state.network_value]);
 
   return (
     <Table>

--- a/src/pages/Validators/ValidatorsTable.tsx
+++ b/src/pages/Validators/ValidatorsTable.tsx
@@ -163,7 +163,7 @@ function ValidatorHeaderCell({
   }
 }
 
-export type ValidatorCellProps = {
+type ValidatorCellProps = {
   validator: ValidatorData;
 };
 


### PR DESCRIPTION
1. use 0x1 since delegation's in released in testnet
2. first check whether validator has delegation pool before querying all the delegation related info. so that we don't run into tons of network errors that will lead to 429
3. use whitelisted validator address again so that we can avoid querying view function on whether delegation pool exists or not for all validators, to save network query.

<img width="1082" alt="Screenshot 2023-03-22 at 12 43 35 PM" src="https://user-images.githubusercontent.com/121921928/227018684-c693ca67-bd9a-4083-8fa7-f4fc49eca1aa.png">
