### PR TITLE
[delegation] fix constant refreshing

### DIFF
--- a/src/components/IntervalBar.tsx
+++ b/src/components/IntervalBar.tsx
@@ -36,7 +36,7 @@ export default function IntervalBar({
     seconds: number;
     completed: boolean;
   }) => {
-    if (completed) {
+    if (completed && intervalType === IntervalType.EPOCH) {
       window.location.reload();
     }
     switch (intervalType) {


### PR DESCRIPTION
temp mitigation on the constant refreshing issue in delegation validator page to exclude the window reload for delegation use case.

### context
 for the specific validator, `0xfd47a2fb988c959839ea2fe4d7169b48536a42bf5e4933790701a08252ba2039` on 0x1, lockup cycle already ends and doesn't get updated to a new lockup cycle. so window.reload is constantly triggered.

i'm working on a long-term solution rn. 