### PR TITLE
[delegation] add inactive validator scenario for countdown bar

### DIFF
--- a/src/components/IntervalBar.tsx
+++ b/src/components/IntervalBar.tsx
@@ -36,7 +36,10 @@ export default function IntervalBar({
     seconds: number;
     completed: boolean;
   }) => {
-    if (completed && intervalType === IntervalType.EPOCH) {
+    if (timestamp < Date.now()) {
+      return <span>Validator's no longer active</span>;
+    }
+    if (completed) {
       window.location.reload();
     }
     switch (intervalType) {


### PR DESCRIPTION
### this pr
- when lockup cycle only exists in the past, meaning that validator's no longer active and lockup cycle will not get updated anymore. this pr is to add this edge case in.

### future PR
- need to use view function to check whether funds are withdrawble. cuz once validator is in inactive status, funds will not be moved from pending_inactive to inactive pool automatically, since the move is initiated with epoch change and lockup cycle change but lockup cycle will not be changed for inactive validators. 


<img width="573" alt="Screenshot 2023-03-23 at 3 57 47 PM" src="https://user-images.githubusercontent.com/121921928/227382834-316d9102-f139-473a-92b3-546cd457a62d.png">
