### PR TITLE
[explorer] use the same background color for source code and json view

### DIFF
--- a/src/components/CodeLineBox.tsx
+++ b/src/components/CodeLineBox.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import {Box, SxProps, Theme, useTheme} from "@mui/material";
+import {codeBlockColor} from "../themes/colors/aptosColorPalette";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";
-const BACKGROUND_COLOR = "rgba(14,165,233,0.1)";
 
 export function CodeLineBox({
   children,
@@ -20,7 +20,7 @@ export function CodeLineBox({
           width: "max-content",
           color:
             theme.palette.mode === "dark" ? TEXT_COLOR_DARK : TEXT_COLOR_LIGHT,
-          backgroundColor: BACKGROUND_COLOR,
+          backgroundColor: codeBlockColor,
           padding: "0.35rem 1rem 0.35rem 1rem",
           overflow: "hidden",
           whiteSpace: "nowrap",

--- a/src/components/IndividualPageContent/JsonCard.tsx
+++ b/src/components/IndividualPageContent/JsonCard.tsx
@@ -5,10 +5,10 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import EmptyValue from "./ContentValue/EmptyValue";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import StyledTooltip from "../StyledTooltip";
+import {codeBlockColor} from "../../themes/colors/aptosColorPalette";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";
-const BACKGROUND_COLOR = "rgba(14,165,233,0.1)";
 const CARD_HEIGHT = 60;
 const EXPANDED_CARD_HEIGHT = 500;
 const TOOLTIP_TIME = 2000; // 2s
@@ -60,7 +60,7 @@ export default function JsonCard({
       sx={{
         color:
           theme.palette.mode === "dark" ? TEXT_COLOR_DARK : TEXT_COLOR_LIGHT,
-        backgroundColor: BACKGROUND_COLOR,
+        backgroundColor: codeBlockColor,
         "&:hover": {
           boxShadow: expandable ? "1px 1px 3px 3px rgba(0, 0, 0, 0.05)" : "",
         },

--- a/src/components/IndividualPageContent/JsonViewCard.tsx
+++ b/src/components/IndividualPageContent/JsonViewCard.tsx
@@ -1,12 +1,12 @@
 import {Box, useTheme} from "@mui/material";
 import React from "react";
 import ReactJson from "react-json-view";
+import {codeBlockColor} from "../../themes/colors/aptosColorPalette";
 import EmptyValue from "./ContentValue/EmptyValue";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";
 const SECONDARY_TEXT_COLOR = "rgba(14,165,233,0.3)";
-const BACKGROUND_COLOR = "rgba(14,165,233,0.1)";
 const TRANSPARENT = "rgba(0,0,0,0)";
 
 const GROUP_ARRAYS_AFTER_LENGTH = 100;
@@ -58,7 +58,7 @@ export default function JsonViewCard({
   return (
     <Box
       sx={{
-        backgroundColor: BACKGROUND_COLOR,
+        backgroundColor: codeBlockColor,
         overflow: "auto",
         maxHeight: MAX_CARD_HEIGHT,
       }}

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -31,7 +31,12 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {useGetAccountResource} from "../../../api/hooks/useGetAccountResource";
 import {assertNever, getBytecodeSizeInKB, transformCode} from "../../../utils";
-import {grey} from "../../../themes/colors/aptosColorPalette";
+import {
+  codeBlockColor,
+  codeBlockColorRgbDark,
+  codeBlockColorRgbLight,
+  grey,
+} from "../../../themes/colors/aptosColorPalette";
 import StyledTabs from "../../../components/StyledTabs";
 import StyledTab from "../../../components/StyledTab";
 import {useGetAccountModules} from "../../../api/hooks/useGetAccountModules";
@@ -665,10 +670,11 @@ function Code({bytecode}: {bytecode: string}) {
         >
           <SyntaxHighlighter
             language="rust"
+            key={theme.palette.mode}
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
-            customStyle={{margin: 0, backgroundColor: "rgba(14,165,233,0.1)"}}
+            customStyle={{margin: 0, backgroundColor: codeBlockColor}}
             showLineNumbers
           >
             {sourceCode}
@@ -721,6 +727,7 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
         >
           <SyntaxHighlighter
             language="rust"
+            key={theme.palette.mode}
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
@@ -728,8 +735,8 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
               margin: 0,
               backgroundColor:
                 theme.palette.mode === "light"
-                  ? "rgb(227,236,243)"
-                  : "rgb(33,45,50)",
+                  ? codeBlockColorRgbLight
+                  : codeBlockColorRgbDark,
             }}
             showLineNumbers
           >

--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -668,7 +668,7 @@ function Code({bytecode}: {bytecode: string}) {
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
-            customStyle={{margin: 0}}
+            customStyle={{margin: 0, backgroundColor: "rgba(14,165,233,0.1)"}}
             showLineNumbers
           >
             {sourceCode}
@@ -724,7 +724,13 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
             style={
               theme.palette.mode === "light" ? solarizedLight : solarizedDark
             }
-            customStyle={{margin: 0}}
+            customStyle={{
+              margin: 0,
+              backgroundColor:
+                theme.palette.mode === "light"
+                  ? "rgb(227,236,243)"
+                  : "rgb(33,45,50)",
+            }}
             showLineNumbers
           >
             {sourceCode!}

--- a/src/themes/colors/aptosColorPalette.ts
+++ b/src/themes/colors/aptosColorPalette.ts
@@ -30,3 +30,9 @@ export const primary = {
 export const aptosColor = primary[600];
 export const negativeColor: string = "#F97373";
 export const warningColor: string = "#f1c232";
+
+// code block colors
+export const codeBlockColor: string = "rgba(14,165,233,0.1)";
+// use rgb for codeblock in modal otherwise it will be transparent and not very visible
+export const codeBlockColorRgbLight: string = "#E3ECF3";
+export const codeBlockColorRgbDark: string = "#212D32";


### PR DESCRIPTION
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228392503-24aa9125-a5e4-42a3-923b-b8909c4560bf.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228392529-79d2a254-f130-490a-a135-1a5de42b05d2.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228392479-f5a6407e-40df-406e-8093-291e414f4325.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228392545-b58e1565-eb04-4648-85f2-58281c4afa23.png">
