### PR TITLE
[explorer] fix copy code button and expand code button style

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -636,9 +636,15 @@ function Code({bytecode}: {bytecode: string}) {
               variant="outlined"
               onClick={copyCode}
               disabled={!sourceCode}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                height: "2rem",
+                borderRadius: "0.5rem",
+              }}
             >
-              <ContentCopyIcon />{" "}
-              <Typography marginLeft={2}>copy code</Typography>
+              <ContentCopyIcon style={{height: "1.25rem", width: "1.25rem"}} />{" "}
+              <Typography marginLeft={1}>copy code</Typography>
             </Button>
           </StyledTooltip>
           <ExpandCode sourceCode={sourceCode} />
@@ -691,8 +697,14 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
         variant="outlined"
         onClick={handleOpenModal}
         disabled={!sourceCode}
+        sx={{
+          height: "2rem",
+          width: "2rem",
+          minWidth: "unset",
+          borderRadius: "0.5rem",
+        }}
       >
-        <OpenInFull />
+        <OpenInFull style={{height: "1.25rem", width: "1.25rem"}} />
       </Button>
       <Modal open={isModalOpen} onClose={handleCloseModal}>
         <Box


### PR DESCRIPTION
from lex: Secondary button height is 36 px. Should be 32. Expand code button should be 32x32

before
<img width="340" alt="image" src="https://user-images.githubusercontent.com/101405096/228191931-e4fc69b9-df5c-4bc5-b7a7-c2d4e4db643d.png">

after
<img width="375" alt="image" src="https://user-images.githubusercontent.com/101405096/228191517-67d92ee1-62dc-45eb-a0f9-e582b288bd97.png">
