### PR TITLE
[explorer] fixed code modal width

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -720,7 +720,7 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
             left: "50%",
             transform: "translate(-50%, -50%)",
             maxHeight: "80%",
-            maxWidth: "80%",
+            width: "80%",
             overflowY: "auto",
             borderRadius: 1,
           }}


### PR DESCRIPTION
lex: Why do we have a different modal size for expanded code? And different left padding?

0xbe1:
1. this PR fixes the different modal size issue by changing `maxWidth` to `width`
2. different left padding: the left padding is actually the same, but why do you see the inconsistency? it is because the "line number" column determines its width based on the max line number. For example, if the module has 1000 lines of code, then the whole line number column has the width for 4 numbers `xxxx`. However, if the module has just 50 lines of code, then the column saves the space for only 2 numbers `xx`. I am not sure what's the desired behavior here, so I haven't fixed it in this PR

---

before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228236608-aa303cad-d88d-47d3-8300-d1ebc662cad6.png">

after
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/101405096/228236670-2a7fdc4e-d333-495b-a70a-06bbf51021cb.png">
