### PR TITLE
[delegation] make funds withdrawable when validator becomes inactive

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -245,3 +245,17 @@ export async function getDelegationPoolExist(
   };
   return withResponseError(client.view(payload));
 }
+
+// Return whether `pending_inactive` stake can be directly withdrawn from the delegation pool,
+// for the edge case when the validator had gone inactive before its lockup expired.
+export async function getCanWithdrawPendingInactive(
+  client: AptosClient,
+  validatorAddress: Types.Address,
+): Promise<Types.MoveValue[]> {
+  const payload: Types.ViewRequest = {
+    function: "0x1::delegation_pool::can_withdraw_pending_inactive",
+    type_arguments: [],
+    arguments: [validatorAddress],
+  };
+  return withResponseError(client.view(payload));
+}


### PR DESCRIPTION
Return whether `pending_inactive` stake can be directly withdrawn from the delegation pool, for the edge case when the validator had gone inactive before its lockup expired.