### PR TITLE
add tooltip to countdown interval when it is completed

### DIFF
--- a/src/components/IntervalBar.tsx
+++ b/src/components/IntervalBar.tsx
@@ -1,7 +1,8 @@
 import {Stack, Typography, useTheme} from "@mui/material";
-import React from "react";
+import React, {useState} from "react";
 import {grey} from "../themes/colors/aptosColorPalette";
 import Countdown from "react-countdown";
+import StyledTooltip from "./StyledTooltip";
 
 const BAR_COLOR = "#818CF8";
 const BAR_BACKGROUND_COLOR = "rgb(129, 140, 248, 0.4)";
@@ -23,25 +24,22 @@ export default function IntervalBar({
   intervalType,
 }: IntervalBarProps) {
   const theme = useTheme();
+  const [displayTooltip, setDisplayTooltip] = useState<boolean>(false);
+  const handleCountdownComplete = () => {
+    setDisplayTooltip(true);
+  };
+
   const renderer = ({
     days,
     hours,
     minutes,
     seconds,
-    completed,
   }: {
     days: number;
     hours: number;
     minutes: number;
     seconds: number;
-    completed: boolean;
   }) => {
-    if (timestamp < Date.now()) {
-      return <span>Validator's no longer active</span>;
-    }
-    if (completed) {
-      window.location.reload();
-    }
     switch (intervalType) {
       case IntervalType.EPOCH:
         return (
@@ -58,7 +56,7 @@ export default function IntervalBar({
     }
   };
 
-  return (
+  const intervalBar = (
     <Stack direction="row" width={182} height={16}>
       <Stack
         width={`${percentage}%`}
@@ -75,7 +73,11 @@ export default function IntervalBar({
             sx={{fontSize: 10, fontWeight: 600}}
             marginX={0.5}
           >
-            <Countdown date={timestamp} renderer={renderer} />
+            <Countdown
+              date={timestamp}
+              renderer={renderer}
+              onComplete={handleCountdownComplete}
+            />
           </Typography>
         )}
       </Stack>
@@ -94,10 +96,25 @@ export default function IntervalBar({
             sx={{fontSize: 10, fontWeight: 600}}
             marginX={0.5}
           >
-            <Countdown date={timestamp} renderer={renderer} />
+            <Countdown
+              date={timestamp}
+              renderer={renderer}
+              onComplete={handleCountdownComplete}
+            />
           </Typography>
         )}
       </Stack>
     </Stack>
+  );
+
+  return displayTooltip ? (
+    <StyledTooltip
+      title="Please refresh the page to view the updated time remaining."
+      placement="right"
+    >
+      {intervalBar}
+    </StyledTooltip>
+  ) : (
+    <>{intervalBar}</>
   );
 }


### PR DESCRIPTION
### TLDR: to make the experience non intrusive, instead of reloading the window, have a tooltip ready when countdown is completed.
#### failed to re-render the component with `react-countdown` package and a better UX is to have a tooltip that will display when hovering over after countdown completes. 

### future work
- once we have a list of inactive validators, will signal in the validator page that this validator is inactive and avoid showing the tooltip.



<img width="771" alt="Screenshot 2023-03-29 at 11 00 22 AM" src="https://user-images.githubusercontent.com/121921928/228627889-be04c76e-065d-425f-a537-10d77e31a284.png">
