### PR TITLE
[explorer] fix modules page sidebar text style

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab.tsx
+++ b/src/pages/Account/Tabs/ModulesTab.tsx
@@ -516,7 +516,20 @@ function ModuleSidebar({
             onChange={(e) => setSelectedModuleIndex(Number(e.target.value))}
           >
             {moduleNames.map((moduleName, i) => (
-              <MenuItem key={i} value={i}>
+              <MenuItem
+                key={i}
+                value={i}
+                sx={
+                  theme.palette.mode === "dark" && i !== selectedModuleIndex
+                    ? {
+                        color: grey[400],
+                        ":hover": {
+                          color: grey[200],
+                        },
+                      }
+                    : {}
+                }
+              >
                 {moduleName}
               </MenuItem>
             ))}
@@ -548,8 +561,10 @@ function ModuleNameOption({
           : theme.palette.mode === "dark"
           ? grey[500]
           : grey[200],
+        ...(theme.palette.mode === "dark" && !selected && {color: grey[400]}),
         ":hover": {
           cursor: "pointer",
+          ...(theme.palette.mode === "dark" && !selected && {color: grey[200]}),
         },
       }}
     >


### PR DESCRIPTION
before
<img width="324" alt="image" src="https://user-images.githubusercontent.com/101405096/228629002-de9f22aa-cf11-41a5-95c7-5c328c88f572.png">

after
<img width="348" alt="image" src="https://user-images.githubusercontent.com/101405096/228630923-1cdaf6d6-ffb5-423b-907e-1969a85ce9c1.png">