### PR TITLE
[delegation] refactor inactive withdraw and add add_stake fee info

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 import {AptosClient, Types} from "aptos";
+import {OCTA} from "../constants";
 import {isNumeric} from "../pages/utils";
 import {sortTransactions} from "../utils";
 import {withResponseError} from "./client";
@@ -256,6 +257,19 @@ export async function getCanWithdrawPendingInactive(
     function: "0x1::delegation_pool::can_withdraw_pending_inactive",
     type_arguments: [],
     arguments: [validatorAddress],
+  };
+  return withResponseError(client.view(payload));
+}
+
+export async function getAddStakeFee(
+  client: AptosClient,
+  validatorAddress: Types.Address,
+  amount: string,
+): Promise<Types.MoveValue[]> {
+  const payload: Types.ViewRequest = {
+    function: "0x1::delegation_pool::get_add_stake_fee",
+    type_arguments: [],
+    arguments: [validatorAddress, (Number(amount) * OCTA).toString()],
   };
   return withResponseError(client.view(payload));
 }

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -142,6 +142,7 @@ export default function StakingBar({
       isDialogOpen={dialogOpen}
       stakeOperation={StakeOperation.STAKE}
       commission={commission}
+      canWithdrawPendingInactive={false}
     />
   );
 

--- a/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
+++ b/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
@@ -50,7 +50,7 @@ export default function TransactionSucceededDialog({
           <Box>
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"You’ve successfully unlocked "}
-              <text style={{fontWeight: 600}}>{amount}</text>
+              <span style={{fontWeight: 600}}>{amount}</span>
               {" APT"}
             </Typography>
           </Box>
@@ -60,7 +60,7 @@ export default function TransactionSucceededDialog({
           <Box>
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"You’ve successfully withdrawn "}
-              <text style={{fontWeight: 600}}>{amount}</text>
+              <span style={{fontWeight: 600}}>{amount}</span>
               {" APT"}
             </Typography>
           </Box>
@@ -74,7 +74,7 @@ export default function TransactionSucceededDialog({
             </Typography>
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"Soon you will see your deposit of "}
-              <text style={{fontWeight: 600}}>{amount}</text>
+              <span style={{fontWeight: 600}}>{amount}</span>
               {" APT in the staking pool."}
             </Typography>
           </Box>


### PR DESCRIPTION
context: after syncing with external partners, we've decided collectively to enforce 11 min APT and add_stake fee's deducted from this 11 min. 

---
this PR involves 3 changes
1. add add_stake fee info to the staking dialog so that delegators are aware of the fee.
2. refactor inactive pool withdraw experience
3. migrate from `<text>` to `<span>` to avoid the error in console


https://user-images.githubusercontent.com/121921928/228945204-59f32f31-a50a-42a9-afc5-1319ff9215d9.mov


https://user-images.githubusercontent.com/121921928/228945234-0eaee634-18a0-42e9-a781-496b3d63c2ac.mov

