### PR TITLE
[delegation] add completely inactive delegation validators

### DIFF
--- a/src/api/hooks/useGetDelegatedStakingPoolList.ts
+++ b/src/api/hooks/useGetDelegatedStakingPoolList.ts
@@ -1,0 +1,35 @@
+import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+
+export interface DelegatedStakingPool {
+  staking_pool_address: string;
+  current_staking_pool: {
+    operator_address: string;
+  };
+}
+
+const VALIDATOR_LIST_QUERY = gql`
+  query DelegationPools {
+    delegated_staking_pools {
+      staking_pool_address
+      current_staking_pool {
+        operator_address
+      }
+    }
+  }
+`;
+
+export function useGetDelegatedStakingPoolList(): {
+  delegatedStakingPools: DelegatedStakingPool[];
+  loading: boolean;
+} {
+  const {data, error, loading} = useGraphqlQuery(VALIDATOR_LIST_QUERY);
+  if (error) {
+    return {delegatedStakingPools: [], loading};
+  }
+
+  return {
+    delegatedStakingPools:
+      data?.delegated_staking_pools as DelegatedStakingPool[],
+    loading,
+  };
+}

--- a/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
+++ b/src/pages/DelegatoryValidator/Components/StakingStatusIcon.tsx
@@ -19,7 +19,7 @@ import {
   WITHDRAW_READY_LABEL,
   WITHDRAW_READY_TEXT_COLOR_DARK,
   WITHDRAW_READY_TEXT_COLOR_LIGHT,
-} from "./../constants";
+} from "../constants";
 import LockIcon from "@mui/icons-material/Lock";
 import PendingIcon from "@mui/icons-material/Pending";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -6,13 +6,18 @@ import ValidatorTitle from "./Title";
 import ValidatorDetailCard from "./DetailCard";
 import ValidatorStakingBar from "./StakingBar";
 import {HexString} from "aptos";
-import {useGetValidators} from "../../api/hooks/useGetValidators";
+import {
+  useGetValidators,
+  ValidatorData,
+} from "../../api/hooks/useGetValidators";
 import MyDepositsSection from "./MyDepositsSection";
 import {useGetAccountResource} from "../../api/hooks/useGetAccountResource";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {SkeletonTheme} from "react-loading-skeleton";
 import {useGetValidatorPageSkeletonLoading} from "../../api/hooks/useGetValidatorPageSkeletonLoading";
 import {DelegationStateContext} from "./context/DelegationContext";
+import {useGetDelegatedStakingPoolList} from "../../api/hooks/useGetDelegatedStakingPoolList";
+import {useEffect, useState} from "react";
 
 export default function ValidatorPage() {
   const address = useParams().address ?? "";
@@ -29,9 +34,43 @@ export default function ValidatorPage() {
     isSkeletonLoading,
   } = useGetValidatorPageSkeletonLoading();
 
-  const validator = validators.find(
-    (validator) => validator.owner_address === addressHex.hex(),
-  );
+  const {delegatedStakingPools, loading} =
+    useGetDelegatedStakingPoolList() ?? [];
+
+  const [validator, setValidator] = useState<ValidatorData>();
+
+  useEffect(() => {
+    let validator = validators.find(
+      (validator) => validator.owner_address === addressHex.hex(),
+    );
+    if (!loading && !validator) {
+      // If the validator is not in the list of validators, it means that the validator was never active.
+      // In this case, we need to get the validator data from the delegated staking pools list and manually
+      // populate required fields.
+      const delegatedStakingPoolsNotInValidators: ValidatorData[] =
+        delegatedStakingPools
+          .filter((pool) => {
+            return addressHex.hex() === pool.staking_pool_address;
+          })
+          .map((pool) => ({
+            owner_address: pool.staking_pool_address,
+            operator_address: pool.current_staking_pool.operator_address,
+            voting_power: "0",
+            governance_voting_record: "",
+            last_epoch: 0,
+            last_epoch_performance: "",
+            liveness: 0,
+            rewards_growth: 0,
+            apt_rewards_distributed: 0,
+          }));
+
+      setValidator(
+        delegatedStakingPoolsNotInValidators.length > 0
+          ? delegatedStakingPoolsNotInValidators[0]
+          : undefined,
+      );
+    }
+  }, [delegatedStakingPools, loading, validators]);
 
   if (!validator || !accountResource) {
     return null;


### PR DESCRIPTION
### context

even though some validators were never active, they are also delegation validators, (which's achieved by running CMD to create delegation pool sc).

these validators should also get listed up in the explorer so that they still get the chance to receive stakes even though these stakes won't generate rewards at all.

https://user-images.githubusercontent.com/121921928/230229594-f7af4f1d-5369-4bce-a692-8a9d6a257006.mov

