### PR TITLE
[code view] Implement deep linking to module and function name

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -31,7 +31,11 @@ export default function ExplorerRoutes() {
         </Route>
         <Route path="/account">
           <Route
-            path=":address/modules/:modulesTab"
+            path=":address/modules/:selectedModuleName/:modulesTab"
+            element={<AccountPage />}
+          />
+          <Route
+            path=":address/modules/:selectedModuleName"
             element={<AccountPage />}
           />
           <Route path=":address/:tab" element={<AccountPage />} />

--- a/src/components/CodeLineBox.tsx
+++ b/src/components/CodeLineBox.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import {Box, SxProps, Theme, useTheme} from "@mui/material";
-import {codeBlockColor} from "../themes/colors/aptosColorPalette";
+import {
+  codeBlockColor,
+  codeBlockColorClickableOnHover,
+} from "../themes/colors/aptosColorPalette";
 
 const TEXT_COLOR_LIGHT = "#0EA5E9";
 const TEXT_COLOR_DARK = "#83CCED";
@@ -8,9 +11,11 @@ const TEXT_COLOR_DARK = "#83CCED";
 export function CodeLineBox({
   children,
   sx,
+  clickable = false,
 }: {
   children: React.ReactNode;
   sx?: SxProps<Theme>;
+  clickable?: boolean;
 }) {
   const theme = useTheme();
   return (
@@ -20,7 +25,6 @@ export function CodeLineBox({
           width: "max-content",
           color:
             theme.palette.mode === "dark" ? TEXT_COLOR_DARK : TEXT_COLOR_LIGHT,
-          backgroundColor: codeBlockColor,
           padding: "0.35rem 1rem 0.35rem 1rem",
           overflow: "hidden",
           whiteSpace: "nowrap",
@@ -28,10 +32,21 @@ export function CodeLineBox({
           fontFamily: theme.typography.fontFamily,
           fontWeight: theme.typography.fontWeightRegular,
           fontSize: 13,
+          ...(clickable
+            ? {
+                backgroundColor: codeBlockColor,
+                "&:hover": {
+                  backgroundColor: codeBlockColorClickableOnHover,
+                },
+              }
+            : {
+                borderStyle: "solid",
+              }),
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
-      borderRadius={1}
+      borderColor={codeBlockColor}
+      borderRadius={50}
     >
       {children}
     </Box>

--- a/src/components/Table/GeneralTableCell.tsx
+++ b/src/components/Table/GeneralTableCell.tsx
@@ -10,6 +10,7 @@ interface GeneralTableCellProps extends TableCellProps {
 export default function GeneralTableCell({
   children,
   sx,
+  ...rest
 }: GeneralTableCellProps) {
   return (
     <TableCell
@@ -20,6 +21,7 @@ export default function GeneralTableCell({
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
+      {...rest}
     >
       {children}
     </TableCell>

--- a/src/components/Table/GeneralTableCell.tsx
+++ b/src/components/Table/GeneralTableCell.tsx
@@ -10,7 +10,7 @@ interface GeneralTableCellProps extends TableCellProps {
 export default function GeneralTableCell({
   children,
   sx,
-  ...rest
+  ...props
 }: GeneralTableCellProps) {
   return (
     <TableCell
@@ -21,7 +21,7 @@ export default function GeneralTableCell({
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
-      {...rest}
+      {...props}
     >
       {children}
     </TableCell>

--- a/src/components/router-link.tsx
+++ b/src/components/router-link.tsx
@@ -7,6 +7,7 @@ export function Link({to, children}: {to: string; children: React.ReactNode}) {
     <MuiLink
       component={RouterLink}
       to={to}
+      style={{textDecoration: "none", color: "inherit"}}
       onClick={(e) => {
         e.stopPropagation();
       }}

--- a/src/components/router-link.tsx
+++ b/src/components/router-link.tsx
@@ -1,0 +1,17 @@
+import {Link as MuiLink} from "@mui/material";
+import React from "react";
+import {Link as RouterLink} from "react-router-dom";
+
+export function Link({to, children}: {to: string; children: React.ReactNode}) {
+  return (
+    <MuiLink
+      component={RouterLink}
+      to={to}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      {children}
+    </MuiLink>
+  );
+}

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -92,14 +92,16 @@ export default function AccountTabs({
   accountData,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
-  const {modulesTab, tab} = useParams();
+  const {tab, selectedModuleName, modulesTab} = useParams();
   const navigate = useNavigate();
-  const value =
-    tab === undefined
-      ? modulesTab === undefined
-        ? TAB_VALUES[0]
-        : "modules"
-      : (tab as TabValue);
+  let effectiveTab: TabValue;
+  if (selectedModuleName) {
+    effectiveTab = "modules" as TabValue;
+  } else if (tab !== undefined) {
+    effectiveTab = tab as TabValue;
+  } else {
+    effectiveTab = TAB_VALUES[0];
+  }
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
     navigate(`/account/${address}/${newValue}`);
@@ -108,7 +110,7 @@ export default function AccountTabs({
   return (
     <Box sx={{width: "100%"}}>
       <Box>
-        <StyledTabs value={value} onChange={handleChange}>
+        <StyledTabs value={effectiveTab} onChange={handleChange}>
           {tabValues.map((value, i) => (
             <StyledTab
               key={i}
@@ -122,7 +124,11 @@ export default function AccountTabs({
         </StyledTabs>
       </Box>
       <Box>
-        <TabPanel value={value} address={address} accountData={accountData} />
+        <TabPanel
+          value={effectiveTab}
+          address={address}
+          accountData={accountData}
+        />
       </Box>
     </Box>
   );

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -39,13 +39,13 @@ function TabPanel({value, address}: TabPanelProps): JSX.Element {
 function ModulesTabs({address}: {address: string}): JSX.Element {
   const theme = useTheme();
   const tabValues = Object.keys(TabComponents) as TabValue[];
-  const {modulesTab} = useParams();
+  const {selectedModuleName, modulesTab} = useParams();
   const navigate = useNavigate();
   const value =
     modulesTab === undefined ? tabValues[0] : (modulesTab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/account/${address}/modules/${newValue}`);
+    navigate(`/account/${address}/modules/${selectedModuleName}/${newValue}`);
   };
 
   return (

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -270,6 +270,11 @@ function ModuleHeader({
   );
 }
 
+// inspired by https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+function escapeRegExp(regexpString: string) {
+  return regexpString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function useStartingLineNumber(sourceCode?: string) {
   const [searchParams] = useSearchParams();
 
@@ -279,9 +284,13 @@ function useStartingLineNumber(sourceCode?: string) {
   if (entryFunctionToHightlight == null) return 0;
 
   const lines = sourceCode.split("\n");
+  const publicEntryFunRegexp = new RegExp(
+    `\\s*public\\s*entry\\s*fun\\s*${escapeRegExp(
+      entryFunctionToHightlight,
+    )}(<.*>)?\\s*\\(`,
+  );
   const lineNumber = lines.findIndex((line) =>
-    // TODO: improve line matching algorithm by using regex or something. Currently this will match falsely other entry functions that contain the entry function name in their name - e.g. `my_func_blue` will be matched when searching for `my_func`.
-    line.includes(`public entry fun ${entryFunctionToHightlight}`),
+    line.match(publicEntryFunRegexp),
   );
   if (lineNumber !== -1) {
     return lineNumber;

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -5,10 +5,11 @@ import CurrencyExchangeOutlinedIcon from "@mui/icons-material/CurrencyExchangeOu
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import {CodeLineBox} from "../../../../components/CodeLineBox";
 import {Link} from "../../../../components/router-link";
+import {codeBlockColorClickableOnHover} from "../../../../themes/colors/aptosColorPalette";
 
 function CoinTransferCodeLine({sx}: {sx?: SxProps<Theme>}): JSX.Element {
   return (
-    <CodeLineBox sx={[...(Array.isArray(sx) ? sx : [sx])]}>
+    <CodeLineBox clickable sx={[...(Array.isArray(sx) ? sx : [sx])]}>
       <Stack direction="row" alignItems="center" spacing={1.5}>
         <CurrencyExchangeOutlinedIcon sx={{fontSize: 17, padding: 0}} />
         <Box>{`Coin Transfer`}</Box>
@@ -48,21 +49,35 @@ export default function TransactionFunction({
   }
 
   const functionFullStr = transaction.payload.function;
+  const [address, moduleName, functionName] = functionFullStr.split("::");
 
   if (
     functionFullStr === "0x1::coin::transfer" ||
     functionFullStr === "0x1::aptos_account::transfer"
   ) {
-    return <CoinTransferCodeLine sx={[...(Array.isArray(sx) ? sx : [sx])]} />;
+    return (
+      <Link
+        to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+      >
+        <CoinTransferCodeLine
+          sx={[
+            ...(Array.isArray(sx) ? sx : [sx]),
+            {
+              "&:hover": {
+                backgroundColor: codeBlockColorClickableOnHover,
+              },
+            },
+          ]}
+        />
+      </Link>
+    );
   }
-
-  const [address, moduleName, functionName] = functionFullStr.split("::");
 
   return (
     <Link
       to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
     >
-      <CodeLineBox sx={[...(Array.isArray(sx) ? sx : [sx])]}>
+      <CodeLineBox clickable sx={[...(Array.isArray(sx) ? sx : [sx])]}>
         {moduleName + "::" + functionName}
       </CodeLineBox>
     </Link>

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -4,8 +4,7 @@ import {Types} from "aptos";
 import CurrencyExchangeOutlinedIcon from "@mui/icons-material/CurrencyExchangeOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import {CodeLineBox} from "../../../../components/CodeLineBox";
-
-const BLOCK_MODULE_NAME = "candy_machine_v2";
+import {Link} from "../../../../components/router-link";
 
 function CoinTransferCodeLine({sx}: {sx?: SxProps<Theme>}): JSX.Element {
   return (
@@ -57,16 +56,15 @@ export default function TransactionFunction({
     return <CoinTransferCodeLine sx={[...(Array.isArray(sx) ? sx : [sx])]} />;
   }
 
-  const functionStrStartIdx = functionFullStr.indexOf("::") + 2;
-  let functionStr = functionFullStr.substring(functionStrStartIdx);
-
-  if (functionStr.startsWith(BLOCK_MODULE_NAME)) {
-    functionStr = functionStr.substring(BLOCK_MODULE_NAME.length + 2);
-  }
+  const [address, moduleName, functionName] = functionFullStr.split("::");
 
   return (
-    <CodeLineBox sx={[...(Array.isArray(sx) ? sx : [sx])]}>
-      {functionStr}
-    </CodeLineBox>
+    <Link
+      to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+    >
+      <CodeLineBox sx={[...(Array.isArray(sx) ? sx : [sx])]}>
+        {moduleName + "::" + functionName}
+      </CodeLineBox>
+    </Link>
   );
 }

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -6,7 +6,7 @@ import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import {useNavigate, useParams} from "react-router-dom";
+import {useNavigate} from "react-router-dom";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import HashButton, {HashType} from "../../components/HashButton";

--- a/src/pages/utils.tsx
+++ b/src/pages/utils.tsx
@@ -108,5 +108,5 @@ export function getTableFormattedTimestamp(timestamp?: string): string {
   const moment = parseTimestamp(timestamp);
   const timestamp_display = timestampDisplay(moment);
 
-  return timestamp_display.local_formatted_short;
+  return timestamp_display.local_formatted;
 }

--- a/src/themes/colors/aptosColorPalette.ts
+++ b/src/themes/colors/aptosColorPalette.ts
@@ -33,6 +33,7 @@ export const warningColor: string = "#f1c232";
 
 // code block colors
 export const codeBlockColor: string = "rgba(14,165,233,0.1)";
+export const codeBlockColorClickableOnHover: string = "rgba(14,165,233,0.2)";
 // use rgb for codeblock in modal otherwise it will be transparent and not very visible
 export const codeBlockColorRgbLight: string = "#E3ECF3";
 export const codeBlockColorRgbDark: string = "#212D32";


### PR DESCRIPTION
This PR implements deep linking from entry function links in the transaction list and transaction details to the corresponding module and function name.

### Motivation
Often times when looking at a list of transactions it's useful to do what this transaction was actually doing by looking at the source code.
Currently it takes 5+ mouse clicks (to get the corresponding module) + several keystrokes (to copy&paste the function name and find it in the source code) in rather unintuitive places to get from a function name to it's definition. This PR reduces this in the ideal case to essentially 1 single mouse click.

### Some implementation notes:
1. Introduced a new Link component that tries to use Copyable Links / hrefs vs programmatic navigation so that users can right-click a URL and copy it or open it in a new tab vs having to actually click a button.
2. The currently used `<SyntaxHighlighter>` component for the module code doesn't make it super easy to scroll to a specific section out of the box, so I implemented some pixel based scrolling logic on the wrapping `<Box>` component. It's a bit ugly but it works for now.
3. Implemented some heuristic that finds the entry function in the source code, but that heuristic can be improved as described in the code comment via some regex or so (probably needs some regex safe escaping).

demo video:

https://user-images.githubusercontent.com/1221897/230337005-6fa28d22-ed4f-45ba-a969-3c772edac962.mp4


