### PR TITLE
[delegation] fix and feedback addressing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-loading-skeleton": "^3.1.1",
     "react-number-format": "^4.9.4",
     "react-query": "^3.39.3",
-    "react-router-dom": "^6.8.2",
+    "react-router-dom": "^6.10.0",
     "react-scripts": "latest",
     "react-simple-maps": "^3.0.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ specifiers:
   react-loading-skeleton: ^3.1.1
   react-number-format: ^4.9.4
   react-query: ^3.39.3
-  react-router-dom: ^6.8.2
+  react-router-dom: ^6.10.0
   react-scripts: latest
   react-simple-maps: ^3.0.0
   react-syntax-highlighter: ^15.5.0
@@ -107,7 +107,7 @@ dependencies:
   react-loading-skeleton: 3.2.0_react@18.2.0
   react-number-format: 4.9.4_biqbaboplfbrettd7655fr4n2y
   react-query: 3.39.3_biqbaboplfbrettd7655fr4n2y
-  react-router-dom: 6.9.0_biqbaboplfbrettd7655fr4n2y
+  react-router-dom: 6.10.0_biqbaboplfbrettd7655fr4n2y
   react-scripts: 5.0.1_odn5rdmyrxuyfnlhepsb7fjnvi
   react-simple-maps: 3.0.0_biqbaboplfbrettd7655fr4n2y
   react-syntax-highlighter: 15.5.0_react@18.2.0
@@ -234,7 +234,7 @@ packages:
       aptos: 1.7.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router-dom: 6.9.0_biqbaboplfbrettd7655fr4n2y
+      react-router-dom: 6.10.0_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
       - '@types/react'
       - debug
@@ -2769,8 +2769,8 @@ packages:
     resolution: {integrity: sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==}
     dev: false
 
-  /@remix-run/router/1.4.0:
-    resolution: {integrity: sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==}
+  /@remix-run/router/1.5.0:
+    resolution: {integrity: sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==}
     engines: {node: '>=14'}
     dev: false
 
@@ -10139,26 +10139,26 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /react-router-dom/6.9.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==}
+  /react-router-dom/6.10.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.4.0
+      '@remix-run/router': 1.5.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router: 6.9.0_react@18.2.0
+      react-router: 6.10.0_react@18.2.0
     dev: false
 
-  /react-router/6.9.0_react@18.2.0:
-    resolution: {integrity: sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==}
+  /react-router/6.10.0_react@18.2.0:
+    resolution: {integrity: sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.4.0
+      '@remix-run/router': 1.5.0
       react: 18.2.0
     dev: false
 

--- a/src/components/AmountTextField.tsx
+++ b/src/components/AmountTextField.tsx
@@ -10,8 +10,6 @@ import {getFormattedBalanceStr} from "./IndividualPageContent/ContentValue/Curre
 
 interface AmountTextFieldProps {
   amount: string;
-  amountIsValid: boolean;
-  errorMessage: string;
   warnMessage: string | undefined;
   onAmountChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   balance?: string | null;
@@ -19,13 +17,11 @@ interface AmountTextFieldProps {
 
 export default function AmountTextField({
   amount,
-  amountIsValid,
-  errorMessage,
   warnMessage,
   onAmountChange,
   balance,
 }: AmountTextFieldProps): JSX.Element {
-  return amountIsValid ? (
+  return (
     <FormControl fullWidth>
       <Stack direction="row" justifyContent="space-between">
         <FormHelperText sx={{fontSize: "1rem"}}>Enter Amount</FormHelperText>
@@ -42,25 +38,6 @@ export default function AmountTextField({
         }
       />
       {warnMessage && <FormHelperText>{warnMessage}</FormHelperText>}
-    </FormControl>
-  ) : (
-    <FormControl fullWidth>
-      <Stack direction="row" justifyContent="space-between">
-        <FormHelperText sx={{fontSize: "1rem"}}>Enter Amount</FormHelperText>
-      </Stack>
-      <OutlinedInput
-        error
-        notched
-        value={amount}
-        onChange={onAmountChange}
-        endAdornment={<InputAdornment position="end">APT</InputAdornment>}
-        placeholder={
-          balance
-            ? `Your balance: ${getFormattedBalanceStr(balance, undefined, 1)}`
-            : ""
-        }
-      />
-      <FormHelperText error>{errorMessage}</FormHelperText>
     </FormControl>
   );
 }

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -308,6 +308,7 @@ export default function MyDepositsSection({
               canWithdrawPendingInactive,
             )}
             canWithdrawPendingInactive={canWithdrawPendingInactive}
+            stakes={stakes}
           />
         ) : (
           <WalletConnectionDialog

--- a/src/pages/DelegatoryValidator/utils.tsx
+++ b/src/pages/DelegatoryValidator/utils.tsx
@@ -163,18 +163,17 @@ export function getStakeOperationAPTRequirement(
         min,
         suggestedMax,
         max,
-        disabled: min > max || max < MINIMUM_APT_IN_POOL,
+        disabled: min > max && max < MINIMUM_APT_IN_POOL,
       };
     }
     case StakeOperation.UNLOCK: {
       const min =
-        pending_inactive < MINIMUM_APT_IN_POOL_FOR_EXPLORER
-          ? MINIMUM_APT_IN_POOL_FOR_EXPLORER - pending_inactive
+        pending_inactive < MINIMUM_APT_IN_POOL
+          ? MINIMUM_APT_IN_POOL - pending_inactive
           : 0;
       const suggestedMax =
-        active > MINIMUM_APT_IN_POOL_FOR_EXPLORER &&
-        active - MINIMUM_APT_IN_POOL_FOR_EXPLORER > min
-          ? active - MINIMUM_APT_IN_POOL_FOR_EXPLORER
+        active > MINIMUM_APT_IN_POOL && active - MINIMUM_APT_IN_POOL > min
+          ? active - MINIMUM_APT_IN_POOL
           : null;
       const max = active;
       return {
@@ -186,13 +185,11 @@ export function getStakeOperationAPTRequirement(
     }
     case StakeOperation.REACTIVATE: {
       const min =
-        MINIMUM_APT_IN_POOL_FOR_EXPLORER > active
-          ? MINIMUM_APT_IN_POOL_FOR_EXPLORER - active
-          : 0;
+        MINIMUM_APT_IN_POOL > active ? MINIMUM_APT_IN_POOL - active : 0;
       const suggestedMax =
-        MINIMUM_APT_IN_POOL_FOR_EXPLORER < pending_inactive &&
-        pending_inactive - MINIMUM_APT_IN_POOL_FOR_EXPLORER > min
-          ? pending_inactive - MINIMUM_APT_IN_POOL_FOR_EXPLORER
+        MINIMUM_APT_IN_POOL < pending_inactive &&
+        pending_inactive - MINIMUM_APT_IN_POOL > min
+          ? pending_inactive - MINIMUM_APT_IN_POOL
           : null;
       const max = pending_inactive;
       return {

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -152,8 +152,12 @@ function ValidatorHeaderCell({
       );
     case "rewardsEarned":
       return (
-        <GeneralTableHeaderCell
+        <SortableHeaderCell
           header="Rewards Earned"
+          column={column}
+          direction={direction}
+          setDirection={setDirection}
+          setSortColumn={setSortColumn}
           tooltip={
             <StyledLearnMoreTooltip text="Amount of rewards earned by this stake pool to date" />
           }
@@ -381,7 +385,7 @@ export function DelegationValidatorsTable() {
   const columns = connected
     ? DEFAULT_COLUMNS
     : COLUMNS_WITHOUT_WALLET_CONNECTION;
-  const [sortColumn, setSortColumn] = useState<Column>("delegatedAmount");
+  const [sortColumn, setSortColumn] = useState<Column>("rewardsEarned");
   const [sortDirection, setSortDirection] = useState<"desc" | "asc">("desc");
   const sortedValidators = getSortedValidators(
     validators,


### PR DESCRIPTION
### scenarios i tested

1. stake
    1. active validator
        1. current 0 in active pool
            1. if < 11, stake disabled, can’t stake
            2. if > wallet balance, stake disabled, can’t stake
        2. current have > 10 in active pool
            1. if stake amount + current < 11, stake disabled
            2. if stake amount + current > 11 and stake amount < wallet balance, stake enabled
            3. if stake amount > wallet balance, stake disabled
        3. if wallet balance + active pool < 11, stake disabled
    2. inactive validator
        1. same to active validator except that unlock date row is removed
        2. TODO: remove add stake fee row as well
2. unstake
    1. active validator
        1. pending_active has more than 10
            1. unstake < 10, warning will tell total amount will be unstaked, unstake enabled
            2. unstake more than what’s staked, warning will tell total amount will be unstaked, unstake enabled
        2. pending_active has 0
            1. unstake row hidden
    2. inactive validator
        1. same to active validator
3. reactivate
    1. active validator
        1. restake amount + active pool < 11, or pending_inactive pool - restake amount < 11, warning will tell total amount will be restaked, restake enabled
        2. restake amount + active pool > 11, pending_inactive pool - restake amount > 11, restake enabled
        3. if restake more than pending_inactive, warning will tell total amount will be restaked, restake enabled
    2. inactive validator
        1. no reactivate option, once unstaked, will be withdrawable.
4. withdraw
    1. active validator
        1. withdraw will show when fund is withdrawable
    2. inactive validator
        1. fund will be withdrawable right after unstaking


### feedbacks and fixes this PR covers
1. Should we make the min APT clearer either before user enters or right after they enter an amount but before clicking deposit? Current users wouldn't find out until after they click deposit that they're not meeting the min of 11 APT
2. Looks like user cannot withdraw everything they have if their total stake is < 11 APT due to add stake fee. See third screenshot. We should always allow users to unstake everything. The delegation contract does allow them to do this
3. When a user withdraws most of their APT, leaving < 10 APT less in active state, all of their stake is actually unlocked. For example, if a user has 11.5 APT in total and request to unlock 11, all 11.5 is actually unlocked. This is a common behavior in most liquid staking services. Currently our UI doesn't tell the user this (Fewcha actually did this relatively well when I tested what they have yesterday)
4. one other thing i noticed when i went through the flow just now but the min/max messaging is a little weird if the max you have in your wallet is less than 11 APT (see screenshot)
5. rewards earned so far when you click into the individual delegation pool page says 0 APT
6. rewards performance and last epoch performance say N/A
7. I see a sort functionality for delegated amount but it doesn't work? 