### PR TITLE
Revert "[GP-209] cache ANS name for owner in account page (#442)"

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -1,11 +1,7 @@
 import {useEffect, useState} from "react";
 import {NetworkName} from "../../constants";
 import {useGlobalState} from "../../GlobalState";
-import {
-  fetchJsonResponse,
-  getLocalStorageWithExpiry,
-  truncateAptSuffix,
-} from "../../utils";
+import {fetchJsonResponse, truncateAptSuffix} from "../../utils";
 
 function getFetchNameUrl(
   network: NetworkName,
@@ -26,12 +22,6 @@ export function useGetNameFromAddress(address: string) {
   const [name, setName] = useState<string | undefined>();
 
   useEffect(() => {
-    const cachedName = getLocalStorageWithExpiry(address);
-    if (cachedName) {
-      setName(cachedName);
-      return;
-    }
-
     const primaryNameUrl = getFetchNameUrl(state.network_name, address, true);
     if (primaryNameUrl !== undefined) {
       const fetchData = async () => {

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -13,11 +13,9 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {truncateAddress, truncateAddressMiddle} from "../pages/utils";
 import {useGetNameFromAddress} from "../api/hooks/useGetANS";
-import {setLocalStorageWithExpiry} from "../utils";
 
 const BUTTON_HEIGHT = 34;
 const TOOLTIP_TIME = 2000; // 2s
-const TTL = 60000; // 1 minute
 
 export enum HashType {
   ACCOUNT = "account",
@@ -116,7 +114,6 @@ function Name({address}: {address: string}) {
   if (!name) {
     return null;
   }
-  setLocalStorageWithExpiry(address, name, TTL);
 
   return (
     <Box>


### PR DESCRIPTION
This reverts commit 512e58dacf5648068fde91175c1e8d75648e1d95.

cache caused it keeps displaying the first name for all following account user viewed.