### PR TITLE
Fix ans name caching

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -4,8 +4,11 @@ import {useGlobalState} from "../../GlobalState";
 import {
   fetchJsonResponse,
   getLocalStorageWithExpiry,
+  setLocalStorageWithExpiry,
   truncateAptSuffix,
 } from "../../utils";
+
+const TTL = 60000; // 1 minute
 
 function getFetchNameUrl(
   network: NetworkName,
@@ -38,11 +41,13 @@ export function useGetNameFromAddress(address: string) {
         const {name: primaryName} = await fetchJsonResponse(primaryNameUrl);
 
         if (primaryName) {
+          setLocalStorageWithExpiry(address, primaryName, TTL);
           setName(primaryName);
         } else {
           const nameUrl =
             getFetchNameUrl(state.network_name, address, false) ?? "";
           const {name} = await fetchJsonResponse(nameUrl);
+          setLocalStorageWithExpiry(address, name, TTL);
           setName(name);
         }
       };

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -17,7 +17,6 @@ import {setLocalStorageWithExpiry} from "../utils";
 
 const BUTTON_HEIGHT = 34;
 const TOOLTIP_TIME = 2000; // 2s
-const TTL = 60000; // 1 minute
 
 export enum HashType {
   ACCOUNT = "account",
@@ -116,7 +115,6 @@ function Name({address}: {address: string}) {
   if (!name) {
     return null;
   }
-  setLocalStorageWithExpiry(address, name, TTL);
 
   return (
     <Box>


### PR DESCRIPTION
We need to cache in `useEffect` otherwise we are caching the previous value because `useState` is not synchronous.

This will try to cache both sender and receiver if they have corresponding ANS, since we set cache expiration to 1 min, it shouldn't blow up the cache.