### PR TITLE
fix ANS caching

### DIFF
--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -109,7 +109,7 @@ function HashButton({hash}: {hash: string}) {
 
 function Name({address}: {address: string}) {
   const theme = useTheme();
-  const name = useGetNameFromAddress(address);
+  const name = useGetNameFromAddress(address, true);
 
   if (!name) {
     return null;


### PR DESCRIPTION
**Background**
We previously try to cache ANS name to reduce API call to indexer. But there were some issues.

**Solution**
We need to cache in `useEffect` otherwise we are caching the previous value because useState is not synchronous.

Since we only cache the account owner's ANS name, it shouldn't add too much data to `localStorage`, chatgpt said if average string length is 50 char, `localStorage` should be able to hold 100_000 strings.
