### PR TITLE
[GP-2] fix external links by enhancing/generalizing InternalLink component to Link and use it everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Clone the repo. Requires [pnpm](https://pnpm.io/installation)
 
-
 Install dependencies:
+
 ```sh
 pnpm install
 ```

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "fmt": "prettier --write '**/*.(js|jsx|ts|tsx|json|css|scss|md)'",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "postinstall": "husky install"

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -18,11 +18,11 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
 function getGraphqlURI(networkName: NetworkName): string | undefined {
   switch (networkName) {
     case "mainnet":
-      return process.env.REACT_APP_INDEXER_GRAPHQL_MAINNET;
+      return "https://indexer.mainnet.aptoslabs.com/v1/graphql";
     case "testnet":
-      return process.env.REACT_APP_INDEXER_GRAPHQL_TESTNET;
+      return "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql";
     case "devnet":
-      return process.env.REACT_APP_INDEXER_GRAPHQL_DEVNET;
+      return "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql";
     case "local":
       return undefined;
     default:

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -14,7 +14,7 @@ import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
 import {truncateAddress, truncateAddressMiddle} from "../pages/utils";
 import {assertNever} from "../utils";
 import {useGetNameFromAddress} from "../api/hooks/useGetANS";
-import {InternalLink} from "../routing";
+import {Link} from "../routing";
 
 export enum HashType {
   ACCOUNT = "account",
@@ -40,9 +40,9 @@ function HashLink(hash: string, type: HashType): JSX.Element {
     case HashType.ACCOUNT:
     case HashType.TRANSACTION:
       return (
-        <InternalLink to={getHashLinkStr(hash, type)} color="inherit">
+        <Link to={getHashLinkStr(hash, type)} color="inherit">
           {hash}
-        </InternalLink>
+        </Link>
       );
     case HashType.OTHERS:
       return <>{hash}</>;

--- a/src/components/snakebar/FailureSnackbar.tsx
+++ b/src/components/snakebar/FailureSnackbar.tsx
@@ -2,7 +2,7 @@ import {Snackbar, Alert, Typography} from "@mui/material";
 import {CloseAction} from "./TransactionResponseSnackbar";
 import {Types} from "aptos";
 import React from "react";
-import {InternalLink} from "../../routing";
+import {Link} from "../../routing";
 
 type FailureSnackbarProps = {
   onCloseSnackbar: () => void;
@@ -30,9 +30,9 @@ export default function FailureSnackbar({
       >
         <Typography variant="inherit">
           Transaction {""}
-          <InternalLink to={`/txn/${hash}`} color="inherit" target="_blank">
+          <Link to={`/txn/${hash}`} color="inherit" target="_blank">
             {hash}
-          </InternalLink>{" "}
+          </Link>{" "}
           failed{" "}
           {"vm_status" in data && data.vm_status
             ? `with "${data.vm_status}"`

--- a/src/pages/Account/Components/TokensTable.tsx
+++ b/src/pages/Account/Components/TokensTable.tsx
@@ -6,7 +6,7 @@ import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeader
 import {assertNever} from "../../../utils";
 import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
-import {InternalLink, useNavigate} from "../../../routing";
+import {Link, useNavigate} from "../../../routing";
 
 type TokenCellProps = {
   token: any; // TODO: add graphql data typing
@@ -15,7 +15,7 @@ type TokenCellProps = {
 function TokenNameCell({token}: TokenCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "left"}}>
-      <InternalLink
+      <Link
         to={`/token/${token?.token_data_id_hash}/${token?.property_version}`}
         color="primary"
       >
@@ -28,7 +28,7 @@ function TokenNameCell({token}: TokenCellProps) {
         >
           {token?.name}
         </Box>
-      </InternalLink>
+      </Link>
     </GeneralTableCell>
   );
 }

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -35,7 +35,7 @@ import {getBytecodeSizeInKB, transformCode} from "../../../../utils";
 
 import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import {useParams, useSearchParams} from "react-router-dom";
-import {InternalLink, useNavigate} from "../../../../routing";
+import {Link, useNavigate} from "../../../../routing";
 
 type PackageMetadata = {
   name: string;
@@ -197,7 +197,7 @@ function ModuleNameOption({selected, name, linkTo}: ModuleNameOptionProps) {
   const theme = useTheme();
 
   return (
-    <InternalLink to={linkTo}>
+    <Link to={linkTo} underline="none" color={"inherit"}>
       <Box
         key={name}
         sx={{
@@ -220,7 +220,7 @@ function ModuleNameOption({selected, name, linkTo}: ModuleNameOptionProps) {
       >
         {name}
       </Box>
-    </InternalLink>
+    </Link>
   );
 }
 

--- a/src/pages/Analytics/NetworkInfo/NetworkInfo.tsx
+++ b/src/pages/Analytics/NetworkInfo/NetworkInfo.tsx
@@ -6,7 +6,7 @@ import TPS from "./TPS";
 import ActiveValidators from "./ActiveValidators";
 import TotalTransactions from "./TotalTransactions";
 import {useGetInMainnet} from "../../../api/hooks/useGetInMainnet";
-import {InternalLink} from "../../../routing";
+import {Link} from "../../../routing";
 
 type CardStyle = "default" | "outline";
 
@@ -22,14 +22,9 @@ function LinkableContainer({
   const inMainnet = useGetInMainnet();
 
   return inMainnet && linkToAnalyticsPage ? (
-    <InternalLink
-      to="/analytics"
-      underline="none"
-      color="inherit"
-      variant="inherit"
-    >
+    <Link to="/analytics" underline="none" color="inherit" variant="inherit">
       {children}
-    </InternalLink>
+    </Link>
   ) : (
     <>{children}</>
   );

--- a/src/pages/Block/Tabs/OverviewTab.tsx
+++ b/src/pages/Block/Tabs/OverviewTab.tsx
@@ -5,7 +5,7 @@ import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import {InternalLink} from "../../../routing";
+import {Link} from "../../../routing";
 import {getLearnMoreTooltip} from "../../Transaction/helpers";
 
 function isBlockMetadataTransaction(
@@ -21,13 +21,13 @@ function VersionValue({data}: {data: Types.Block}) {
   const {first_version, last_version} = data;
   return (
     <>
-      <InternalLink to={`/txn/${first_version}`} underline="none">
+      <Link to={`/txn/${first_version}`} underline="none">
         {first_version}
-      </InternalLink>
+      </Link>
       {" - "}
-      <InternalLink to={`/txn/${last_version}`} underline="none">
+      <Link to={`/txn/${last_version}`} underline="none">
         {last_version}
-      </InternalLink>
+      </Link>
     </>
   );
 }

--- a/src/pages/Blocks/Table.tsx
+++ b/src/pages/Blocks/Table.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {Link, Table, TableHead, TableRow} from "@mui/material";
+import {Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../utils";
@@ -9,7 +9,7 @@ import {parseTimestamp} from "../utils";
 import moment from "moment";
 import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
-import {InternalLink, useAugmentToWithGlobalSearchParams} from "../../routing";
+import {Link, useAugmentToWithGlobalSearchParams} from "../../routing";
 
 function getAgeInSeconds(block: Types.Block): string {
   const blockTimestamp = parseTimestamp(block.block_timestamp);
@@ -26,13 +26,13 @@ type BlockCellProps = {
 function BlockHeightCell({block}: BlockCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "left"}}>
-      <InternalLink
+      <Link
         to={`/block/${block.block_height}`}
         target="_blank"
         underline="none"
       >
         {block.block_height}
-      </InternalLink>
+      </Link>
     </GeneralTableCell>
   );
 }
@@ -56,13 +56,9 @@ function BlockHashCell({block}: BlockCellProps) {
 function FirstVersionCell({block}: BlockCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "right"}}>
-      <InternalLink
-        to={`/txn/${block.first_version}`}
-        target="_blank"
-        underline="none"
-      >
+      <Link to={`/txn/${block.first_version}`} target="_blank" underline="none">
         {block.first_version}
-      </InternalLink>
+      </Link>
     </GeneralTableCell>
   );
 }
@@ -70,13 +66,9 @@ function FirstVersionCell({block}: BlockCellProps) {
 function LastVersionCell({block}: BlockCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "right"}}>
-      <InternalLink
-        to={`/txn/${block.last_version}`}
-        target="_blank"
-        underline="none"
-      >
+      <Link to={`/txn/${block.last_version}`} target="_blank" underline="none">
         {block.last_version}
-      </InternalLink>
+      </Link>
     </GeneralTableCell>
   );
 }

--- a/src/pages/Token/Component/ActivitiesTable.tsx
+++ b/src/pages/Token/Component/ActivitiesTable.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import * as RRD from "react-router-dom";
-import {Link, Table, TableHead, TableRow} from "@mui/material";
+import {Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../../utils";
 import HashButton, {HashType} from "../../../components/HashButton";
 import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
-import {InternalLink} from "../../../routing";
+import {Link} from "../../../routing";
 
 type ActivityCellProps = {
   activity: any; // TODO: add graphql data typing
@@ -16,7 +16,7 @@ type ActivityCellProps = {
 function TransactionVersionCell({activity}: ActivityCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "left"}}>
-      <InternalLink
+      <Link
         to={`/txn/${
           "transaction_version" in activity && activity.transaction_version
         }`}
@@ -24,7 +24,7 @@ function TransactionVersionCell({activity}: ActivityCellProps) {
         underline="none"
       >
         {activity?.transaction_version}
-      </InternalLink>
+      </Link>
     </GeneralTableCell>
   );
 }

--- a/src/pages/Token/Tabs/OverviewTab.tsx
+++ b/src/pages/Token/Tabs/OverviewTab.tsx
@@ -1,12 +1,12 @@
 import {useParams} from "react-router-dom";
 import {gql, useQuery} from "@apollo/client";
-import {Box, Link, Stack} from "@mui/material";
+import {Box, Stack} from "@mui/material";
 import React, {useState} from "react";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
-import {InternalLink} from "../../../routing";
+import {Link} from "../../../routing";
 
 const OWNER_QUERY = gql`
   query OwnersData($token_id: String, $property_version: numeric) {
@@ -107,7 +107,9 @@ export default function OverviewTab({data}: OverviewTabProps) {
                 />
               </a>
             ) : (
-              <InternalLink to={data?.metadata_uri}>Link</InternalLink>
+              <Link to={data?.metadata_uri} target="_blank">
+                {data?.metadata_uri}
+              </Link>
             )
           }
         />

--- a/src/pages/Transaction/Tabs/Components/TransactionBlockRow.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionBlockRow.tsx
@@ -1,9 +1,8 @@
-import {Link} from "@mui/material";
 import * as React from "react";
 import {useGetBlockByVersion} from "../../../../api/hooks/useGetBlock";
 import ContentRow from "../../../../components/IndividualPageContent/ContentRow";
 import {getLearnMoreTooltip} from "../../helpers";
-import {InternalLink} from "../../../../routing";
+import {Link} from "../../../../routing";
 
 export default function TransactionBlockRow({version}: {version: string}) {
   const {data} = useGetBlockByVersion({version: parseInt(version)});
@@ -16,9 +15,9 @@ export default function TransactionBlockRow({version}: {version: string}) {
     <ContentRow
       title="Block:"
       value={
-        <InternalLink to={`/block/${data.block_height}`} underline="none">
+        <Link to={`/block/${data.block_height}`} underline="none">
           {data.block_height}
-        </InternalLink>
+        </Link>
       }
       tooltip={getLearnMoreTooltip("block_height")}
     />

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -4,7 +4,7 @@ import {Types} from "aptos";
 import CurrencyExchangeOutlinedIcon from "@mui/icons-material/CurrencyExchangeOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import {CodeLineBox} from "../../../../components/CodeLineBox";
-import {InternalLink} from "../../../../routing";
+import {Link} from "../../../../routing";
 import {codeBlockColorClickableOnHover} from "../../../../themes/colors/aptosColorPalette";
 
 function CoinTransferCodeLine({sx}: {sx?: SxProps<Theme>}): JSX.Element {
@@ -56,8 +56,9 @@ export default function TransactionFunction({
     functionFullStr === "0x1::aptos_account::transfer"
   ) {
     return (
-      <InternalLink
+      <Link
         to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+        underline="none"
       >
         <CoinTransferCodeLine
           sx={[
@@ -69,17 +70,18 @@ export default function TransactionFunction({
             },
           ]}
         />
-      </InternalLink>
+      </Link>
     );
   }
 
   return (
-    <InternalLink
+    <Link
       to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+      underline="none"
     >
       <CodeLineBox clickable sx={[...(Array.isArray(sx) ? sx : [sx])]}>
         {moduleName + "::" + functionName}
       </CodeLineBox>
-    </InternalLink>
+    </Link>
   );
 }

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 import {Box, Stack} from "@mui/material";
-import * as RRD from "react-router-dom";
-import Link from "@mui/material/Link";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
@@ -31,7 +29,7 @@ import {
   getTransactionAmount,
   getTransactionCounterparty,
 } from "../Transaction/utils";
-import {InternalLink, useNavigate} from "../../routing";
+import {Link, useNavigate} from "../../routing";
 
 type TransactionCellProps = {
   transaction: Types.Transaction;
@@ -50,13 +48,13 @@ function TransactionVersionStatusCell({transaction}: TransactionCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "left"}}>
       <Stack direction="row" spacing={0.5}>
-        <InternalLink
+        <Link
           to={`/txn/${"version" in transaction && transaction.version}`}
           color="primary"
           underline="none"
         >
           {"version" in transaction && transaction.version}
-        </InternalLink>
+        </Link>
         {"success" in transaction && (
           <TableTransactionStatus success={transaction.success} />
         )}

--- a/src/pages/Validators/StakingDrawer.tsx
+++ b/src/pages/Validators/StakingDrawer.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Divider,
-  Link,
   List,
   ListItem,
   Typography,
@@ -11,7 +10,7 @@ import * as React from "react";
 import SideDrawer from "../../components/SideDrawer";
 import {grey} from "../../themes/colors/aptosColorPalette";
 import {REWARDS_LEARN_MORE_LINK} from "./Components/Staking";
-import {InternalLink} from "../../routing";
+import {Link} from "../../routing";
 
 type StakingDrawerProps = {
   open: boolean;
@@ -26,16 +25,15 @@ const faqStakingData = [
         total delegation pool is an aggregation of staked APT from various token
         owners, and collectively staked. Aptos is a proof-of-stake network,
         which means that tokens are staked to{" "}
-        <InternalLink to={"#validators-section"}>validators</InternalLink> in
-        order to keep the network healthy.
+        <Link to={"#validators-section"}>validators</Link> in order to keep the
+        network healthy.
         <br />
         <br />
         When you delegate stake, you own the tokens and earn{" "}
-        <InternalLink to={"#rewards-section"}>rewards</InternalLink> on top of
-        the staked amount. At no point does the validator have any access to
-        your tokens as they remain securely in your control. The delegation
-        smart contract has undergone security audit and thorough testing before
-        launch.
+        <Link to={"#rewards-section"}>rewards</Link> on top of the staked
+        amount. At no point does the validator have any access to your tokens as
+        they remain securely in your control. The delegation smart contract has
+        undergone security audit and thorough testing before launch.
       </React.Fragment>
     ),
   },
@@ -53,9 +51,9 @@ const faqStakingData = [
     answer: (
       <React.Fragment>
         "You can stake APT directly by going to the{" "}
-        <Link href={"/validators/delegation"}>Explorer</Link> page and
-        connecting your wallet. If you are using the Petra wallet, you should
-        see the following flow:
+        <Link to={"/validators/delegation"}>Explorer</Link> page and connecting
+        your wallet. If you are using the Petra wallet, you should see the
+        following flow:
         <br />
         <br />
         <ol style={{marginLeft: "1em"}}>
@@ -78,7 +76,7 @@ const faqStakingData = [
         Congratulations! You have successfully staked APT on Explorer! You can
         also stake APT directly to a validator node through the{" "}
         <Link
-          href="https://aptos.dev/nodes/validator-node/operator/staking-pool-operations"
+          to="https://aptos.dev/nodes/validator-node/operator/staking-pool-operations"
           target="_blank"
         >
           CLI
@@ -175,7 +173,7 @@ const faqValidatorData = [
         trusted to vote on transactions. You can read more about how the Aptos
         blockchain works{" "}
         <Link
-          href={"https://aptos.dev/guides/basics-life-of-txn#consensus"}
+          to={"https://aptos.dev/guides/basics-life-of-txn#consensus"}
           target="_blank"
         >
           here

--- a/src/pages/layout/Footer.tsx
+++ b/src/pages/layout/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Box, Container, Link, Stack, Typography, useTheme} from "@mui/material";
+import {Box, Container, Stack, Typography, useTheme} from "@mui/material";
 
 import Grid from "@mui/material/Unstable_Grid2";
 
@@ -12,7 +12,7 @@ import {grey} from "../../themes/colors/aptosColorPalette";
 import SvgIcon from "@mui/material/SvgIcon";
 
 import {ReactComponent as LogoFull} from "../../assets/svg/aptos_logo_icon.svg";
-import {InternalLink} from "../../routing";
+import {Link} from "../../routing";
 
 const socialLinks = [
   {title: "Git", url: "https://github.com/aptos-labs", icon: GithubLogo},
@@ -52,7 +52,7 @@ export default function Footer() {
           <Grid xs="auto" container justifyContent="start">
             <Link
               color="inherit"
-              href="https://aptoslabs.com/"
+              to="https://aptoslabs.com/"
               target="_blank"
               sx={{width: "3rem", mb: {xs: 2, md: 0}, mr: {md: 2}}}
             >
@@ -87,7 +87,7 @@ export default function Footer() {
             >
               <Link
                 color="inherit"
-                href="https://aptoslabs.com/privacy"
+                to="https://aptoslabs.com/privacy"
                 target="_blank"
                 sx={{
                   fontSize: "0.8rem",
@@ -98,7 +98,7 @@ export default function Footer() {
               </Link>
               <Link
                 color="inherit"
-                href="https://aptoslabs.com/terms"
+                to="https://aptoslabs.com/terms"
                 target="_blank"
                 sx={{
                   fontSize: "0.8rem",
@@ -125,7 +125,7 @@ export default function Footer() {
                 <Grid key={link.title}>
                   <Link
                     color="inherit"
-                    href={link.url}
+                    to={link.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     title={link.title}

--- a/src/pages/layout/Header.tsx
+++ b/src/pages/layout/Header.tsx
@@ -21,7 +21,7 @@ import {useGlobalState} from "../../global-config/GlobalConfig";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {sendToGTM} from "../../api/hooks/useGoogleTagManager";
 import {Statsig} from "statsig-react";
-import {InternalLink, useNavigate} from "../../routing";
+import {Link, useNavigate} from "../../routing";
 
 export default function Header() {
   const scrollTop = () => {
@@ -110,7 +110,7 @@ export default function Header() {
             }}
             disableGutters
           >
-            <InternalLink
+            <Link
               onClick={scrollTop}
               to="/"
               color="inherit"
@@ -122,7 +122,7 @@ export default function Header() {
               }}
             >
               <LogoIcon />
-            </InternalLink>
+            </Link>
 
             <Nav />
             <NetworkSelect />

--- a/src/pages/layout/Search/ResultLink.tsx
+++ b/src/pages/layout/Search/ResultLink.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {Link, Typography} from "@mui/material";
+import {Typography} from "@mui/material";
 import * as RRD from "react-router-dom";
-import {InternalLink} from "../../../routing";
+import {Link} from "../../../routing";
 
 type ResultLinkProps = {
   to: string | null;
@@ -28,8 +28,8 @@ export default function ResultLink({to, text}: ResultLinkProps): JSX.Element {
   }
 
   return (
-    <InternalLink to={to} color="inherit" underline="none" sx={style}>
+    <Link to={to} color="inherit" underline="none" sx={style}>
       {text}
-    </InternalLink>
+    </Link>
   );
 }

--- a/src/routing.tsx
+++ b/src/routing.tsx
@@ -10,9 +10,8 @@ import {
 const GLOBAL_PERSISTENT_SEARCH_PARAMS = ["network", "feature"];
 
 // This is a wrapper around MuiLink that ensures that some global params stay persistent across all links
-export const InternalLink = ({
+export const Link = ({
   to,
-  style,
   children,
   ...props
 }: Omit<React.ComponentProps<typeof MuiLink>, "component"> & {
@@ -22,7 +21,6 @@ export const InternalLink = ({
 
   return (
     <MuiLink
-      style={{textDecoration: "none", color: "inherit", ...style}}
       {...props}
       component={RouterLink}
       to={augmentToWithGlobalSearchParams(to)}
@@ -58,6 +56,10 @@ export function useAugmentToWithGlobalSearchParams() {
   const [currentSearchParams] = useSearchParams();
   return function augmentToWithGlobalSearchParams(to: string) {
     const toUrl = new URL(to, window.location.origin);
+    if (toUrl.origin !== window.location.origin) {
+      // Don't augment external links
+      return to;
+    }
     for (const param of GLOBAL_PERSISTENT_SEARCH_PARAMS) {
       if (!toUrl.searchParams.has(param) && currentSearchParams.has(param)) {
         toUrl.searchParams.set(param, currentSearchParams.get(param)!);


### PR DESCRIPTION
This generalizes the `InternalLink` component into the `Link` component that can be used everywhere, incl. external links.
We do so by skipping link augmentation if the `to` parameter points to an external origin.
This fixes the broken nft metadata links such as https://explorer.aptoslabs.com/token/7c8d820c87ad860e42dfff3b3a6b8e1eb4f305fb3228d3facf4ef13a33fdd68b/0?network=mainnet which accidentally used the InternalLink component and broke the external metadata link.
Now we don't have to worry anymore where to use <Link> vs <InternalLink>, everything can just use the`<Link>` component from routing.tsx.

In addition to this I removed the style overrides (such underline="none") from within the Link component and moved them to the call-site when removing underline etc. is actually desired.
This should undo some uninentional style changes that were introduced as part of my previous PR.

Before: https://explorer.aptoslabs.com/token/7c8d820c87ad860e42dfff3b3a6b8e1eb4f305fb3228d3facf4ef13a33fdd68b/0?network=mainnet 
After: https://deploy-preview-470--aptos-explorer.netlify.app/token/7c8d820c87ad860e42dfff3b3a6b8e1eb4f305fb3228d3facf4ef13a33fdd68b/0?network=mainnet