### PR TITLE
[delegation] address mainnet testing feedback

### DIFF
--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -2,6 +2,7 @@ import {AptosClient, Types} from "aptos";
 import {useState, useMemo} from "react";
 import {getValidatorCommission, getValidatorState} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {ResponseError} from "../client";
 import {useGetAccountResource} from "./useGetAccountResource";
 import {useGetValidatorSet} from "./useGetValidatorSet";
 
@@ -17,6 +18,7 @@ type DelegationNodeInfoResponse = {
   commission: number | undefined;
   isQueryLoading: boolean;
   validatorStatus: Types.MoveValue[] | undefined;
+  error: ResponseError | null;
 };
 
 type DelegationNodeInfoProps = {
@@ -28,7 +30,11 @@ export function useGetDelegationNodeInfo({
 }: DelegationNodeInfoProps): DelegationNodeInfoResponse {
   const [state, _] = useGlobalState();
   const {totalVotingPower} = useGetValidatorSet();
-  const {data: delegationPool, isLoading} = useGetAccountResource(
+  const {
+    data: delegationPool,
+    isLoading,
+    error,
+  } = useGetAccountResource(
     validatorAddress,
     "0x1::delegation_pool::DelegationPool",
   );
@@ -65,5 +71,6 @@ export function useGetDelegationNodeInfo({
     delegatedStakeAmount,
     isQueryLoading,
     validatorStatus,
+    error,
   };
 }

--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -4,7 +4,7 @@ import {Alert} from "@mui/material";
 
 type ErrorProps = {
   error: ResponseError;
-  address: string;
+  address?: string;
 };
 
 export default function Error({error, address}: ErrorProps) {
@@ -17,16 +17,24 @@ export default function Error({error, address}: ErrorProps) {
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
-      return (
-        <Alert severity="error">
-          Unknown error ({error.type}) fetching an Account with address{" "}
-          {address}:
-          <br />
-          {error.message}
-          <br />
-          Try again later
-        </Alert>
-      );
+      if (address) {
+        return (
+          <Alert severity="error">
+            Unknown error ({error.type}) fetching an Account with address{" "}
+            {address}:
+            <br />
+            {error.message}
+            <br />
+            Try again later
+          </Alert>
+        );
+      } else {
+        return (
+          <Alert severity="error">
+            To many requests. Please try again 5 minutes later.
+          </Alert>
+        );
+      }
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/DelegatoryValidator/Components/ValidatorStatusIcon.tsx
+++ b/src/pages/DelegatoryValidator/Components/ValidatorStatusIcon.tsx
@@ -23,7 +23,7 @@ export default function ValidatorStatusIcon({
             label={"Pending Active"}
             color={"warning"}
             icon={<PendingIcon />}
-            sx={{color: "#14B8A6", backgroundColor: "rgba(20, 184, 166, 0.1)"}}
+            sx={{color: "#44c6ee", backgroundColor: "rgba(68, 198, 238, 0.1)"}}
           />
         );
       case 2:

--- a/src/pages/DelegatoryValidator/Components/ValidatorStatusIcon.tsx
+++ b/src/pages/DelegatoryValidator/Components/ValidatorStatusIcon.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import {useGetDelegationNodeInfo} from "../../../api/hooks/useGetDelegationNodeInfo";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DangerousIcon from "@mui/icons-material/Dangerous";
+import PendingIcon from "@mui/icons-material/Pending";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
 export default function ValidatorStatusIcon({
   address,
@@ -13,31 +15,52 @@ export default function ValidatorStatusIcon({
     validatorAddress: address,
   });
 
-  const status = validatorStatus
-    ? // const VALIDATOR_STATUS_INACTIVE: u64 = 4;
-      Number(validatorStatus[0]) === 4
-      ? "Inactive "
-      : "Active"
-    : "N/A";
-  const statusIcon =
-    status === "Active" ? (
-      <Chip
-        label={status}
-        color={"primary"}
-        icon={<CheckCircleIcon />}
-        sx={{color: "#14B8A6", backgroundColor: "rgba(20, 184, 166, 0.1)"}}
-      />
-    ) : (
-      <Chip
-        label={status}
-        color={"warning"}
-        icon={<DangerousIcon />}
-        sx={{
-          color: "rgba(234, 179, 8, 1)",
-          backgroundColor: "rgba(234, 179, 8, 0.1)",
-        }}
-      />
-    );
+  const getStatusIcon = () => {
+    switch (Number(validatorStatus![0])) {
+      case 1:
+        return (
+          <Chip
+            label={"Pending Active"}
+            color={"warning"}
+            icon={<PendingIcon />}
+            sx={{color: "#14B8A6", backgroundColor: "rgba(20, 184, 166, 0.1)"}}
+          />
+        );
+      case 2:
+        return (
+          <Chip
+            label={"Active"}
+            color={"primary"}
+            icon={<CheckCircleIcon />}
+            sx={{color: "#14B8A6", backgroundColor: "rgba(20, 184, 166, 0.1)"}}
+          />
+        );
+      case 3:
+        return (
+          <Chip
+            label={"Pending Inactive"}
+            color={"warning"}
+            icon={<MoreHorizIcon />}
+            sx={{
+              color: "rgba(252, 211, 77, 1)",
+              backgroundColor: "rgba(252, 211, 77, 0.1)",
+            }}
+          />
+        );
+      default:
+        return (
+          <Chip
+            label={"Inactive"}
+            color={"error"}
+            icon={<DangerousIcon />}
+            sx={{
+              color: "rgb(249, 115, 115, 1)",
+              backgroundColor: "rgb(249, 115, 115, 0.1)",
+            }}
+          />
+        );
+    }
+  };
 
-  return validatorStatus ? statusIcon : <></>;
+  return validatorStatus ? getStatusIcon() : <></>;
 }

--- a/src/pages/DelegatoryValidator/constants.ts
+++ b/src/pages/DelegatoryValidator/constants.ts
@@ -8,7 +8,7 @@ export const STAKED_TEXT_COLOR_DARK = "rgba(125, 211, 252, 1)";
 export const STAKED_BACKGROUND_COLOR_LIGHT = "rgba(14, 165, 233, 0.1)";
 export const STAKED_BACKGROUND_COLOR_DARK = "rgba(125, 211, 252, 0.1)";
 export const STAKED_LABEL = "Staked";
-export const STAKED_DESCRIPTION = `You are getting rewards for the staked deposit, but not able to
+export const STAKED_DESCRIPTION = `You are getting rewards for the staked deposit, not able to
 withdraw it until the lock period ends. But you can initiate this process with an
 unstake option.`;
 
@@ -20,7 +20,7 @@ export const WITHDRAW_PENDING_BACKGROUND_COLOR_LIGHT =
 export const WITHDRAW_PENDING_BACKGROUND_COLOR_DARK = "rgba(252, 211, 77, 0.1)";
 export const WITHDRAW_PENDING_LABEL = "Withdraw pending";
 export const WITHDRAW_PENDING_DESCRIPTION =
-  "If you decided to unstake your deposit, it will be locked till the end of the lock period.";
+  "If you decided to unstake your deposit, it will be locked till the end of the lock period. Your deposit is still earning rewards.";
 
 // step 3 WITHDRAW READY
 export const WITHDRAW_READY_TEXT_COLOR_LIGHT = "rgba(15, 118, 110, 1)";

--- a/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
+++ b/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
@@ -53,23 +53,60 @@ const useAmountInput = (stakeOperation: StakeOperation) => {
 
       switch (stakeOperation) {
         case StakeOperation.UNLOCK:
+          /**
+           * if active pool has less than 10 apt after txn, unlock all
+           * if pending_inactive pool has less than 10 apt after txn
+           * if active pool has enough stake, unlock 10 apt to meet minimum requirement
+           * else unlock all
+           */
           if (
             amount &&
-            (stakedAmount - Number(amount) < MINIMUM_APT_IN_POOL ||
-              unlockedAmount + Number(amount) < MINIMUM_APT_IN_POOL) &&
+            stakedAmount - Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== stakedAmount.toString()
           ) {
             return `If you unlock ${amount} APT, your total staked amount ${stakedAmount} APT will be unlocked.`;
+          } else if (
+            amount &&
+            unlockedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
+            amount !== stakedAmount.toString()
+          ) {
+            if (stakedAmount - MINIMUM_APT_IN_POOL > MINIMUM_APT_IN_POOL) {
+              return `If you unlock ${amount} APT, ${MINIMUM_APT_IN_POOL} APT will be unlocked.`;
+            } else {
+              return `If you unlock ${amount} APT, your total staked amount ${stakedAmount} APT will be unlocked.`;
+            }
           }
           break;
         case StakeOperation.REACTIVATE:
+          /**
+           * if pending_inactive pool has less than 10 apt after txn, reactivate all
+           * if active pool has less than 10 apt after txn, reactivate 10 apt to meet minimum requirement
+           * if pending_inactive pool has enough stake, ractivate 10 apt to meet minimum requirement
+           * else reactivate all
+           */
           if (
             amount &&
-            (unlockedAmount - Number(amount) < MINIMUM_APT_IN_POOL ||
-              stakedAmount + Number(amount) < MINIMUM_APT_IN_POOL) &&
+            unlockedAmount - Number(amount) < MINIMUM_APT_IN_POOL &&
+            stakedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== unlockedAmount.toString()
           ) {
             return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+          } else if (
+            amount &&
+            unlockedAmount - Number(amount) < MINIMUM_APT_IN_POOL &&
+            amount !== unlockedAmount.toString()
+          ) {
+            return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+          } else if (
+            amount &&
+            stakedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
+            amount !== unlockedAmount.toString()
+          ) {
+            if (unlockedAmount - MINIMUM_APT_IN_POOL > MINIMUM_APT_IN_POOL) {
+              return `If you restake ${amount} APT, ${MINIMUM_APT_IN_POOL} APT will be restaked.`;
+            } else {
+              return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+            }
           }
           break;
         case StakeOperation.STAKE:

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -75,7 +75,7 @@ export default function ValidatorPage() {
   }, [delegatedStakingPools, loading, validators, validator]);
 
   if (error) {
-    return <Error error={error} address={validator?.owner_address!} />;
+    return <Error error={error} />;
   }
 
   if ((!validator && !delegationValidator) || !accountResource) {

--- a/src/pages/Validators/Components/Staking.tsx
+++ b/src/pages/Validators/Components/Staking.tsx
@@ -9,7 +9,7 @@ import {useGetStakingRewardsRate} from "../../../api/hooks/useGetStakingRewardsR
 import {StyledLearnMoreTooltip} from "../../../components/StyledTooltip";
 
 export const REWARDS_TOOLTIP_TEXT =
-  "Represents the Annual Percentage Yield (APY) that accrue as compound interest on staked APT. Rewards are paid out by the network after each Epoch.";
+  "Represents the Annual Percentage Yield (APY) that accrue as compound interest on staked APT. Rewards are paid out by the network after each Epoch.APY is subject to change based on validator performance or in accordance with network specifications. There is no guarantee that the current APY will continue to apply in future periods.";
 export const REWARDS_LEARN_MORE_LINK =
   "https://aptos.dev/concepts/staking#rewards";
 

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -173,13 +173,7 @@ function ValidatorHeaderCell({
         />
       );
     case "view":
-      return (
-        <GeneralTableHeaderCell
-          header="View"
-          isTableTooltip={false}
-          sx={{paddingLeft: 3}}
-        />
-      );
+      return <GeneralTableHeaderCell header="View" isTableTooltip={false} />;
     case "myDeposit":
       return (
         <GeneralTableHeaderCell header="My Deposit" isTableTooltip={false} />
@@ -303,17 +297,20 @@ function DelegatedAmountCell({
 function ViewCell() {
   return (
     <GeneralTableCell>
-      <Button
+      <VisibilityOutlinedIcon
+        fontSize="small"
         sx={{
+          color: "black",
           backgroundColor: aptosColor,
           "&:hover": {
             backgroundColor: alpha(primary["500"], 1),
           },
-          width: "5px",
+          borderRadius: 0.75,
+          width: "2rem",
+          height: "2rem",
+          padding: "0.5rem",
         }}
-      >
-        <VisibilityOutlinedIcon sx={{color: "black"}} />
-      </Button>
+      />
     </GeneralTableCell>
   );
 }

--- a/src/pages/Validators/Index.tsx
+++ b/src/pages/Validators/Index.tsx
@@ -14,7 +14,7 @@ export default function ValidatorsPage() {
   const [state, _] = useGlobalState();
   const {account, wallet} = useWallet();
   const {config} = useConfig(STAKING_BANNER_CONFIG_NAME);
-  const viewCountCap = config.getValue("viewCount");
+  const viewCountCap = config.getValue("view_count");
   // Get the user's stable ID
   const stableID = Statsig.getStableID();
 


### PR DESCRIPTION
1. make staking and unstaking warning message more accurate.
    - if active pool has less than 10 apt after txn, unlock all
    - if pending_inactive pool has less than 10 apt after txn
    - if active pool has enough stake, unlock 10 apt to meet minimum requirement, else unlock all
2. update tooltip wording on apy, and staking status
3. update validator state to reflect all 4 states
4. fix the txn succeeded dialog amount mismatch issue: https://aptos-org.slack.com/archives/C04EXV6UTR7/p1681942876524159
5. fix withdraw action when validator's inactive to check for both withdraw and pending_inactive fund 


<img width="240" alt="Screenshot 2023-04-19 at 5 00 13 PM" src="https://user-images.githubusercontent.com/121921928/233224255-7d5ed6d9-0f50-439e-9186-86535100afe4.png">
<img width="805" alt="Screenshot 2023-04-19 at 4 59 56 PM" src="https://user-images.githubusercontent.com/121921928/233224215-7cecf268-9475-44bd-ba48-156a44fc5ecd.png">
<img width="291" alt="Screenshot 2023-04-19 at 5 00 17 PM" src="https://user-images.githubusercontent.com/121921928/233224245-bfc3b2f0-b1bf-4f9f-b40d-b2e86c39a34b.png">


| before | after |
| -- | -- |
| <img width="456" alt="Screenshot 2023-04-19 at 5 01 31 PM" src="https://user-images.githubusercontent.com/121921928/233224379-74fc4b7d-3759-478f-b639-1ee018925a7b.png"> | <img width="301" alt="Screenshot 2023-04-19 at 5 00 46 PM" src="https://user-images.githubusercontent.com/121921928/233224395-4f88e230-61e1-4761-a31c-849ff3ffa272.png"> |

