### PR TITLE
[EZ] add operator address padding as well

### DIFF
--- a/src/api/hooks/useGetValidators.ts
+++ b/src/api/hooks/useGetValidators.ts
@@ -67,6 +67,9 @@ function useGetValidatorsRawData(network: NetworkName) {
             return {
               ...validatorData,
               owner_address: standardizeAddress(validatorData.owner_address),
+              operator_address: standardizeAddress(
+                validatorData.operator_address,
+              ),
             };
           }),
         );


### PR DESCRIPTION
issue reported from partner: https://aptos-org.slack.com/archives/C03BE1CFFR8/p1682106982957519

> Hi! Just noticed the such thing - the explorer does not show our validator name. And the link to it leads here - https://explorer.aptoslabs.com/account/0x639fd7e993d9fbdee08e96a77b0fc6cde10d0636fa289382812124156738348  And if you look at the information through aptos names, then here - https://explorer.aptoslabs.com/account/0x0639fd7e993d9fbdee08e96a77b0fc6cde10d0636fa289382812124156738348
It seems that the problem is that the address starts with 0?

as well as issue reported on github: https://github.com/aptos-labs/explorer/issues/480


<img width="1284" alt="Screenshot 2023-04-21 at 2 52 22 PM" src="https://user-images.githubusercontent.com/121921928/233740254-be18757c-bfd5-4a68-813f-3a1a0266344a.png">
