### PR TITLE
[explorer] /modules default to /modules/code

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -31,11 +31,7 @@ export default function ExplorerRoutes() {
         </Route>
         <Route path="/account">
           <Route
-            path=":address/modules/:selectedModuleName/:modulesTab"
-            element={<AccountPage />}
-          />
-          <Route
-            path=":address/modules/:selectedModuleName"
+            path=":address/modules/:modulesTab/:selectedModuleName"
             element={<AccountPage />}
           />
           <Route path=":address/:tab" element={<AccountPage />} />

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -169,6 +169,14 @@ export function getAccountModule(
   );
 }
 
+export function view(
+  request: Types.ViewRequest,
+  nodeUrl: string,
+): Promise<Types.MoveValue[]> {
+  const client = new AptosClient(nodeUrl);
+  return withResponseError(client.view(request));
+}
+
 export function getTableItem(
   requestParameters: {tableHandle: string; data: Types.TableItemRequest},
   nodeUrl: string,

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -93,10 +93,10 @@ export default function AccountTabs({
   accountData,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
-  const {tab, selectedModuleName, modulesTab} = useParams();
+  const {tab, modulesTab} = useParams();
   const navigate = useNavigate();
   let effectiveTab: TabValue;
-  if (selectedModuleName) {
+  if (modulesTab) {
     effectiveTab = "modules" as TabValue;
   } else if (tab !== undefined) {
     effectiveTab = tab as TabValue;

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -99,7 +99,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
         ) : isRead ? (
           <ReadContractForm module={module} fn={fn} />
         ) : (
-          <WriteContractForm module={module} fn={fn} />
+          <RunContractForm module={module} fn={fn} />
         )}
       </Grid>
     </Grid>
@@ -168,7 +168,7 @@ function ContractSidebar({
   );
 }
 
-function WriteContractForm({
+function RunContractForm({
   module,
   fn,
 }: {

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -228,7 +228,6 @@ function ReadContractForm({
       type_arguments: data.typeArgs,
       arguments: data.args,
     };
-    console.log(JSON.stringify(viewRequest, null, 2));
     const result = await view(viewRequest, state.network_value);
     setResult(result);
   };

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -1,5 +1,5 @@
 import {Types} from "aptos";
-import {useState} from "react";
+import {ReactNode, useState} from "react";
 import Error from "../../Error";
 import {useGetAccountModules} from "../../../../api/hooks/useGetAccountModules";
 import EmptyTabContent from "../../../../components/IndividualPageContent/EmptyTabContent";
@@ -20,20 +20,21 @@ import React from "react";
 import {useForm, SubmitHandler, Controller} from "react-hook-form";
 import useSubmitTransaction from "../../../../api/hooks/useSubmitTransaction";
 import {useGlobalState} from "../../../../global-config/GlobalConfig";
+import {view} from "../../../../api";
 
-type WriteContractFormType = {
+type ContractFormType = {
   typeArgs: string[];
   args: string[];
 };
 
-interface WriteContractSidebarProps {
+interface ContractSidebarProps {
   selectedModuleName: string | undefined;
   selectedFnName: string | undefined;
   moduleAndFnsGroup: Record<string, Types.MoveFunction[]>;
   handleClick: (moduleName: string, fnName: string) => void;
 }
 
-function WriteContract({address}: {address: string}) {
+function Contract({address, isRead}: {address: string; isRead: boolean}) {
   const {data, isLoading, error} = useGetAccountModules(address);
   const [selectedModuleName, setSelectedModuleName] = useState<string>();
   const [selectedFnName, setSelectedFnName] = useState<string>();
@@ -56,7 +57,11 @@ function WriteContract({address}: {address: string}) {
       return acc;
     }
 
-    const fns = module.abi.exposed_functions.filter((fn) => fn.is_entry);
+    const fns = module.abi.exposed_functions.filter((fn) =>
+      isRead
+        ? fn.is_view
+        : fn.is_entry && fn.params.length > 0 && fn.params[0] === "&signer",
+    );
     if (fns.length === 0) {
       return acc;
     }
@@ -78,7 +83,7 @@ function WriteContract({address}: {address: string}) {
   return (
     <Grid container spacing={2}>
       <Grid item md={3} xs={12}>
-        <WriteContractSidebar
+        <ContractSidebar
           selectedModuleName={selectedModuleName}
           selectedFnName={selectedFnName}
           moduleAndFnsGroup={moduleAndFnsGroup}
@@ -90,7 +95,9 @@ function WriteContract({address}: {address: string}) {
       </Grid>
       <Grid item md={9} xs={12}>
         {!module || !fn ? (
-          <EmptyTabContent message="Please selet a function" />
+          <EmptyTabContent message="Please select a function" />
+        ) : isRead ? (
+          <ReadContractForm module={module} fn={fn} />
         ) : (
           <WriteContractForm module={module} fn={fn} />
         )}
@@ -99,12 +106,12 @@ function WriteContract({address}: {address: string}) {
   );
 }
 
-function WriteContractSidebar({
+function ContractSidebar({
   selectedModuleName,
   selectedFnName,
   moduleAndFnsGroup,
   handleClick,
-}: WriteContractSidebarProps) {
+}: ContractSidebarProps) {
   const theme = useTheme();
   return (
     <Box
@@ -169,22 +176,92 @@ function WriteContractForm({
   fn: Types.MoveFunction;
 }) {
   const [state] = useGlobalState();
-  const {account, connected} = useWallet();
-  const {handleSubmit, control} = useForm<WriteContractFormType>();
+  const {connected} = useWallet();
   const {submitTransaction} = useSubmitTransaction();
-  const theme = useTheme();
 
-  const onSubmit: SubmitHandler<WriteContractFormType> = async (data) => {
+  const onSubmit: SubmitHandler<ContractFormType> = async (data) => {
     const payload: Types.TransactionPayload = {
       type: "entry_function_payload",
       function: `${module.address}::${module.name}::${fn.name}`,
       type_arguments: data.typeArgs,
-      arguments: data.args,
+      // drop signer argument (that is null)
+      arguments: data.args.slice(1),
     };
     await submitTransaction(payload);
   };
 
-  const hasSigner = fn.params.length > 0 && fn.params[0] === "&signer";
+  return (
+    <ContractForm
+      fn={fn}
+      onSubmit={onSubmit}
+      result={
+        connected ? (
+          <Button type="submit" variant="contained" sx={{maxWidth: "8rem"}}>
+            Write
+          </Button>
+        ) : (
+          <Box display="flex" flexDirection="row" alignItems="center">
+            <WalletConnector networkSupport={state.network_name} />
+            <Typography ml={2} fontSize={10}>
+              To write you need to connect wallet first
+            </Typography>
+          </Box>
+        )
+      }
+    />
+  );
+}
+
+function ReadContractForm({
+  module,
+  fn,
+}: {
+  module: Types.MoveModule;
+  fn: Types.MoveFunction;
+}) {
+  const [state] = useGlobalState();
+  const [result, setResult] = useState<Types.MoveValue[]>([]);
+
+  const onSubmit: SubmitHandler<ContractFormType> = async (data) => {
+    const viewRequest: Types.ViewRequest = {
+      function: `${module.address}::${module.name}::${fn.name}`,
+      type_arguments: data.typeArgs,
+      arguments: data.args,
+    };
+    console.log(JSON.stringify(viewRequest, null, 2));
+    const result = await view(viewRequest, state.network_value);
+    setResult(result);
+  };
+
+  return (
+    <ContractForm
+      fn={fn}
+      onSubmit={onSubmit}
+      result={
+        <Box display="flex" flexDirection="row" alignItems="center">
+          <Button type="submit" variant="contained" sx={{maxWidth: "8rem"}}>
+            Query
+          </Button>
+          <Typography ml={2} fontSize={10}>
+            {JSON.stringify(result, null, 2)}
+          </Typography>
+        </Box>
+      }
+    />
+  );
+}
+
+function ContractForm({
+  fn,
+  onSubmit,
+  result,
+}: {
+  fn: Types.MoveFunction;
+  onSubmit: SubmitHandler<ContractFormType>;
+  result: ReactNode;
+}) {
+  const {handleSubmit, control} = useForm<ContractFormType>();
+  const theme = useTheme();
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -221,27 +298,17 @@ function WriteContractForm({
               />
             ))}
             {fn.params.map((param, i) => {
-              if (i === 0 && hasSigner) {
-                return (
-                  <TextField
-                    key={i}
-                    fullWidth
-                    disabled
-                    value={account?.address ?? ""}
-                    label={"account: &signer"}
-                  />
-                );
-              }
               return (
                 <Controller
                   key={i}
-                  name={`args.${hasSigner ? i - 1 : i}`}
+                  name={`args.${i}`}
                   control={control}
                   render={({field: {onChange, value}}) => (
+                    // TODO: treat signer differently
                     <TextField
                       onChange={onChange}
                       value={value}
-                      label={`arg${hasSigner ? i - 1 : i}: ${param}`}
+                      label={`arg${i}: ${param}`}
                       fullWidth
                     />
                   )}
@@ -249,22 +316,11 @@ function WriteContractForm({
               );
             })}
           </Stack>
-          {connected ? (
-            <Button type="submit" variant="contained" sx={{maxWidth: "8rem"}}>
-              Write
-            </Button>
-          ) : (
-            <Box display="flex" flexDirection="row" alignItems="center">
-              <WalletConnector networkSupport={state.network_name} />
-              <Typography ml={2} fontSize={10}>
-                To write you need to connect wallet first
-              </Typography>
-            </Box>
-          )}
+          {result}
         </Stack>
       </Box>
     </form>
   );
 }
 
-export default WriteContract;
+export default Contract;

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -15,12 +15,12 @@ import {
   Button,
   useTheme,
 } from "@mui/material";
-import {grey} from "@mui/material/colors";
 import React from "react";
 import {useForm, SubmitHandler, Controller} from "react-hook-form";
 import useSubmitTransaction from "../../../../api/hooks/useSubmitTransaction";
 import {useGlobalState} from "../../../../global-config/GlobalConfig";
 import {view} from "../../../../api";
+import {grey} from "../../../../themes/colors/aptosColorPalette";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -129,7 +129,7 @@ function ContractSidebar({
         }}
       >
         {Object.entries(moduleAndFnsGroup).map(([moduleName, fns]) => (
-          <Box key={moduleName} marginY={3}>
+          <Box key={moduleName} marginBottom={3}>
             <Typography fontSize={14} fontWeight={500} marginBottom={"8px"}>
               {moduleName}
             </Typography>
@@ -146,14 +146,19 @@ function ContractSidebar({
                   padding={1}
                   borderRadius={1}
                   sx={{
+                    ...(theme.palette.mode === "dark" && !selected
+                      ? {
+                          color: grey[400],
+                          ":hover": {
+                            color: grey[200],
+                          },
+                        }
+                      : {}),
                     bgcolor: !selected
                       ? "transparent"
                       : theme.palette.mode === "dark"
                       ? grey[500]
                       : grey[200],
-                    ":hover": {
-                      cursor: "pointer",
-                    },
                   }}
                 >
                   {fn.name}

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -46,7 +46,7 @@ function ModulesTabs({address}: {address: string}): JSX.Element {
     modulesTab === undefined ? tabValues[0] : (modulesTab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/account/${address}/modules/${selectedModuleName}/${newValue}`);
+    navigate(`/account/${address}/modules/${newValue}/${selectedModuleName}`);
   };
 
   return (

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -6,12 +6,13 @@ import StyledTabs from "../../../../components/StyledTabs";
 import {grey} from "../../../../themes/colors/aptosColorPalette";
 import {assertNever} from "../../../../utils";
 import ViewCode from "./ViewCode";
-import WriteContract from "./WriteContract";
+import Contract from "./Contract";
 import {useNavigate} from "../../../../routing";
 
 const TabComponents = Object.freeze({
   code: ViewCode,
   write: WriteContract,
+  read: ReadContract,
 });
 
 type TabValue = keyof typeof TabComponents;
@@ -22,6 +23,8 @@ function getTabLabel(value: TabValue): string {
       return "View Code";
     case "write":
       return "Write";
+    case "read":
+      return "Read";
     default:
       return assertNever(value);
   }
@@ -31,6 +34,14 @@ type TabPanelProps = {
   value: TabValue;
   address: string;
 };
+
+function WriteContract({address}: {address: string}) {
+  return <Contract address={address} isRead={false} />;
+}
+
+function ReadContract({address}: {address: string}) {
+  return <Contract address={address} isRead />;
+}
 
 function TabPanel({value, address}: TabPanelProps): JSX.Element {
   const TabComponent = TabComponents[value];

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -11,8 +11,8 @@ import {useNavigate} from "../../../../routing";
 
 const TabComponents = Object.freeze({
   code: ViewCode,
-  write: WriteContract,
-  read: ReadContract,
+  run: RunContract,
+  view: ReadContract,
 });
 
 type TabValue = keyof typeof TabComponents;
@@ -20,11 +20,11 @@ type TabValue = keyof typeof TabComponents;
 function getTabLabel(value: TabValue): string {
   switch (value) {
     case "code":
-      return "View Code";
-    case "write":
-      return "Write";
-    case "read":
-      return "Read";
+      return "Code";
+    case "run":
+      return "Run";
+    case "view":
+      return "View";
     default:
       return assertNever(value);
   }
@@ -35,7 +35,7 @@ type TabPanelProps = {
   address: string;
 };
 
-function WriteContract({address}: {address: string}) {
+function RunContract({address}: {address: string}) {
   return <Contract address={address} isRead={false} />;
 }
 

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -81,7 +81,9 @@ function ViewCode({address}: {address: string}): JSX.Element {
 
   const selectedModuleName = useParams().selectedModuleName ?? "";
   if (!selectedModuleName && modules.length > 0) {
-    navigate(`/account/${address}/modules/${modules[0].name}`, {replace: true});
+    navigate(`/account/${address}/modules/code/${modules[0].name}`, {
+      replace: true,
+    });
   }
 
   if (modules.length === 0) {
@@ -93,7 +95,7 @@ function ViewCode({address}: {address: string}): JSX.Element {
   );
 
   function getLinkToModule(moduleName: string) {
-    return `/account/${address}/modules/${moduleName}`;
+    return `/account/${address}/modules/code/${moduleName}`;
   }
 
   function navigateToModule(moduleName: string) {

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -57,7 +57,7 @@ export default function TransactionFunction({
   ) {
     return (
       <Link
-        to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+        to={`/account/${address}/modules/code/${moduleName}?entry_function=${functionName}`}
         underline="none"
       >
         <CoinTransferCodeLine
@@ -76,7 +76,7 @@ export default function TransactionFunction({
 
   return (
     <Link
-      to={`/account/${address}/modules/${moduleName}?entry_function=${functionName}`}
+      to={`/account/${address}/modules/code/${moduleName}?entry_function=${functionName}`}
       underline="none"
     >
       <CodeLineBox clickable sx={[...(Array.isArray(sx) ? sx : [sx])]}>


### PR DESCRIPTION
as we're about to add read and write, the current routes for /modules doesn't work.

current:
/account/:account/modules/:module

proposed:
/account/:account/modules/:action/:module (action is one of "code", "read" and "write")

see https://deploy-preview-483--aptos-explorer.netlify.app/account/0x1/modules/code/account?network=mainnet for an example
