### PR TITLE
Router for Run and View contract

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -34,6 +34,10 @@ export default function ExplorerRoutes() {
             path=":address/modules/:modulesTab/:selectedModuleName"
             element={<AccountPage />}
           />
+          <Route
+            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            element={<AccountPage />}
+          />
           <Route path=":address/:tab" element={<AccountPage />} />
           <Route path=":address" element={<AccountPage />} />
         </Route>

--- a/src/pages/Account/Components/SidebarItem.tsx
+++ b/src/pages/Account/Components/SidebarItem.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {Box, useTheme} from "@mui/material";
+import {grey} from "../../../themes/colors/aptosColorPalette";
+import {Link} from "../../../routing";
+
+interface SidebarItemProps {
+  linkTo: string;
+  selected: boolean;
+  name: string;
+}
+
+// The item on the sidebar
+export default function SidebarItem({
+  selected,
+  name,
+  linkTo,
+}: SidebarItemProps) {
+  const theme = useTheme();
+
+  return (
+    <Link to={linkTo} underline="none" color={"inherit"}>
+      <Box
+        sx={{
+          fontSize: 12,
+          fontWeight: selected ? 600 : 400,
+          padding: "8px",
+          borderRadius: 1,
+          bgcolor: !selected
+            ? "transparent"
+            : theme.palette.mode === "dark"
+            ? grey[500]
+            : grey[200],
+          ...(theme.palette.mode === "dark" && !selected && {color: grey[400]}),
+          ":hover": {
+            cursor: "pointer",
+            ...(theme.palette.mode === "dark" &&
+              !selected && {color: grey[200]}),
+          },
+        }}
+      >
+        {name}
+      </Box>
+    </Link>
+  );
+}

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -3,6 +3,7 @@ import {ReactNode, useEffect, useState} from "react";
 import Error from "../../Error";
 import {useGetAccountModules} from "../../../../api/hooks/useGetAccountModules";
 import EmptyTabContent from "../../../../components/IndividualPageContent/EmptyTabContent";
+import SidebarItem from "../../Components/SidebarItem";
 import {WalletConnector} from "@aptos-labs/wallet-adapter-mui-design";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {
@@ -17,6 +18,7 @@ import {
 } from "@mui/material";
 import React from "react";
 import {useForm, SubmitHandler, Controller} from "react-hook-form";
+import {useParams} from "react-router-dom";
 import useSubmitTransaction from "../../../../api/hooks/useSubmitTransaction";
 import {useGlobalState} from "../../../../global-config/GlobalConfig";
 import {view} from "../../../../api";
@@ -31,13 +33,13 @@ interface ContractSidebarProps {
   selectedModuleName: string | undefined;
   selectedFnName: string | undefined;
   moduleAndFnsGroup: Record<string, Types.MoveFunction[]>;
-  handleClick: (moduleName: string, fnName: string) => void;
+  getLinkToFn(moduleName: string, fnName: string): string;
 }
 
 function Contract({address, isRead}: {address: string; isRead: boolean}) {
   const {data, isLoading, error} = useGetAccountModules(address);
-  const [selectedModuleName, setSelectedModuleName] = useState<string>();
-  const [selectedFnName, setSelectedFnName] = useState<string>();
+  const selectedModuleName = useParams().selectedModuleName ?? "";
+  const selectedFnName = useParams().selectedFnName ?? "";
 
   if (isLoading) {
     return null;
@@ -80,6 +82,15 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
       )
     : undefined;
 
+  function getLinkToFn(moduleName: string, fnName: string) {
+    // This string implicitly depends on the fact that
+    // the `isRead` value is determined by the
+    // pathname `view` and `run`.
+    return `/account/${address}/modules/${
+      isRead ? "view" : "run"
+    }/${moduleName}/${fnName}`;
+  }
+
   return (
     <Grid container spacing={2}>
       <Grid item md={3} xs={12}>
@@ -87,10 +98,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
           selectedModuleName={selectedModuleName}
           selectedFnName={selectedFnName}
           moduleAndFnsGroup={moduleAndFnsGroup}
-          handleClick={(moduleName: string, fnName: string) => {
-            setSelectedModuleName(moduleName);
-            setSelectedFnName(fnName);
-          }}
+          getLinkToFn={getLinkToFn}
         />
       </Grid>
       <Grid item md={9} xs={12}>
@@ -110,7 +118,7 @@ function ContractSidebar({
   selectedModuleName,
   selectedFnName,
   moduleAndFnsGroup,
-  handleClick,
+  getLinkToFn,
 }: ContractSidebarProps) {
   const theme = useTheme();
   return (
@@ -140,32 +148,12 @@ function ContractSidebar({
                   moduleName === selectedModuleName &&
                   fn.name === selectedFnName;
                 return (
-                  <Box
+                  <SidebarItem
                     key={fn.name}
-                    onClick={() => handleClick(moduleName, fn.name)}
-                    fontSize={12}
-                    fontWeight={selected ? 600 : 400}
-                    marginBottom={"8px"}
-                    padding={1}
-                    borderRadius={1}
-                    sx={{
-                      ...(theme.palette.mode === "dark" && !selected
-                        ? {
-                            color: grey[400],
-                            ":hover": {
-                              color: grey[200],
-                            },
-                          }
-                        : {}),
-                      bgcolor: !selected
-                        ? "transparent"
-                        : theme.palette.mode === "dark"
-                        ? grey[500]
-                        : grey[200],
-                    }}
-                  >
-                    {fn.name}
-                  </Box>
+                    linkTo={getLinkToFn(moduleName, fn.name)}
+                    selected={selected}
+                    name={fn.name}
+                  />
                 );
               })}
               <Divider />

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -51,13 +51,16 @@ function TabPanel({value, address}: TabPanelProps): JSX.Element {
 function ModulesTabs({address}: {address: string}): JSX.Element {
   const theme = useTheme();
   const tabValues = Object.keys(TabComponents) as TabValue[];
-  const {selectedModuleName, modulesTab} = useParams();
+  const {selectedFnName, selectedModuleName, modulesTab} = useParams();
   const navigate = useNavigate();
   const value =
     modulesTab === undefined ? tabValues[0] : (modulesTab as TabValue);
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    navigate(`/account/${address}/modules/${newValue}/${selectedModuleName}`);
+    navigate(
+      `/account/${address}/modules/${newValue}/${selectedModuleName}` +
+        (selectedFnName ? `/${selectedFnName}` : ``),
+    );
   };
 
   return (

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -25,6 +25,7 @@ import {useGetAccountModule} from "../../../../api/hooks/useGetAccountModule";
 import {useGetAccountResource} from "../../../../api/hooks/useGetAccountResource";
 import EmptyTabContent from "../../../../components/IndividualPageContent/EmptyTabContent";
 import StyledTooltip from "../../../../components/StyledTooltip";
+import SidebarItem from "../../Components/SidebarItem";
 import {
   codeBlockColor,
   codeBlockColorRgbDark,
@@ -35,7 +36,7 @@ import {getBytecodeSizeInKB, transformCode} from "../../../../utils";
 
 import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import {useParams, useSearchParams} from "react-router-dom";
-import {Link, useNavigate} from "../../../../routing";
+import {useNavigate} from "../../../../routing";
 
 type PackageMetadata = {
   name: string;
@@ -50,12 +51,6 @@ interface ModuleSidebarProps {
   selectedModuleName: string;
   getLinkToModule(moduleName: string): string;
   navigateToModule(moduleName: string): void;
-}
-
-interface ModuleNameOptionProps {
-  linkTo: string;
-  selected: boolean;
-  name: string;
 }
 
 interface ModuleContentProps {
@@ -158,7 +153,7 @@ function ModuleSidebar({
             {isWideScreen ? (
               <Box>
                 {pkg.modules.map((module) => (
-                  <ModuleNameOption
+                  <SidebarItem
                     key={module.name}
                     linkTo={getLinkToModule(module.name)}
                     selected={module.name === selectedModuleName}
@@ -199,37 +194,6 @@ function ModuleSidebar({
         );
       })}
     </Box>
-  );
-}
-
-function ModuleNameOption({selected, name, linkTo}: ModuleNameOptionProps) {
-  const theme = useTheme();
-
-  return (
-    <Link to={linkTo} underline="none" color={"inherit"}>
-      <Box
-        key={name}
-        sx={{
-          fontSize: 12,
-          fontWeight: selected ? 600 : 400,
-          padding: "8px",
-          borderRadius: 1,
-          bgcolor: !selected
-            ? "transparent"
-            : theme.palette.mode === "dark"
-            ? grey[500]
-            : grey[200],
-          ...(theme.palette.mode === "dark" && !selected && {color: grey[400]}),
-          ":hover": {
-            cursor: "pointer",
-            ...(theme.palette.mode === "dark" &&
-              !selected && {color: grey[200]}),
-          },
-        }}
-      >
-        {name}
-      </Box>
-    </Link>
   );
 }
 


### PR DESCRIPTION
#501 

Before this change, only the "code" tab on the modules page align the URL with the tab state. 
For example: `http://localhost:3000/account/0x1/modules/code/acl?network=devnet&feature=dev`

After this change, the "run" and "view" tabs will also align the URL with the tab state. But for the "run" and "view" tabs, the sidebar item is a function in a module, instead of the module itself.
So the link would be: `http://localhost:3000/account/0x1/modules/view/${moduleName}/${functionName}?network=devnet&feature=dev`

And when switch between tabs, we will keep the URL state. For example:
-  If the user is looking at the `balance` function in the `coin` module, which is `http://localhost:3000/account/0x1/modules/view/coin/balance?network=devnet&feature=dev`.
-  Then the user switches to the `code` tab. The code of the `coin` module will directly be opened.
- Then the user switches back to the `view` tab. He can still see the `balance` function in the `coin` module.