### PR TITLE
[Contract] Add contract execution result

### DIFF
--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,4 +1,4 @@
-import {Types} from "aptos";
+import {FailedTransactionError, Types} from "aptos";
 import {useEffect, useState} from "react";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -12,6 +12,8 @@ export type TransactionResponse =
 export type TransactionResponseOnSubmission = {
   transactionSubmitted: true;
   transactionHash: string;
+  success: boolean; // indicates if the transaction submitted but failed or not
+  errorMessage?: string; // error message if the transaction failed
 };
 
 export type TransactionResponseOnError = {
@@ -52,19 +54,33 @@ const useSubmitTransaction = () => {
         transactionSubmitted: false,
         message: "Unknown Error",
       };
+
+      let response;
       try {
-        const response = await signAndSubmitTransaction(transactionPayload);
-        // transaction succeed
+        response = await signAndSubmitTransaction(transactionPayload);
+
+        // transaction submit succeed
         if ("hash" in response) {
-          await state.aptos_client.waitForTransaction(response["hash"]);
+          await state.aptos_client.waitForTransaction(response["hash"], {
+            checkSuccess: true,
+          });
           return {
             transactionSubmitted: true,
             transactionHash: response["hash"],
+            success: true,
           };
         }
         // transaction failed
         return {...responseOnError, message: response.message};
       } catch (error: any) {
+        if (error instanceof FailedTransactionError) {
+          return {
+            transactionSubmitted: true,
+            transactionHash: response ? response.hash : "",
+            errorMessage: error.message,
+            success: false,
+          };
+        }
         responseOnError.message = error;
       }
       return responseOnError;

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -13,7 +13,7 @@ export type TransactionResponseOnSubmission = {
   transactionSubmitted: true;
   transactionHash: string;
   success: boolean; // indicates if the transaction submitted but failed or not
-  errorMessage?: string; // error message if the transaction failed
+  message?: string; // error message if the transaction failed
 };
 
 export type TransactionResponseOnError = {
@@ -77,7 +77,7 @@ const useSubmitTransaction = () => {
           return {
             transactionSubmitted: true,
             transactionHash: response ? response.hash : "",
-            errorMessage: error.message,
+            message: error.message,
             success: false,
           };
         }

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -169,7 +169,7 @@ export function Code({bytecode}: {bytecode: string}) {
                 borderRadius: "0.5rem",
               }}
             >
-              <ContentCopy style={{height: "1.25rem", width: "1.25rem"}} />{" "}
+              <ContentCopy style={{height: "1.25rem", width: "1.25rem"}} />
               <Typography
                 marginLeft={1}
                 sx={{

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -72,7 +72,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
             marginBottom={"16px"}
             color={theme.palette.mode === "dark" ? grey[300] : grey[600]}
           >
-            Unfortunately, we are not supporting run method on mobile at the
+            Unfortunately, we are not supporting <b>Run</b> entry functions on mobile at the
             moment.
           </Typography>
 

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -315,11 +315,7 @@ function RunContractForm({
                     ? "success"
                     : "error"
                 }
-                sx={{
-                  overflowX: "auto",
-                  marginTop: "16px",
-                  whiteSpace: "nowrap",
-                }}
+                sx={{marginTop: "16px"}}
               >
                 {JSON.stringify(transactionResponse, null, 2)}
               </Alert>
@@ -389,11 +385,7 @@ function ReadContractForm({
           {!inProcess && (errMsg || result) && (
             <Alert
               severity={errMsg ? "error" : "success"}
-              sx={{
-                overflowX: "auto",
-                marginTop: "16px",
-                whiteSpace: "nowrap",
-              }}
+              sx={{marginTop: "16px"}}
             >
               {errMsg ?? JSON.stringify(result, null, 2)}
             </Alert>

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -72,7 +72,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
             marginBottom={"16px"}
             color={theme.palette.mode === "dark" ? grey[300] : grey[600]}
           >
-            Unfortunately, we are not supporting write method on mobile at the
+            Unfortunately, we are not supporting run method on mobile at the
             moment.
           </Typography>
 
@@ -311,7 +311,7 @@ function RunContractForm({
               {transactionInProcess ? (
                 <CircularProgress size={30}></CircularProgress>
               ) : (
-                "Write"
+                "Run"
               )}
             </Button>
             {!transactionInProcess && transactionResponse && (
@@ -375,7 +375,7 @@ function RunContractForm({
           <Box display="flex" flexDirection="row" alignItems="center">
             <WalletConnector networkSupport={state.network_name} />
             <Typography ml={2} fontSize={10}>
-              To write you need to connect wallet first
+              To run you need to connect wallet first
             </Typography>
           </Box>
         )
@@ -452,7 +452,7 @@ function ReadContractForm({
             {inProcess ? (
               <CircularProgress size={30}></CircularProgress>
             ) : (
-              "Query"
+              "View"
             )}
           </Button>
 

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -353,8 +353,9 @@ function RunContractForm({
                       <Button
                         variant="outlined"
                         onClick={() =>
-                          navigate(
+                          window.open(
                             `/txn/${transactionResponse.transactionHash}`,
+                            "_blank",
                           )
                         }
                         sx={{

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -23,7 +23,9 @@ import {
 import React from "react";
 import {useForm, SubmitHandler, Controller} from "react-hook-form";
 import {useParams} from "react-router-dom";
-import useSubmitTransaction from "../../../../api/hooks/useSubmitTransaction";
+import useSubmitTransaction, {
+  TransactionResponseOnSubmission,
+} from "../../../../api/hooks/useSubmitTransaction";
 import {useGlobalState} from "../../../../global-config/GlobalConfig";
 import {view} from "../../../../api";
 import {grey} from "../../../../themes/colors/aptosColorPalette";
@@ -33,6 +35,8 @@ import {
   PackageMetadata,
   useGetAccountPackages,
 } from "../../../../api/hooks/useGetAccountResource";
+import {ContentCopy} from "@mui/icons-material";
+import StyledTooltip from "../../../../components/StyledTooltip";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -165,7 +169,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
 
           {module && fn && selectedModule && (
             <>
-              <Divider sx={{margin: "16px 0"}} />
+              <Divider sx={{margin: "24px 0"}} />
               <Code bytecode={selectedModule?.source} />
             </>
           )}
@@ -276,6 +280,7 @@ function RunContractForm({
 }) {
   const [state] = useGlobalState();
   const {connected} = useWallet();
+  const navigate = useNavigate();
   const {submitTransaction, transactionResponse, transactionInProcess} =
     useSubmitTransaction();
 
@@ -289,6 +294,9 @@ function RunContractForm({
     await submitTransaction(payload);
   };
 
+  const isFunctionSuccess = !!(
+    transactionResponse?.transactionSubmitted && transactionResponse?.success
+  );
   return (
     <ContractForm
       fn={fn}
@@ -309,16 +317,60 @@ function RunContractForm({
               )}
             </Button>
             {!transactionInProcess && transactionResponse && (
-              <Alert
-                severity={
-                  transactionResponse?.transactionSubmitted
-                    ? "success"
-                    : "error"
-                }
-                sx={{marginTop: "16px"}}
-              >
-                {JSON.stringify(transactionResponse, null, 2)}
-              </Alert>
+              <ExecutionResult success={isFunctionSuccess}>
+                <Stack
+                  direction="row"
+                  gap={2}
+                  pt={2}
+                  justifyContent="space-between"
+                >
+                  <Stack>
+                    {!isFunctionSuccess && (
+                      <>
+                        <Typography fontSize={12} fontWeight={600} mb={1}>
+                          Error:
+                        </Typography>
+                        <Typography fontSize={12} fontWeight={400}>
+                          {transactionResponse.message
+                            ? transactionResponse.message
+                            : "Unknown"}
+                        </Typography>
+                      </>
+                    )}
+                    {transactionResponse.transactionSubmitted &&
+                      transactionResponse.transactionHash && (
+                        <>
+                          <Typography fontSize={12} fontWeight={600} mb={1}>
+                            Transaction:
+                          </Typography>
+                          <Typography fontSize={12} fontWeight={400}>
+                            {transactionResponse.transactionHash}
+                          </Typography>
+                        </>
+                      )}
+                  </Stack>
+
+                  {transactionResponse.transactionSubmitted &&
+                    transactionResponse.transactionHash && (
+                      <Button
+                        variant="outlined"
+                        onClick={() =>
+                          navigate(
+                            `/txn/${transactionResponse.transactionHash}`,
+                          )
+                        }
+                        sx={{
+                          height: "2rem",
+                          minWidth: "unset",
+                          borderRadius: "0.5rem",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        View Transaction
+                      </Button>
+                    )}
+                </Stack>
+              </ExecutionResult>
             )}
           </Box>
         ) : (
@@ -334,6 +386,7 @@ function RunContractForm({
   );
 }
 
+const TOOLTIP_TIME = 2000; // 2s
 function ReadContractForm({
   module,
   fn,
@@ -345,6 +398,16 @@ function ReadContractForm({
   const [result, setResult] = useState<Types.MoveValue[]>();
   const [errMsg, setErrMsg] = useState<string>();
   const [inProcess, setInProcess] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
+
+  const resultString = JSON.stringify(result, null, 2);
+  async function copyValue() {
+    await navigator.clipboard.writeText(resultString);
+    setTooltipOpen(true);
+    setTimeout(() => {
+      setTooltipOpen(false);
+    }, TOOLTIP_TIME);
+  }
 
   const onSubmit: SubmitHandler<ContractFormType> = async (data) => {
     const viewRequest: Types.ViewRequest = {
@@ -358,7 +421,14 @@ function ReadContractForm({
       setResult(result);
       setErrMsg(undefined);
     } catch (e: any) {
-      setErrMsg(e.message ?? String(e));
+      let error = e.message ?? String(e);
+
+      const prefix = "Error:";
+      if (error.startsWith(prefix)) {
+        error = error.substring(prefix.length).trim();
+      }
+
+      setErrMsg(error);
       setResult(undefined);
     }
     setInProcess(false);
@@ -382,17 +452,89 @@ function ReadContractForm({
               "Query"
             )}
           </Button>
+
           {!inProcess && (errMsg || result) && (
-            <Alert
-              severity={errMsg ? "error" : "success"}
-              sx={{marginTop: "16px"}}
-            >
-              {errMsg ?? JSON.stringify(result, null, 2)}
-            </Alert>
+            <>
+              <Divider sx={{margin: "24px 0"}} />
+              <Stack
+                direction="row"
+                gap={2}
+                mt={2}
+                justifyContent="space-between"
+              >
+                <Stack>
+                  <Typography fontSize={12} fontWeight={400}>
+                    {errMsg
+                      ? "Error: " + errMsg
+                      : JSON.stringify(result, null, 2)}
+                  </Typography>
+                </Stack>
+
+                {!errMsg && (
+                  <StyledTooltip
+                    title="Value copied"
+                    placement="right"
+                    open={tooltipOpen}
+                    disableFocusListener
+                    disableHoverListener
+                    disableTouchListener
+                  >
+                    <Button
+                      sx={{
+                        height: "2rem",
+                        minWidth: "unset",
+                      }}
+                      onClick={copyValue}
+                    >
+                      <ContentCopy
+                        style={{height: "1.25rem", width: "1.25rem"}}
+                      />
+                      <Typography
+                        marginLeft={1}
+                        fontSize={12}
+                        sx={{
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        Copy value
+                      </Typography>
+                    </Button>
+                  </StyledTooltip>
+                )}
+              </Stack>
+            </>
           )}
         </Box>
       }
     />
+  );
+}
+
+function ExecutionResult({
+  success,
+  children,
+}: {
+  success: boolean;
+  children: React.ReactNode;
+}) {
+  const theme = useTheme();
+  return (
+    <Box
+      padding={3}
+      borderRadius={1}
+      bgcolor={theme.palette.mode === "dark" ? grey[700] : grey[200]}
+      mt={4}
+    >
+      <Alert
+        severity={success ? "success" : "error"}
+        sx={{width: "fit-content", padding: "0rem 1rem"}}
+      >
+        <Typography fontSize={12}>
+          {success ? "Function successfully executed" : "Function failed"}
+        </Typography>
+      </Alert>
+      <Box>{children}</Box>
+    </Box>
   );
 }
 
@@ -413,15 +555,10 @@ function ContractForm({
       args: [],
     },
   });
-  const theme = useTheme();
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Box
-        padding={3}
-        borderRadius={1}
-        bgcolor={theme.palette.mode === "dark" ? grey[800] : grey[100]}
-      >
+      <Box>
         <Stack spacing={4}>
           <Typography fontSize={14} fontWeight={600}>
             {fn.name}

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -23,9 +23,7 @@ import {
 import React from "react";
 import {useForm, SubmitHandler, Controller} from "react-hook-form";
 import {useParams} from "react-router-dom";
-import useSubmitTransaction, {
-  TransactionResponseOnSubmission,
-} from "../../../../api/hooks/useSubmitTransaction";
+import useSubmitTransaction from "../../../../api/hooks/useSubmitTransaction";
 import {useGlobalState} from "../../../../global-config/GlobalConfig";
 import {view} from "../../../../api";
 import {grey} from "../../../../themes/colors/aptosColorPalette";
@@ -321,7 +319,7 @@ function RunContractForm({
                 <Stack
                   direction="row"
                   gap={2}
-                  pt={2}
+                  pt={3}
                   justifyContent="space-between"
                 >
                   <Stack>

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -466,7 +466,13 @@ function ReadContractForm({
                   <Typography fontSize={12} fontWeight={400}>
                     {errMsg
                       ? "Error: " + errMsg
-                      : JSON.stringify(result, null, 2)}
+                      : result
+                          ?.map((r) =>
+                            typeof r === "string"
+                              ? r
+                              : JSON.stringify(r, null, 2),
+                          )
+                          .join("\n")}
                   </Typography>
                 </Stack>
 
@@ -486,9 +492,7 @@ function ReadContractForm({
                       }}
                       onClick={copyValue}
                     >
-                      <ContentCopy
-                        style={{height: "1.25rem", width: "1.25rem"}}
-                      />
+                      <ContentCopy style={{height: "1rem", width: "1.25rem"}} />
                       <Typography
                         marginLeft={1}
                         fontSize={12}

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -394,6 +394,8 @@ function ReadContractForm({
 }) {
   const [state] = useGlobalState();
   const [result, setResult] = useState<Types.MoveValue[]>();
+  const theme = useTheme();
+  const isWideScreen = useMediaQuery(theme.breakpoints.up("md"));
   const [errMsg, setErrMsg] = useState<string>();
   const [inProcess, setInProcess] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
@@ -458,13 +460,13 @@ function ReadContractForm({
             <>
               <Divider sx={{margin: "24px 0"}} />
               <Stack
-                direction="row"
+                direction={isWideScreen ? "row" : "column"}
                 gap={2}
                 mt={2}
                 justifyContent="space-between"
               >
                 <Stack>
-                  <Typography fontSize={12} fontWeight={400}>
+                  <Typography fontSize={12} fontWeight={400} ml={1}>
                     {errMsg ? "Error: " + errMsg : resultString}
                   </Typography>
                 </Stack>
@@ -482,6 +484,7 @@ function ReadContractForm({
                       sx={{
                         height: "2rem",
                         minWidth: "unset",
+                        width: "fit-content",
                       }}
                       onClick={copyValue}
                     >

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -400,7 +400,10 @@ function ReadContractForm({
   const [inProcess, setInProcess] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
 
-  const resultString = JSON.stringify(result, null, 2);
+  const resultString =
+    result
+      ?.map((r) => (typeof r === "string" ? r : JSON.stringify(r, null, 2)))
+      .join("\n") ?? "";
   async function copyValue() {
     await navigator.clipboard.writeText(resultString);
     setTooltipOpen(true);
@@ -464,15 +467,7 @@ function ReadContractForm({
               >
                 <Stack>
                   <Typography fontSize={12} fontWeight={400}>
-                    {errMsg
-                      ? "Error: " + errMsg
-                      : result
-                          ?.map((r) =>
-                            typeof r === "string"
-                              ? r
-                              : JSON.stringify(r, null, 2),
-                          )
-                          .join("\n")}
+                    {errMsg ? "Error: " + errMsg : resultString}
                   </Typography>
                 </Stack>
 


### PR DESCRIPTION
Run Success, click the "View transaction" can go to the transaction page.
<img width="1523" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/b117c3db-0149-4cc1-a89b-a5dd5ab83a6f">

Run Failed
<img width="1535" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/0f9f2da3-d87f-4ff6-9e2d-8c24ba33db44">

View Success
<img width="1530" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/95c0ffde-09c7-4e7a-8d56-f51b5c2d220f">

View Failed
<img width="1521" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/3f49302e-16b7-4201-9efd-ee5e79983e97">

Disable the button to avoid repeated execution, and show a spinner:
<img width="1436" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/fbed4cc1-0ec5-4224-9079-94d01ea42933">
