### PR TITLE
[Contract] Align the View result

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -489,7 +489,7 @@ function ReadContractForm({
                 justifyContent="space-between"
               >
                 <Stack>
-                  <Typography fontSize={12} fontWeight={400} ml={1}>
+                  <Typography fontSize={12} fontWeight={400} pl={1} pt="6px">
                     {errMsg ? "Error: " + errMsg : resultString}
                   </Typography>
                 </Stack>


### PR DESCRIPTION
Align the View result with the button at center
<img width="1042" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/74301e07-852d-40eb-a03c-a8284b620ff7">

Only align at the first line of the content, a multi-line screenshot:
<img width="1051" alt="image" src="https://github.com/aptos-labs/explorer/assets/19623228/22ae1c79-b4eb-4370-8188-9ab4e22733b1">
