### PR TITLE
[Contract] Fix bool & vector for contract execute

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -36,7 +36,10 @@ import {
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
 import {ContentCopy} from "@mui/icons-material";
 import StyledTooltip from "../../../../components/StyledTooltip";
-import {deserializeVector, encodeVectorForViewRequest} from "../../../../utils";
+import {
+  deserializeVector,
+  encodeInputArgsForViewRequest,
+} from "../../../../utils";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -469,12 +472,7 @@ function ReadContractForm({
         function: `${module.address}::${module.name}::${fn.name}`,
         type_arguments: data.typeArgs,
         arguments: data.args.map((arg, i) => {
-          if (fn.params[i].includes("vector")) {
-            // when it's a vector, we support both hex and javascript array format
-            return arg.trim().startsWith("0x")
-              ? arg.trim()
-              : encodeVectorForViewRequest(fn.params[i], arg);
-          } else return arg;
+          return encodeInputArgsForViewRequest(fn.params[i], arg);
         }),
       };
     } catch (e: any) {

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -302,7 +302,9 @@ function RunContractForm({
         if (fn.params[i + 1].includes("vector")) {
           // when it's a vector, we support both hex and javascript array format
           return arg.trim().startsWith("0x")
-            ? new HexString(arg).toUint8Array()
+            ? Array.from(new HexString(arg).toUint8Array()).map((x) =>
+                x.toString(),
+              )
             : deserializeVector(arg);
         } else return arg;
       }),

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -1,4 +1,4 @@
-import {Types} from "aptos";
+import {HexString, Types} from "aptos";
 import {ReactNode, useEffect, useMemo, useState} from "react";
 import Error from "../../Error";
 import {useGetAccountModules} from "../../../../api/hooks/useGetAccountModules";
@@ -302,7 +302,7 @@ function RunContractForm({
         if (fn.params[i + 1].includes("vector")) {
           // when it's a vector, we support both hex and javascript array format
           return arg.trim().startsWith("0x")
-            ? arg.trim()
+            ? new HexString(arg).toUint8Array()
             : deserializeVector(arg);
         } else return arg;
       }),

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -299,9 +299,10 @@ function RunContractForm({
       type_arguments: data.typeArgs,
       arguments: data.args.map((arg, i) => {
         // use i+1 because the first argument is the signer
-        if (fn.params[i + 1].includes("vector")) {
-          // when it's a vector, we support both hex and javascript array format
-          return arg.trim().startsWith("0x")
+        const type = fn.params[i + 1];
+        if (type.includes("vector")) {
+          // when it's a vector<u8>, we support both hex and javascript array format
+          return type === "vector<u8>" && arg.trim().startsWith("0x")
             ? Array.from(new HexString(arg).toUint8Array()).map((x) =>
                 x.toString(),
               )

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -300,7 +300,10 @@ function RunContractForm({
       arguments: data.args.map((arg, i) => {
         // use i+1 because the first argument is the signer
         if (fn.params[i + 1].includes("vector")) {
-          return deserializeVector(arg);
+          // when it's a vector, we support both hex and javascript array format
+          return arg.trim().startsWith("0x")
+            ? arg.trim()
+            : deserializeVector(arg);
         } else return arg;
       }),
     };
@@ -464,7 +467,10 @@ function ReadContractForm({
         type_arguments: data.typeArgs,
         arguments: data.args.map((arg, i) => {
           if (fn.params[i].includes("vector")) {
-            return encodeVectorForViewRequest(fn.params[i], arg);
+            // when it's a vector, we support both hex and javascript array format
+            return arg.trim().startsWith("0x")
+              ? arg.trim()
+              : encodeVectorForViewRequest(fn.params[i], arg);
           } else return arg;
         }),
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,7 +193,10 @@ function encodeVectorForViewRequest(type: string, value: string) {
         HexString.fromUint8Array(
           new Uint8Array(
             rawVector.map((v) => {
-              return ensureNumber(v.trim());
+              const result = ensureNumber(v.trim());
+              if (result < 0 || result > 255)
+                throw new Error(`Invalid u8 value: ${result}`);
+              return result;
             }),
           ),
         ) as any

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,20 @@ export function getPublicFunctionLineNumber(
   return 0;
 }
 
+export function encodeInputArgsForViewRequest(type: string, value: string) {
+  if (type.includes("vector")) {
+    // when it's a vector, we support both hex and javascript array format
+    return value.trim().startsWith("0x")
+      ? value.trim()
+      : encodeVectorForViewRequest(type, value);
+  } else if (type === "bool") {
+    if (value !== "true" && value !== "false")
+      throw new Error(`Invalid bool value: ${value}`);
+
+    return value === "true" ? true : false;
+  } else return value;
+}
+
 // Deserialize "[1,2,3]" or "1,2,3" to ["1", "2", "3"]
 export function deserializeVector(vectorString: string): string[] {
   let result = vectorString.trim();
@@ -170,7 +184,7 @@ export function deserializeVector(vectorString: string): string[] {
   return result.split(",");
 }
 
-export function encodeVectorForViewRequest(type: string, value: string) {
+function encodeVectorForViewRequest(type: string, value: string) {
   const rawVector = deserializeVector(value);
   const regex = /vector<([^]+)>/;
   const match = type.match(regex);


### PR DESCRIPTION
We can test on this account in testnet: 0x3d097bb505c9e5d8a96e367f371168240025877f6be8d4a88eacaafb709fe5c9.

After this change, we support user input hex or array for `vector<u8>`.

Meanwhile, I figured out that the BCS serialization for `view` function is not necessary, so I removed that code.

`view` function can accept `vector<u8>` as hex. `submit` function can accept `vector<u8>` as an array of strings.

I haven't tested vector type other than `vector<u8>`. I will deploy some contracts to test to see if it's the same. When I figured it out, I will make a new PR to fix other types.