### PR TITLE
Updates wallet-adapter and react-number-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "@apollo/client": "^3.7.9",
     "@aptos-labs/aptos-names-connector": "^0.0.2",
-    "@aptos-labs/wallet-adapter-mui-design": "^0.3.1",
-    "@aptos-labs/wallet-adapter-react": "^1.0.4",
+    "@aptos-labs/wallet-adapter-mui-design": "^1.0.0",
+    "@aptos-labs/wallet-adapter-react": "^1.2.1",
     "@blocto/aptos-wallet-adapter-plugin": "^0.1.4",
     "@download/blockies": "^1.0.3",
     "@emotion/react": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ dependencies:
     version: 3.7.10(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
   '@aptos-labs/aptos-names-connector':
     specifier: ^0.0.2
-    version: 0.0.2(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-copy-to-clipboard@5.1.0)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.0.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-copy-to-clipboard@5.1.0)(react-dom@18.2.0)(react@18.2.0)
   '@aptos-labs/wallet-adapter-mui-design':
-    specifier: ^0.3.1
-    version: 0.3.2(@types/react@18.2.8)
+    specifier: ^1.0.0
+    version: 1.0.0(@types/react@18.2.12)
   '@aptos-labs/wallet-adapter-react':
-    specifier: ^1.0.4
-    version: 1.0.5
+    specifier: ^1.2.1
+    version: 1.2.1
   '@blocto/aptos-wallet-adapter-plugin':
     specifier: ^0.1.4
     version: 0.1.4(@solana/web3.js@1.75.0)
@@ -25,25 +25,25 @@ dependencies:
     version: 1.0.3
   '@emotion/react':
     specifier: latest
-    version: 11.11.0(@types/react@18.2.8)(react@18.2.0)
+    version: 11.11.1(@types/react@18.2.12)(react@18.2.0)
   '@emotion/styled':
     specifier: latest
-    version: 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
+    version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
   '@martianwallet/aptos-wallet-adapter':
     specifier: ^0.0.4
     version: 0.0.4
   '@mui/icons-material':
     specifier: ^5.11.11
-    version: 5.11.11(@mui/material@5.11.16)(@types/react@18.2.8)(react@18.2.0)
+    version: 5.11.11(@mui/material@5.11.16)(@types/react@18.2.12)(react@18.2.0)
   '@mui/material':
     specifier: ^5.11.13
-    version: 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+    version: 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
   '@mui/system':
     specifier: ^5.11.13
-    version: 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react@18.2.0)
+    version: 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react@18.2.0)
   '@mui/x-date-pickers':
     specifier: ^6.0.0
-    version: 6.0.0(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@mui/material@5.11.16)(@mui/system@5.11.16)(date-fns@2.29.3)(moment@2.29.4)(react-dom@18.2.0)(react@18.2.0)
+    version: 6.0.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.11.16)(@mui/system@5.11.16)(date-fns@2.29.3)(moment@2.29.4)(react-dom@18.2.0)(react@18.2.0)
   '@nightlylabs/aptos-wallet-adapter-plugin':
     specifier: ^0.2.12
     version: 0.2.12
@@ -79,10 +79,10 @@ dependencies:
     version: 4.14.191
   '@types/react':
     specifier: latest
-    version: 18.2.8
+    version: 18.2.12
   '@types/react-dom':
     specifier: latest
-    version: 18.2.4
+    version: 18.2.5
   '@types/react-simple-maps':
     specifier: ^3.0.0
     version: 3.0.0
@@ -160,7 +160,7 @@ dependencies:
     version: 9.4.3(react@18.2.0)
   react-json-view:
     specifier: ^1.21.3
-    version: 1.21.3(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+    version: 1.21.3(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
   react-loading-skeleton:
     specifier: ^3.1.1
     version: 3.2.0(react@18.2.0)
@@ -281,16 +281,16 @@ packages:
       zen-observable-ts: 1.2.5
     dev: false
 
-  /@aptos-labs/aptos-names-connector@0.0.2(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-copy-to-clipboard@5.1.0)(react-dom@18.2.0)(react@18.2.0):
+  /@aptos-labs/aptos-names-connector@0.0.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-copy-to-clipboard@5.1.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-x8mB2Cjiq2y5tXhcaEcKT2/dK2QEz1QdJBBQZ132/HQlkFmINSCxlwjdwAG6xr0/6Om7m1Cmpbv2R+3XvXw6JQ==}
     peerDependencies:
       react: ^18.2.0
       react-copy-to-clipboard: ^5.1.0
       react-dom: ^18.2.0
     dependencies:
-      '@mui/icons-material': 5.11.11(@mui/material@5.11.16)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/material': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/styles': 5.11.16(@types/react@18.2.8)(react@18.2.0)
+      '@mui/icons-material': 5.11.11(@mui/material@5.11.16)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/material': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/styles': 5.11.16(@types/react@18.2.12)(react@18.2.0)
       aptos: 1.8.3
       react: 18.2.0
       react-copy-to-clipboard: 5.1.0(react@18.2.0)
@@ -344,16 +344,27 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-mui-design@0.3.2(@types/react@18.2.8):
-    resolution: {integrity: sha512-hir3hk6ypA5oat3CXtO/iQQexV0+nb2KgBgiEct8WEhzJWOuVdeAUWpRHJ7GRsGB0OE0eeBY4noW2CzlpaAtjg==}
+  /@aptos-labs/wallet-adapter-core@2.3.1:
+    resolution: {integrity: sha512-tK0+KpMG+4M8w7mBLVMcwavVR1TYpC9bnrB+U6FGNy21HrPkCPRmyjfvEyq8fBoxLuFt9fqWthwvMutZvKRegA==}
     dependencies:
-      '@aptos-labs/wallet-adapter-react': 1.0.5
-      '@babel/core': 7.21.3
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/icons-material': 5.11.11(@mui/material@5.11.16)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/material': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
-      aptos: 1.8.3
+      aptos: 1.9.1
+      buffer: 6.0.3
+      eventemitter3: 4.0.7
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@aptos-labs/wallet-adapter-mui-design@1.0.0(@types/react@18.2.12):
+    resolution: {integrity: sha512-qGD2PjRQN4IG6Xr9ynfvisqIo/waxTHPDIWTiPZvTLmGU+osOBLzoUGoCNTepPPFWp0Hl0GYc/nMgTCEYMR21w==}
+    dependencies:
+      '@aptos-labs/wallet-adapter-react': 1.2.1
+      '@babel/core': 7.21.8
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/icons-material': 5.11.11(@mui/material@5.11.16)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/material': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      aptos: 1.9.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router-dom: 6.10.0(react-dom@18.2.0)(react@18.2.0)
@@ -363,11 +374,11 @@ packages:
       - supports-color
     dev: false
 
-  /@aptos-labs/wallet-adapter-react@1.0.5:
-    resolution: {integrity: sha512-9r+gaundBqlNyV3otn5aKSbtWHFOvFXIPZ/XpwvIY5wRIuPeuSDj6nyO7A4/sAkYbZEt0VIBKhGLVmC7M8M3ow==}
+  /@aptos-labs/wallet-adapter-react@1.2.1:
+    resolution: {integrity: sha512-K9F8a1qehGvDKd4M7fDdA+sWPuTYDuK/m5A2oFcqjoWOXRNuTQNWUTBgg7VOqXQxBRMY7FjbJSxOdrj/j3WJOw==}
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 2.1.0
-      aptos: 1.8.3
+      '@aptos-labs/wallet-adapter-core': 2.3.1
+      aptos: 1.9.1
       react: 18.2.0
     transitivePeerDependencies:
       - debug
@@ -379,38 +390,9 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
-  /@babel/compat-data@7.21.0:
-    resolution: {integrity: sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/compat-data@7.21.7:
     resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/core@7.21.3:
-    resolution: {integrity: sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.3
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.3
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/core@7.21.8:
     resolution: {integrity: sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==}
@@ -433,7 +415,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/generator@7.21.3:
     resolution: {integrity: sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==}
@@ -443,6 +424,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
@@ -452,20 +434,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
-
-  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.3):
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.21.3
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.5
-      lru-cache: 5.1.1
-      semver: 6.3.0
-    dev: false
 
   /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
@@ -479,16 +447,15 @@ packages:
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-environment-visitor@7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-environment-visitor@7.21.5:
     resolution: {integrity: sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
@@ -509,22 +476,6 @@ packages:
     dependencies:
       '@babel/types': 7.21.5
 
-  /@babel/helper-module-transforms@7.21.2:
-    resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-simple-access': 7.20.2
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
     engines: {node: '>=6.9.0'}
@@ -539,26 +490,17 @@ packages:
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-simple-access@7.20.2:
-    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.5
-    dev: false
-
   /@babel/helper-simple-access@7.21.5:
     resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.5
-    dev: true
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -578,17 +520,6 @@ packages:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helpers@7.21.0:
-    resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helpers@7.21.5:
     resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
     engines: {node: '>=6.9.0'}
@@ -598,7 +529,6 @@ packages:
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -802,6 +732,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
@@ -819,7 +750,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types@7.21.5:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
@@ -996,8 +926,8 @@ packages:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
 
-  /@emotion/react@11.11.0(@types/react@18.2.8)(react@18.2.0):
-    resolution: {integrity: sha512-ZSK3ZJsNkwfjT3JpDAWJZlrGD81Z3ytNDsxw1LKq1o+xkmO5pnWfr6gmCC8gHEFf3nSSX/09YrG67jybNPxSUw==}
+  /@emotion/react@11.11.1(@types/react@18.2.12)(react@18.2.0):
+    resolution: {integrity: sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==}
     peerDependencies:
       '@types/react': '*'
       react: '>=16.8.0'
@@ -1012,7 +942,7 @@ packages:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
     dev: false
@@ -1031,7 +961,7 @@ packages:
     resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
     dev: false
 
-  /@emotion/styled@11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0):
+  /@emotion/styled@11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
@@ -1044,11 +974,11 @@ packages:
       '@babel/runtime': 7.21.0
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.1
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
       '@emotion/serialize': 1.1.2
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       react: 18.2.0
     dev: false
 
@@ -1839,7 +1769,7 @@ packages:
       - debug
     dev: false
 
-  /@mui/base@5.0.0-alpha.124(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+  /@mui/base@5.0.0-alpha.124(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-I6M+FrjRCybQCr8I8JTu6L2MkUobSQFgNIpOJyDNKL5zq/73LvZIQXvsKumAzthVGvI1PYaarM9vGDrDYbumKA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1852,10 +1782,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@emotion/is-prop-valid': 1.2.1
-      '@mui/types': 7.2.3(@types/react@18.2.8)
+      '@mui/types': 7.2.3(@types/react@18.2.12)
       '@mui/utils': 5.11.13(react@18.2.0)
       '@popperjs/core': 2.11.7
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       clsx: 1.2.1
       prop-types: 15.8.1
       react: 18.2.0
@@ -1867,7 +1797,7 @@ packages:
     resolution: {integrity: sha512-GxRfZ/HquQ/1nUc9qQVGReP6oOMS8/3QjPJ+23a7TMrxl2wjlmXrMNn7tRa30vZcGcDgEG+J0aseefUN0AoawQ==}
     dev: false
 
-  /@mui/icons-material@5.11.11(@mui/material@5.11.16)(@types/react@18.2.8)(react@18.2.0):
+  /@mui/icons-material@5.11.11(@mui/material@5.11.16)(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-Eell3ADmQVE8HOpt/LZ3zIma8JSvPh3XgnhwZLT0k5HRqZcd6F/QDHc7xsWtgz09t+UEFvOYJXjtrwKmLdwwpw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1879,12 +1809,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@mui/material': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.8
+      '@mui/material': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.12
       react: 18.2.0
     dev: false
 
-  /@mui/material@5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+  /@mui/material@5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-++glQqbZ3rMzOWB77yOvqRG+k8+scYTUKVWZpWff+GWsf6L10g9L2wgRhhAS8bDLuxCbXZlPNbSZowXDDw6z6Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1902,14 +1832,14 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/base': 5.0.0-alpha.124(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/base': 5.0.0-alpha.124(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
       '@mui/core-downloads-tracker': 5.11.16
-      '@mui/system': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/types': 7.2.3(@types/react@18.2.8)
+      '@mui/system': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/types': 7.2.3(@types/react@18.2.12)
       '@mui/utils': 5.11.13(react@18.2.0)
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       '@types/react-transition-group': 4.4.5
       clsx: 1.2.1
       csstype: 3.1.2
@@ -1920,7 +1850,7 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@mui/private-theming@5.11.13(@types/react@18.2.8)(react@18.2.0):
+  /@mui/private-theming@5.11.13(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-PJnYNKzW5LIx3R+Zsp6WZVPs6w5sEKJ7mgLNnUXuYB1zo5aX71FVLtV7geyPXRcaN2tsoRNK7h444ED0t7cIjA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1932,12 +1862,12 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@mui/utils': 5.11.13(react@18.2.0)
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
 
-  /@mui/styled-engine@5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(react@18.2.0):
+  /@mui/styled-engine@5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0):
     resolution: {integrity: sha512-8dJRR/LqtGGaZN21p1vU9euwrKERlgtQIWyuzBKZ8/cuSlW5rIzlp46liP+Uh0+7d9NcHU0H4hBMoPt3ax64PA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1952,14 +1882,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
       csstype: 3.1.2
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
 
-  /@mui/styles@5.11.16(@types/react@18.2.8)(react@18.2.0):
+  /@mui/styles@5.11.16(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-KoJubDToD4jqslY4f2K7dzLQoEOWHWnh0qGp8ybFeQBAyffIcuBGEOYqe0YbsJKgU7/Qv+nTHtgvl/y6OS1w3w==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1971,10 +1901,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@emotion/hash': 0.9.1
-      '@mui/private-theming': 5.11.13(@types/react@18.2.8)(react@18.2.0)
-      '@mui/types': 7.2.3(@types/react@18.2.8)
+      '@mui/private-theming': 5.11.13(@types/react@18.2.12)(react@18.2.0)
+      '@mui/types': 7.2.3(@types/react@18.2.12)
       '@mui/utils': 5.11.13(react@18.2.0)
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       clsx: 1.2.1
       csstype: 3.1.2
       hoist-non-react-statics: 3.3.2
@@ -1990,7 +1920,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@mui/system@5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react@18.2.0):
+  /@mui/system@5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-JY7CNm7ik2Gr4kQpz1+C9N/f4ET3QjVBo/iaHcmlSOgjdxnOzFbv+vCdb1DMzBGew+UbqckppZpZwbgbrBE2Rw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2007,20 +1937,20 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/private-theming': 5.11.13(@types/react@18.2.8)(react@18.2.0)
-      '@mui/styled-engine': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/types': 7.2.3(@types/react@18.2.8)
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/private-theming': 5.11.13(@types/react@18.2.12)(react@18.2.0)
+      '@mui/styled-engine': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
+      '@mui/types': 7.2.3(@types/react@18.2.12)
       '@mui/utils': 5.11.13(react@18.2.0)
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       clsx: 1.2.1
       csstype: 3.1.2
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
 
-  /@mui/types@7.2.3(@types/react@18.2.8):
+  /@mui/types@7.2.3(@types/react@18.2.12):
     resolution: {integrity: sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==}
     peerDependencies:
       '@types/react': '*'
@@ -2028,7 +1958,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: false
 
   /@mui/utils@5.11.13(react@18.2.0):
@@ -2045,7 +1975,7 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /@mui/x-date-pickers@6.0.0(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@mui/material@5.11.16)(@mui/system@5.11.16)(date-fns@2.29.3)(moment@2.29.4)(react-dom@18.2.0)(react@18.2.0):
+  /@mui/x-date-pickers@6.0.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.11.16)(@mui/system@5.11.16)(date-fns@2.29.3)(moment@2.29.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-6kraEcal5oBM/14CyJteNYcr0BqVD3qy4fX83dQrruRf2B3j8evzCVPZiT7T+Qdrx3AvbUS2wQdGP+9BcHByhA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2091,10 +2021,10 @@ packages:
       '@date-io/jalaali': 2.16.1(moment@2.29.4)
       '@date-io/luxon': 2.16.1
       '@date-io/moment': 2.16.1(moment@2.29.4)
-      '@emotion/react': 11.11.0(@types/react@18.2.8)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.0)(@types/react@18.2.8)(react@18.2.0)
-      '@mui/material': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/system': 5.11.16(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.2.8)(react@18.2.0)
+      '@emotion/react': 11.11.1(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.12)(react@18.2.0)
+      '@mui/material': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/system': 5.11.16(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.12)(react@18.2.0)
       '@mui/utils': 5.11.13(react@18.2.0)
       '@types/react-transition-group': 4.4.5
       clsx: 1.2.1
@@ -2784,10 +2714,10 @@ packages:
     resolution: {integrity: sha512-5nwNZcVSsftqNj6kl/s48yKFL2VDQBPCPC1wkEeD430s9g/p80ysAYUOxCPBo7OU5OX7Ofo3KMrJzml5Jw8Now==}
     dev: true
 
-  /@types/react-dom@18.2.4:
-    resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
+  /@types/react-dom@18.2.5:
+    resolution: {integrity: sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==}
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: false
 
   /@types/react-gtm-module@2.0.1:
@@ -2797,7 +2727,7 @@ packages:
   /@types/react-is@17.0.3:
     resolution: {integrity: sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==}
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: false
 
   /@types/react-simple-maps@3.0.0:
@@ -2806,23 +2736,23 @@ packages:
       '@types/d3-geo': 2.0.4
       '@types/d3-zoom': 2.0.3
       '@types/geojson': 7946.0.10
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: false
 
   /@types/react-syntax-highlighter@15.5.6:
     resolution: {integrity: sha512-i7wFuLbIAFlabTeD2I1cLjEOrG/xdMa/rpx2zwzAoGHuXJDhSqp9BSfDlMHSh9JSuNfxHk9eEmMX6D55GiyjGg==}
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: true
 
   /@types/react-transition-group@4.4.5:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
     dev: false
 
-  /@types/react@18.2.8:
-    resolution: {integrity: sha512-lTyWUNrd8ntVkqycEEplasWy2OxNlShj3zqS0LuB1ENUGis5HodmhM7DtCoUGbxj3VW/WsGA0DUhpG6XrM7gPA==}
+  /@types/react@18.2.12:
+    resolution: {integrity: sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -5689,7 +5619,7 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
-  /react-json-view@1.21.3(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+  /react-json-view@1.21.3(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -5700,7 +5630,7 @@ packages:
       react-base16-styling: 0.6.0
       react-dom: 18.2.0(react@18.2.0)
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.4.0(@types/react@18.2.8)(react@18.2.0)
+      react-textarea-autosize: 8.4.0(@types/react@18.2.12)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - encoding
@@ -5811,7 +5741,7 @@ packages:
       refractor: 3.6.0
     dev: false
 
-  /react-textarea-autosize@8.4.0(@types/react@18.2.8)(react@18.2.0):
+  /react-textarea-autosize@8.4.0(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -5820,7 +5750,7 @@ packages:
       '@babel/runtime': 7.21.0
       react: 18.2.0
       use-composed-ref: 1.3.0(react@18.2.0)
-      use-latest: 1.2.1(@types/react@18.2.8)(react@18.2.0)
+      use-latest: 1.2.1(@types/react@18.2.12)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -6395,7 +6325,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.8)(react@18.2.0):
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -6404,11 +6334,11 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       react: 18.2.0
     dev: false
 
-  /use-latest@1.2.1(@types/react@18.2.8)(react@18.2.0):
+  /use-latest@1.2.1(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
     peerDependencies:
       '@types/react': '*'
@@ -6417,9 +6347,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.8
+      '@types/react': 18.2.12
       react: 18.2.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.8)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.12)(react@18.2.0)
     dev: false
 
   /use-sync-external-store@1.2.0(react@18.2.0):

--- a/src/components/IndividualPageContent/ContentValue/GasValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/GasValue.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import NumberFormat from "react-number-format";
+import {NumericFormat} from "react-number-format";
 
 type GasValueProps = {
   gas: string;
@@ -8,7 +8,7 @@ type GasValueProps = {
 export default function GasValue({gas}: GasValueProps) {
   return (
     <span>
-      <NumberFormat value={gas} displayType="text" thousandSeparator /> Gas
+      <NumericFormat value={gas} displayType="text" thousandSeparator /> Gas
       Units
     </span>
   );


### PR DESCRIPTION
# Description

The wallet adapter [updated to include deep linking support](https://github.com/aptos-labs/aptos-wallet-adapter/pull/149). This PR updates our version to use the new adapter, as well as fixes a lingering import issue with `react-number-format`. [Here is the upgrade guide](https://s-yadav.github.io/react-number-format/docs/migration/) for `react-number-format` for reference. 

# Test Plan
I smoke tested to make sure the tests in the previous PR work when including the new npm modules:


https://github.com/aptos-labs/explorer/assets/694324/c5718364-246c-4e61-89ce-6332b0f523ac

