### PR TITLE
[playground] add playground marketing banner gated with flag

### DIFF
--- a/src/pages/LandingPage/Components/PlaygroundBanner.tsx
+++ b/src/pages/LandingPage/Components/PlaygroundBanner.tsx
@@ -1,0 +1,64 @@
+import "@aptos-labs/aptos-names-connector/dist/index.css";
+import {Banner} from "../../../components/Banner";
+import {
+  Button,
+  Divider,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import {grey} from "../../../themes/colors/aptosColorPalette";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import {Statsig} from "statsig-react";
+
+export function PlaygroundBanner() {
+  const theme = useTheme();
+  const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
+
+  const text = "Explore more fun stuff at Web3 Playground!";
+
+  const learnMoreButton = (
+    <Button
+      href="https://aptos-playground.web.app"
+      variant="text"
+      target="_blan"
+      sx={{alignSelf: "flex-start", transform: `translateX(-0.5rem)`}}
+    >
+      <Typography>LEARN MORE</Typography>
+      <ArrowForwardIosIcon sx={{marginLeft: 2}} fontSize="small" />
+    </Button>
+  );
+
+  const divider = (
+    <Divider
+      orientation="vertical"
+      variant="middle"
+      flexItem
+      sx={{color: grey[200]}}
+    />
+  );
+
+  const action = isOnMobile ? null : (
+    <>
+      {learnMoreButton}
+      {divider}
+    </>
+  );
+  const children = isOnMobile ? (
+    <Stack direction="column">
+      {text}
+      {learnMoreButton}
+    </Stack>
+  ) : (
+    <>{text}</>
+  );
+
+  const visible = Statsig.checkGate("playground_banner");
+
+  return visible ? (
+    <Banner action={action} sx={{marginBottom: 2}}>
+      {children}
+    </Banner>
+  ) : null;
+}

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -1,9 +1,9 @@
-import React from "react";
 import Typography from "@mui/material/Typography";
 import HeaderSearch from "../layout/Search/Index";
 import Box from "@mui/material/Box";
 import NetworkInfo from "../Analytics/NetworkInfo/NetworkInfo";
 import UserTransactionsPreview from "./UserTransactionsPreview";
+import {PlaygroundBanner} from "./Components/PlaygroundBanner";
 
 export default function LandingPage() {
   return (
@@ -11,6 +11,7 @@ export default function LandingPage() {
       <Typography variant="h3" component="h3" marginBottom={4}>
         Aptos Explorer
       </Typography>
+      <PlaygroundBanner />
       <NetworkInfo isOnHomePage />
       <HeaderSearch />
       <UserTransactionsPreview />


### PR DESCRIPTION
<img width="1597" alt="Screenshot 2023-06-30 at 12 48 56 PM" src="https://github.com/aptos-labs/explorer/assets/121921928/0d392a57-d338-4488-8cf0-e95ce3b8ae4d">
<img width="512" alt="Screenshot 2023-06-30 at 12 48 51 PM" src="https://github.com/aptos-labs/explorer/assets/121921928/8bc9422f-85ed-4c05-b88c-65be7270b18f">
