### PR TITLE
Limits token owners

### DIFF
--- a/src/pages/Token/Tabs/OverviewTab.tsx
+++ b/src/pages/Token/Tabs/OverviewTab.tsx
@@ -12,6 +12,7 @@ const OWNER_QUERY = gql`
   query OwnersData($token_id: String, $property_version: numeric) {
     current_token_ownerships(
       where: {
+        amount: {_gt: 0}
         token_data_id_hash: {_eq: $token_id}
         property_version: {_eq: $property_version}
       }


### PR DESCRIPTION
# Context 
Nodereal noticed that their ANS name was showing previous owners and suggested a fix of limiting the query.

# Tests
**Before:**
![before](https://github.com/aptos-labs/explorer/assets/694324/ba5f3b9a-e184-4945-a845-a56297ffc2eb)

**After:**
![after](https://github.com/aptos-labs/explorer/assets/694324/f91d9c6a-08b0-483f-be2c-74cf776fbdce)
