### PR TITLE
Fix for showing dupe for account and objects

### DIFF
--- a/src/api/hooks/useGetSearchResults.ts
+++ b/src/api/hooks/useGetSearchResults.ts
@@ -16,6 +16,7 @@ import {
 } from "../../pages/utils";
 import {getAddressFromName} from "./useGetANS";
 import {sendToGTM} from "./useGoogleTagManager";
+import {objectCoreAddress} from "../../constants";
 
 export type SearchResult = {
   label: string;
@@ -90,11 +91,19 @@ export default function useGetSearchResults(input: string) {
           {address: searchText},
           state.network_value,
         )
-          .then((): SearchResult => {
-            return {
-              label: `Object ${searchText}`,
-              to: `/object/${searchText}`,
-            };
+          .then((resources): SearchResult | undefined => {
+            let hasObjectCore = false;
+            resources.forEach((resource) => {
+              if (resource.type === objectCoreAddress) {
+                hasObjectCore = true;
+              }
+            });
+            if (hasObjectCore) {
+              return {
+                label: `Object ${searchText}`,
+                to: `/object/${searchText}`,
+              };
+            }
           })
           .catch(() => {
             return null;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -80,3 +80,8 @@ export const WHILTELISTED_TESTNET_DELEGATION_NODES = import.meta.env
   .REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES
   ? import.meta.env.REACT_APP_WHILTELISTED_TESTNET_DELEGATION_NODES.split(",")
   : null;
+
+/**
+ * Core Address
+ */
+export const objectCoreAddress = "0x1::object::ObjectCore";


### PR DESCRIPTION
Whenever querying a account address we would show account and object in the search prefill.

This PR changes the logic so we only so the object result when the account has an object core resource

NOTE: The assumption that Account's can't have ObjectCore is incorrect. But this should fix the dupe results for most cases.



https://github.com/aptos-labs/explorer/assets/19931667/3bcdeead-5acd-422a-9e34-065d961ecb88



