### PR TITLE
Add warning for 100% commision

### DIFF
--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import {useContext, useEffect, useState} from "react";
 import TimestampValue from "../../components/IndividualPageContent/ContentValue/TimestampValue";
-import {grey} from "../../themes/colors/aptosColorPalette";
+import {grey, negativeColor} from "../../themes/colors/aptosColorPalette";
 import {getStakeOperationAPTRequirement} from "./utils";
 import StyledDialog from "../../components/StyledDialog";
 import StyledTooltip, {
@@ -39,6 +39,7 @@ import {useGlobalState} from "../../global-config/GlobalConfig";
 import {MINIMUM_APT_IN_POOL} from "./constants";
 import {ValidatorData} from "../../api/hooks/useGetValidators";
 import {useLogEventWithBasic} from "../Account/hooks/useLogEventWithBasic";
+import TooltipTypography from "../../components/TooltipTypography";
 
 type StakeOperationDialogProps = {
   handleDialogClose: () => void;
@@ -321,6 +322,18 @@ function StakeOperationDialogContent({
             )}
           </ContentBoxSpaceBetween>
         </Stack>
+      </DialogContent>
+      <DialogContent sx={{textAlign: "center"}}>
+        {commission === 100 ? (
+          <TooltipTypography
+            textAlign="center"
+            variant="body2"
+            color={negativeColor}
+          >
+            The commission rate for this pool is 100%, you will not receive
+            rewards.
+          </TooltipTypography>
+        ) : null}
       </DialogContent>
       <DialogActions>
         <StyledTooltip


### PR DESCRIPTION
Add extra warning when attempting to stake in a pool with 100% comission.

not 100% commision
<img width="728" alt="Screenshot 2023-08-23 at 1 59 54 PM" src="https://github.com/aptos-labs/explorer/assets/19931667/18e5500b-6aa5-4620-908d-f1813814b4c9">

100% commision
<img width="784" alt="Screenshot 2023-08-23 at 2 01 22 PM" src="https://github.com/aptos-labs/explorer/assets/19931667/379833a2-4f3c-4e89-9fc7-fd32adc8e830">
