### PR TITLE
Remove statsig waitforinit

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,7 +93,7 @@ ReactDOM.render(
         import.meta.env.REACT_APP_STATSIG_SDK_KEY ||
         "client-gQ2Zhz3hNYRf6CSVaczkQcZfK0yUBv5ln42yCDzTwbr"
       }
-      waitForInitialization={true}
+      waitForInitialization={false}
       options={{
         environment: {tier: import.meta.env.MODE},
       }}

--- a/src/pages/LandingPage/Components/PlaygroundBanner.tsx
+++ b/src/pages/LandingPage/Components/PlaygroundBanner.tsx
@@ -53,7 +53,8 @@ export function PlaygroundBanner() {
     <>{text}</>
   );
 
-  const visible = Statsig.checkGate("playground_banner");
+  // Currently we are hardcoding this to false because statsig waitforinit is causing heavy load times
+  const visible = false;
 
   return visible ? (
     <Banner action={action} sx={{marginBottom: 2}}>


### PR DESCRIPTION
This was causing significant loadtimes that were blocking the content from loading. Once playgrounds is live we can put this back in another way.