### PR TITLE
Fix for not waiting for initialization of statsig

### DIFF
--- a/src/pages/Account/hooks/useLogEventWithBasic.ts
+++ b/src/pages/Account/hooks/useLogEventWithBasic.ts
@@ -1,6 +1,7 @@
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {Statsig} from "statsig-react";
 import {useGlobalState} from "../../../global-config/GlobalConfig";
+import {getStableID} from "../../../utils";
 
 // Log event with basic info
 export const useLogEventWithBasic = () => {
@@ -13,7 +14,7 @@ export const useLogEventWithBasic = () => {
     extraMetadata?: Record<string, string> | null,
   ) => {
     const metadata = {
-      stable_id: Statsig.getStableID(),
+      stable_id: getStableID(),
       wallet_address: account?.address ?? "",
       network_type: state.network_name,
       ...extraMetadata,

--- a/src/pages/Validators/Index.tsx
+++ b/src/pages/Validators/Index.tsx
@@ -8,6 +8,7 @@ import PageHeader from "../layout/PageHeader";
 import {StakingBanner} from "./StakingBanner";
 import ValidatorsPageTabs from "./Tabs";
 import ValidatorsMap from "./ValidatorsMap";
+import {getStableID} from "../../utils";
 
 export default function ValidatorsPage() {
   const [state, _] = useGlobalState();
@@ -15,7 +16,7 @@ export default function ValidatorsPage() {
   const {config} = useConfig(STAKING_BANNER_CONFIG_NAME);
   const viewCountCap = config.getValue("view_count");
   // Get the user's stable ID
-  const stableID = Statsig.getStableID();
+  const stableID = getStableID();
 
   // Create a key for storing the view count and last visit timestamp in localStorage
   const viewCountKey = `${stableID}_view_count`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import {BCS, HexString, TxnBuilderTypes, Types} from "aptos";
 import pako from "pako";
+import {Statsig} from "statsig-react";
 /**
  * Helper function for exhaustiveness checks.
  *
@@ -265,4 +266,9 @@ function assertType(val: any, types: string[] | string, message?: string) {
         }`,
     );
   }
+}
+
+// We should not be using statsig for logging like this, we will transition to google analytics
+export function getStableID(): string {
+  return Statsig.initializeCalled() ? Statsig.getStableID() : "not_initialized";
 }


### PR DESCRIPTION
We will hopefully move off of statsig logging in the coming weeks, so I don't want to think too hard about a better solution