### PR TITLE
Move explorer to fungible assets query

### DIFF
--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -22,14 +22,14 @@ function CoinNameCell({coin}: CoinCellProps) {
         textOverflow: "ellipsis",
       }}
     >
-      {coin?.coin_info?.name}
+      {coin?.metadata?.name}
     </GeneralTableCell>
   );
 }
 
 function AmountCell({coin}: CoinCellProps) {
   const amount = coin?.amount;
-  const decimals = coin?.coin_info?.decimals;
+  const decimals = coin?.metadata?.decimals;
 
   if (!amount || !decimals) {
     return <GeneralTableCell>-</GeneralTableCell>;
@@ -40,7 +40,7 @@ function AmountCell({coin}: CoinCellProps) {
     <GeneralTableCell>
       <span>{formattedAmount}</span>
       <span style={{marginLeft: 8, color: grey[450]}}>
-        {coin?.coin_info?.symbol}
+        {coin?.metadata?.symbol}
       </span>
     </GeneralTableCell>
   );
@@ -49,7 +49,7 @@ function AmountCell({coin}: CoinCellProps) {
 function CoinTypeCell({coin}: CoinCellProps) {
   return (
     <GeneralTableCell sx={{width: 450}}>
-      <HashButton hash={coin?.coin_type} type={HashType.OTHERS} size="large" />
+      <HashButton hash={coin?.asset_type} type={HashType.OTHERS} size="large" />
     </GeneralTableCell>
   );
 }

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -6,14 +6,14 @@ import {CoinsTable} from "../Components/CoinsTable";
 
 const COINS_QUERY = gql`
   query CoinsData($owner_address: String, $limit: Int, $offset: Int) {
-    current_coin_balances(
+    current_fungible_asset_balances(
       where: {owner_address: {_eq: $owner_address}}
       limit: $limit
       offset: $offset
     ) {
       amount
-      coin_type
-      coin_info {
+      asset_type
+      metadata {
         name
         decimals
         symbol
@@ -44,7 +44,7 @@ export default function CoinsTab({address}: TokenTabsProps) {
   }
 
   // TODO: add graphql data typing
-  const coins = data?.current_coin_balances ?? [];
+  const coins = data?.current_fungible_asset_balances ?? [];
 
   if (coins.length === 0) {
     return <EmptyTabContent />;


### PR DESCRIPTION
Moving the coin balances query to the new fungible assets query, this will include coin v1 and fungible assets as seen in the account below.

http://localhost:3000/account/0x40b880d668a9d68d7d521bec03b92857363339053c28459fdfd8d3d905ff0379/coins?network=testnet

vs 

the live version missing the FA coin
https://explorer.aptoslabs.com/account/0x40b880d668a9d68d7d521bec03b92857363339053c28459fdfd8d3d905ff0379/coins?network=testnet