### PR TITLE
Normalize address's for transactions

### DIFF
--- a/src/api/hooks/useGetAccountAllTransactions.ts
+++ b/src/api/hooks/useGetAccountAllTransactions.ts
@@ -1,4 +1,5 @@
 import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+import {normalizeAddress} from "../../utils";
 
 const ACCOUNT_TRANSACTIONS_COUNT_QUERY = gql`
   query AccountTransactionsCount($address: String) {
@@ -18,7 +19,7 @@ export function useGetAccountAllTransactionCount(
 ): number | undefined {
   // whenever talking to the indexer, the address needs to fill in leading 0s
   // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+  const addr64Hash = normalizeAddress(address);
 
   const {loading, error, data} = useGraphqlQuery(
     ACCOUNT_TRANSACTIONS_COUNT_QUERY,
@@ -50,9 +51,7 @@ export function useGetAccountAllTransactionVersions(
   limit: number,
   offset?: number,
 ): number[] {
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+  const addr64Hash = normalizeAddress(address);
 
   const {loading, error, data} = useGraphqlQuery(ACCOUNT_TRANSACTIONS_QUERY, {
     variables: {address: addr64Hash, limit: limit, offset: offset},

--- a/src/api/hooks/useGetAccountTokens.ts
+++ b/src/api/hooks/useGetAccountTokens.ts
@@ -5,12 +5,11 @@ import {
 } from "aptos";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {useQuery} from "@tanstack/react-query";
+import {normalizeAddress} from "../../utils";
 
 export function useGetAccountTokensCount(address: string) {
   const [state] = useGlobalState();
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+  const addr64Hash = normalizeAddress(address);
   return useQuery(
     ["account_tokens_count", {addr64Hash}, state.network_value],
     async () => {
@@ -30,9 +29,7 @@ export function useGetAccountTokens(
   offset?: number,
 ) {
   const [state] = useGlobalState();
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+  const addr64Hash = normalizeAddress(address);
   return useQuery(
     ["account_tokens", {addr64Hash, limit, offset}, state.network_value],
     async () => {

--- a/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
+++ b/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
@@ -1,5 +1,6 @@
 import {ApolloError, gql, useQuery as useGraphqlQuery} from "@apollo/client";
 import {Types} from "aptos";
+import {normalizeAddress} from "../../utils";
 
 export interface DelegatedStakingActivity {
   amount: number;
@@ -40,11 +41,8 @@ export function useGetDelegatedStakeOperationActivities(
   loading: boolean;
   error: ApolloError | undefined;
 } {
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const delegatorAddress64Hash =
-    "0x" + delegatorAddress.substring(2).padStart(64, "0");
-  const poolAddress64Hash = "0x" + poolAddress.substring(2).padStart(64, "0");
+  const delegatorAddress64Hash = normalizeAddress(delegatorAddress);
+  const poolAddress64Hash = normalizeAddress(poolAddress);
 
   const {loading, error, data} = useGraphqlQuery(
     DELEGATED_STAKING_ACTIVITY_QUERY,

--- a/src/api/hooks/useGetNumberOfDelegators.ts
+++ b/src/api/hooks/useGetNumberOfDelegators.ts
@@ -1,5 +1,6 @@
 import {Types} from "aptos";
 import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+import {normalizeAddress} from "../../utils";
 
 const NUMBER_OF_DELEGATORS_QUERY = gql`
   query numberOfDelegatorsQuery($poolAddress: String) {
@@ -16,9 +17,7 @@ const NUMBER_OF_DELEGATORS_QUERY = gql`
 `;
 
 export function useGetNumberOfDelegators(poolAddress: Types.Address) {
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const poolAddress64Hash = "0x" + poolAddress.substring(2).padStart(64, "0");
+  const poolAddress64Hash = normalizeAddress(poolAddress);
 
   const {loading, error, data} = useGraphqlQuery(NUMBER_OF_DELEGATORS_QUERY, {
     variables: {

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -3,6 +3,7 @@ import {gql, useQuery} from "@apollo/client";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {Types} from "aptos";
 import {CoinsTable} from "../Components/CoinsTable";
+import {normalizeAddress} from "../../../utils";
 
 const COINS_QUERY = gql`
   query CoinsData($owner_address: String, $limit: Int, $offset: Int) {
@@ -28,9 +29,7 @@ type TokenTabsProps = {
 };
 
 export default function CoinsTab({address}: TokenTabsProps) {
-  // whenever talking to the indexer, the address needs to fill in leading 0s
-  // for example: 0x123 => 0x000...000123  (61 0s before 123)
-  const addr64Hash = "0x" + address.substring(2).padStart(64, "0");
+  const addr64Hash = normalizeAddress(address);
 
   const {loading, error, data} = useQuery(COINS_QUERY, {
     variables: {

--- a/src/pages/Transaction/utils.tsx
+++ b/src/pages/Transaction/utils.tsx
@@ -1,4 +1,5 @@
 import {Types} from "aptos";
+import {normalizeAddress} from "../../utils";
 
 export type TransactionCounterparty = {
   address: string;
@@ -105,7 +106,7 @@ function getBalanceMap(transaction: Types.Transaction) {
       },
       event: Types.Event,
     ) => {
-      const addr = event.guid.account_address;
+      const addr = normalizeAddress(event.guid.account_address);
 
       if (
         event.type === "0x1::coin::DepositEvent" ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -272,3 +272,9 @@ function assertType(val: any, types: string[] | string, message?: string) {
 export function getStableID(): string {
   return Statsig.initializeCalled() ? Statsig.getStableID() : "not_initialized";
 }
+
+// address' coming back from the node trim leading zeroes
+// for example: 0x123 => 0x000...000123  (61 0s before 123)
+export function normalizeAddress(address: string): string {
+  return "0x" + address.substring(2).padStart(64, "0");
+}


### PR DESCRIPTION
See the amounts shown for this bad address

http://localhost:3000/account/0x0628e72def46bc247908f0b06367bfbf744a50328e429a97632941035ef50a63/transactions?network=mainnet

Future Work:
We can do this better to normalize coming from the node, but I didn't want to try and figure that out today without more testing, so this is a bandaid solution with a little bit of cleanup