### PR TITLE
[Module] Allow Run contract to use empty arrays

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,6 +185,10 @@ export function deserializeVector(vectorString: string): string[] {
   if (result[0] === "[" && result[result.length - 1] === "]") {
     result = result.slice(1, -1);
   }
+  // There's a tradeoff here between empty string, and empty array.  We're going with empty array.
+  if (result.length == 0) {
+    return [];
+  }
   return result.split(",");
 }
 


### PR DESCRIPTION
Inputting into a vector: `[]` will now provide an empty vector instead of the vector `[""]`