### PR TITLE
Add decimals to axis for large numbers

### DIFF
--- a/src/pages/Analytics/Charts/MonthlyActiveUserChart.tsx
+++ b/src/pages/Analytics/Charts/MonthlyActiveUserChart.tsx
@@ -28,7 +28,7 @@ export default function MonthlyActiveUserChart({
         label="Monthly Active Accounts"
         tooltip="Daily count of distinct addresses with signed transactions over the last 28 days."
       />
-      <LineChart labels={labels} dataset={dataset} />
+      <LineChart labels={labels} dataset={dataset} decimals={1} />
     </CardOutline>
   );
 }

--- a/src/pages/Analytics/Components/LineChart.tsx
+++ b/src/pages/Analytics/Components/LineChart.tsx
@@ -31,6 +31,7 @@ type LineChartProps = {
   dataset: number[];
   fill?: boolean;
   tooltipsLabelFunc?: (context: any) => string;
+  decimals?: number;
 };
 
 export default function LineChart({
@@ -38,6 +39,7 @@ export default function LineChart({
   dataset,
   fill,
   tooltipsLabelFunc,
+  decimals,
 }: LineChartProps) {
   const options = {
     responsive: true,
@@ -72,7 +74,7 @@ export default function LineChart({
       },
       y: {
         ticks: {
-          callback: (value: any) => numberFormatter(value, 0),
+          callback: (value: any) => numberFormatter(value, decimals ?? 0),
           autoSkip: true,
           maxTicksLimit: 3,
         },


### PR DESCRIPTION
## Summary
Having 0 decimals on a chart with 1M made it impossible to understand the axis. So we need to add a decimals place.

## Test Plan
<img width="511" alt="Screenshot 2023-09-19 at 7 24 00 AM" src="https://github.com/aptos-labs/explorer/assets/19931667/71650969-a093-4db1-b623-2b419688ca39">

No change for the other charts