### PR TITLE
[view] Add ledger version to be used as an input for view functions

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -172,9 +172,21 @@ export function getAccountModule(
 export function view(
   request: Types.ViewRequest,
   nodeUrl: string,
+  ledgerVersion?: string,
 ): Promise<Types.MoveValue[]> {
   const client = new AptosClient(nodeUrl);
-  return withResponseError(client.view(request));
+  let parsedVersion = ledgerVersion;
+
+  // Handle non-numbers, to default to the latest ledger version
+  if (typeof ledgerVersion === "string" && isNaN(parseInt(ledgerVersion, 10))) {
+    parsedVersion = undefined;
+  }
+
+  if (ledgerVersion === null || ledgerVersion === "") {
+    return withResponseError(client.view(request, parsedVersion));
+  }
+
+  return withResponseError(client.view(request, ledgerVersion));
 }
 
 export function getTableItem(

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -44,6 +44,7 @@ import {
 type ContractFormType = {
   typeArgs: string[];
   args: string[];
+  ledgerVersion?: string;
 };
 
 interface ContractSidebarProps {
@@ -334,6 +335,7 @@ function RunContractForm({
       fn={fn}
       onSubmit={onSubmit}
       setFormValid={setFormValid}
+      isView={false}
       result={
         connected ? (
           <Box>
@@ -485,7 +487,11 @@ function ReadContractForm({
     }
     setInProcess(true);
     try {
-      const result = await view(viewRequest, state.network_value);
+      const result = await view(
+        viewRequest,
+        state.network_value,
+        data.ledgerVersion,
+      );
       setResult(result);
       setErrMsg(undefined);
       logEvent("function_interacted", fn.name, {txn_status: "success"});
@@ -509,6 +515,7 @@ function ReadContractForm({
       fn={fn}
       onSubmit={onSubmit}
       setFormValid={setFormValid}
+      isView={true}
       result={
         <Box>
           <StyledTooltip
@@ -618,11 +625,13 @@ function ContractForm({
   onSubmit,
   setFormValid,
   result,
+  isView,
 }: {
   fn: Types.MoveFunction;
   onSubmit: SubmitHandler<ContractFormType>;
   setFormValid: (valid: boolean) => void;
   result: ReactNode;
+  isView: boolean;
 }) {
   const {account} = useWallet();
   const {
@@ -708,6 +717,24 @@ function ContractForm({
               );
             })}
           </Stack>
+          {isView && (
+            <Stack spacing={4}>
+              <Controller
+                key={"ledgerVersion"}
+                name={"ledgerVersion"}
+                control={control}
+                rules={{required: false}}
+                render={({field: {onChange, value}}) => (
+                  <TextField
+                    onChange={onChange}
+                    value={value}
+                    label={"ledgerVersion: defaults to current version"}
+                    fullWidth
+                  />
+                )}
+              />
+            </Stack>
+          )}
           {result}
         </Stack>
       </Box>


### PR DESCRIPTION
I found this useful in debugging a view function for a user.  View functions are allowed to run on any ledger version, so this adds functionality to the explorer to use it.

https://github.com/aptos-labs/explorer/assets/1335270/2cae303a-0019-4919-8daa-acf14228b36c


