### PR TITLE
Adds banners to notify commission changes are impending

### DIFF
--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -1,6 +1,10 @@
 import {useQuery} from "@tanstack/react-query";
 import {Types} from "aptos";
-import {getValidatorCommission, getValidatorState} from "..";
+import {
+  getValidatorCommission,
+  getValidatorCommissionChange,
+  getValidatorState,
+} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {ResponseError} from "../client";
 import {combineQueries} from "../query-utils";
@@ -8,6 +12,7 @@ import {MoveValue} from "aptos/src/generated";
 
 type DelegationNodeInfoResponse = {
   commission: number | undefined;
+  nextCommission: number | undefined;
   isQueryLoading: boolean;
   validatorStatus: Types.MoveValue[] | undefined;
   error: ResponseError | null;
@@ -24,23 +29,33 @@ export function useGetDelegationNodeInfo({
 
   const {
     combinedQueryState,
-    queries: [validatorCommissionQuery, validatorStateQuery],
+    queries: [
+      validatorCommissionQuery,
+      validatorStateQuery,
+      validatorCommissionChangeQuery,
+    ],
   } = combineQueries([
     useQuery<Types.MoveValue[], ResponseError, number>({
       queryKey: ["validatorCommission", client, validatorAddress],
       queryFn: () => getValidatorCommission(client, validatorAddress),
-      select: (commisionData: MoveValue[]) => Number(commisionData[0]) / 100, // commission rate: 22.85% is represented as 2285
+      select: (commissionData: MoveValue[]) => Number(commissionData[0]) / 100, // commission rate: 22.85% is represented as 2285
     }),
     useQuery<Types.MoveValue[], ResponseError>(
       ["validatorState", client, validatorAddress],
       () => getValidatorState(client, validatorAddress),
     ),
+    useQuery<Types.MoveValue[], ResponseError, number>({
+      queryKey: ["validatorCommissionChange", client, validatorAddress],
+      queryFn: () => getValidatorCommissionChange(client, validatorAddress),
+      select: (commissionData: MoveValue[]) => Number(commissionData[0]) / 100, // commission rate: 22.85% is represented as 2285
+    }),
   ]);
 
   return {
     isQueryLoading: combinedQueryState.isLoading,
     error: combinedQueryState.error,
     commission: validatorCommissionQuery.data,
+    nextCommission: validatorCommissionChangeQuery.data,
     validatorStatus: validatorStateQuery.data,
   };
 }

--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -38,7 +38,7 @@ export function useGetDelegationNodeInfo({
     useQuery<Types.MoveValue[], ResponseError, number>({
       queryKey: ["validatorCommission", client, validatorAddress],
       queryFn: () => getValidatorCommission(client, validatorAddress),
-      select: (commissionData: MoveValue[]) => Number(commissionData[0]) / 100, // commission rate: 22.85% is represented as 2285
+      select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285
     }),
     useQuery<Types.MoveValue[], ResponseError>(
       ["validatorState", client, validatorAddress],
@@ -47,7 +47,7 @@ export function useGetDelegationNodeInfo({
     useQuery<Types.MoveValue[], ResponseError, number>({
       queryKey: ["validatorCommissionChange", client, validatorAddress],
       queryFn: () => getValidatorCommissionChange(client, validatorAddress),
-      select: (commissionData: MoveValue[]) => Number(commissionData[0]) / 100, // commission rate: 22.85% is represented as 2285
+      select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285
     }),
   ]);
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -251,6 +251,19 @@ export async function getValidatorCommission(
   return withResponseError(client.view(payload));
 }
 
+export async function getValidatorCommissionChange(
+  client: AptosClient,
+  poolAddress: Types.Address,
+): Promise<Types.MoveValue[]> {
+  const payload: Types.ViewRequest = {
+    function:
+      "0x1::delegation_pool::operator_commission_percentage_next_lockup_cycle",
+    type_arguments: [],
+    arguments: [poolAddress],
+  };
+  return withResponseError(client.view(payload));
+}
+
 export async function getDelegationPoolExist(
   client: AptosClient,
   validatorAddress: Types.Address,

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -14,13 +14,39 @@ import React, {useState} from "react";
 import CloseIcon from "@mui/icons-material/Close";
 import AptosBannerImage from "../assets/Banner.jpg";
 
+type PillColors =
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning"
+  | "inherit";
+const PillColors: Record<PillColors, string> = {
+  error: "#f44336",
+  info: "#2196f3",
+  primary: "#8B5CF6",
+  secondary: "#f50057",
+  success: "#4caf50",
+  warning: "#ff9800",
+  inherit: "inherit",
+};
+
 interface BannerProps {
   children: React.ReactNode;
   action?: React.ReactNode;
   sx?: SxProps<Theme>;
+  pillText?: string;
+  pillColor?: PillColors;
 }
 
-export function Banner({children, action, sx}: BannerProps) {
+export function Banner({
+  children,
+  action,
+  sx,
+  pillText,
+  pillColor = "primary",
+}: BannerProps) {
   const [bannerOpen, setBannerOpen] = useState<boolean>(true);
   const theme = useTheme();
   const isOnMobile = !useMediaQuery(theme.breakpoints.up("md"));
@@ -42,19 +68,20 @@ export function Banner({children, action, sx}: BannerProps) {
     </IconButton>
   );
 
-  const icon = (
+  const pill = Boolean(pillText) && (
     <Typography
       sx={{
-        backgroundColor: "#8B5CF6",
+        backgroundColor: PillColors[pillColor],
         color: "#ffffff",
         borderRadius: 1,
         paddingX: 1,
-        width: "3rem",
         minWidth: "3rem",
         height: "1.5rem",
+        flex: "0 0 auto",
+        textAlign: "center",
       }}
     >
-      NEW
+      {pillText}
     </Typography>
   );
 
@@ -96,7 +123,7 @@ export function Banner({children, action, sx}: BannerProps) {
                 paddingTop: 0.5,
               }}
             >
-              {icon}
+              {pill}
               {text}
             </Stack>
           </Alert>
@@ -125,7 +152,7 @@ export function Banner({children, action, sx}: BannerProps) {
                 verticalAlign: "center",
               }}
             >
-              {icon}
+              {pill}
               {text}
             </Stack>
           </Alert>

--- a/src/pages/Account/Components/AptosNamesBanner.tsx
+++ b/src/pages/Account/Components/AptosNamesBanner.tsx
@@ -35,7 +35,7 @@ export function AptosNamesBanner() {
   );
 
   return inDev ? (
-    <Banner action={action} sx={{marginBottom: 2}}>
+    <Banner pillText="NEW" action={action} sx={{marginBottom: 2}}>
       {children}
     </Banner>
   ) : null;

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -110,8 +110,8 @@ export default function ValidatorPage() {
                   sx={{marginBottom: 2}}
                 >
                   The current commission rate is {commission}%. The commission
-                  rate will be updated to {nextCommission}% at the end of the
-                  current epoch.
+                  rate will be updated to {nextCommission}% at the current
+                  lockup period.
                 </Banner>
               )}
 

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -18,6 +18,8 @@ import {DelegationStateContext} from "./context/DelegationContext";
 import {useGetDelegatedStakingPoolList} from "../../api/hooks/useGetDelegatedStakingPoolList";
 import {useEffect, useMemo, useState} from "react";
 import Error from "../Account/Error";
+import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
+import {Banner} from "../../components/Banner";
 
 export default function ValidatorPage() {
   const address = useParams().address ?? "";
@@ -42,6 +44,10 @@ export default function ValidatorPage() {
   const validator = validators.find(
     (validator) => validator.owner_address === addressHex.hex(),
   );
+
+  const {commission, nextCommission} = useGetDelegationNodeInfo({
+    validatorAddress: validator?.owner_address ?? "",
+  });
 
   useEffect(() => {
     if (!loading) {
@@ -97,6 +103,18 @@ export default function ValidatorPage() {
                 address={address}
                 isSkeletonLoading={isSkeletonLoading}
               />
+              {commission !== nextCommission && (
+                <Banner
+                  pillText="INFO"
+                  pillColor="warning"
+                  sx={{marginBottom: 2}}
+                >
+                  The current commission rate is {commission}%. The commission
+                  rate will be updated to {nextCommission}% at the end of the
+                  current epoch.
+                </Banner>
+              )}
+
               <ValidatorStakingBar
                 setIsStakingBarSkeletonLoading={setIsStakingBarSkeletonLoading}
                 isSkeletonLoading={isSkeletonLoading}

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -46,7 +46,7 @@ export default function ValidatorPage() {
   );
 
   const {commission, nextCommission} = useGetDelegationNodeInfo({
-    validatorAddress: validator?.owner_address ?? "",
+    validatorAddress: delegationValidator?.owner_address ?? "",
   });
 
   useEffect(() => {

--- a/src/pages/LandingPage/AptosLearnBanner.tsx
+++ b/src/pages/LandingPage/AptosLearnBanner.tsx
@@ -72,7 +72,7 @@ export function AptosLearnBanner() {
 
   return (
     <>
-      <Banner sx={{marginBottom: 2}} action={action}>
+      <Banner pillText="NEW" sx={{marginBottom: 2}} action={action}>
         {children}
       </Banner>
     </>

--- a/src/pages/Validators/CommissionChangeBanner.tsx
+++ b/src/pages/Validators/CommissionChangeBanner.tsx
@@ -1,0 +1,9 @@
+import {Banner} from "../../components/Banner";
+
+export function CommissionChangeBanner() {
+  return (
+    <Banner pillText="INFO" pillColor="warning" sx={{marginBottom: 2}}>
+      Commission rates are now subject to change by the operator
+    </Banner>
+  );
+}

--- a/src/pages/Validators/Index.tsx
+++ b/src/pages/Validators/Index.tsx
@@ -10,6 +10,7 @@ import ValidatorsPageTabs from "./Tabs";
 import ValidatorsMap from "./ValidatorsMap";
 import {getStableID} from "../../utils";
 import {useLogEventWithBasic} from "../Account/hooks/useLogEventWithBasic";
+import {CommissionChangeBanner} from "./CommissionChangeBanner";
 
 export default function ValidatorsPage() {
   const [state] = useGlobalState();
@@ -61,6 +62,7 @@ export default function ValidatorsPage() {
       <Typography variant="h3" marginBottom={2}>
         Validators
       </Typography>
+      <CommissionChangeBanner />
       {currentViewCount &&
       viewCountCap &&
       Number(currentViewCount) <= Number(viewCountCap) ? (

--- a/src/pages/Validators/StakingBanner.tsx
+++ b/src/pages/Validators/StakingBanner.tsx
@@ -70,7 +70,7 @@ export function StakingBanner() {
 
   return (
     <>
-      <Banner sx={{marginBottom: 2}} action={action}>
+      <Banner pillText="NEW" sx={{marginBottom: 2}} action={action}>
         {children}
       </Banner>
       <StakingDrawer open={open} handleClick={handleClick} />

--- a/src/pages/Validators/StakingDrawer.tsx
+++ b/src/pages/Validators/StakingDrawer.tsx
@@ -145,7 +145,7 @@ const faqRewardsData = [
   {
     question: "Can the operator change their commission rate?",
     answer:
-      "Commission rates are now subjec tto change by the operator. The new rate takes effect at the end of the lockup cycle. This period allows stakers to assess the new commission rate. If stakers are not in favor of the upcoming change, they have the full 7.5-day window to unstake their assets before the new rate takes effect.",
+      "Commission rates are now subject to change by the operator. The new rate takes effect at the end of the lockup cycle. This period allows stakers to assess the new commission rate. If stakers are not in favor of the upcoming change, they have the full 7.5-day window to unstake their assets before the new rate takes effect.",
   },
   {
     question: "How much can I expect to earn?",

--- a/src/pages/Validators/StakingDrawer.tsx
+++ b/src/pages/Validators/StakingDrawer.tsx
@@ -144,7 +144,8 @@ const faqRewardsData = [
   },
   {
     question: "Can the operator change their commission rate?",
-    answer: "Commission rates are now subject to change by the operator.",
+    answer:
+      "Commission rates are now subject to change by the operator. Operators are required to make changes to their commission rates 7.5 days before the current lockup cycle ends.",
   },
   {
     question: "How much can I expect to earn?",

--- a/src/pages/Validators/StakingDrawer.tsx
+++ b/src/pages/Validators/StakingDrawer.tsx
@@ -144,7 +144,7 @@ const faqRewardsData = [
   },
   {
     question: "Can the operator change their commission rate?",
-    answer: "No, the commission rate cannot be changed.",
+    answer: "Commission rates are now subject to change by the operator.",
   },
   {
     question: "How much can I expect to earn?",

--- a/src/pages/Validators/StakingDrawer.tsx
+++ b/src/pages/Validators/StakingDrawer.tsx
@@ -145,7 +145,7 @@ const faqRewardsData = [
   {
     question: "Can the operator change their commission rate?",
     answer:
-      "Commission rates are now subject to change by the operator. Operators are required to make changes to their commission rates 7.5 days before the current lockup cycle ends.",
+      "Commission rates are now subjec tto change by the operator. The new rate takes effect at the end of the lockup cycle. This period allows stakers to assess the new commission rate. If stakers are not in favor of the upcoming change, they have the full 7.5-day window to unstake their assets before the new rate takes effect.",
   },
   {
     question: "How much can I expect to earn?",


### PR DESCRIPTION
[Ticket](https://linear.app/aptoslabs/issue/WAL-898/%5Bexplorer-chore%5D-show-commission-rate-changes#comment-b59046de)

* [x] P0 - General banner saying that “Commission rates are now subject to change by the operator.”
Dunno about the language, and yall might not like that mustard yellow pill button 😗 

* [x] P0 - FAQ has to be edited to reflect this new functionality https://aptos-org.slack.com/archives/C0610RM59V3/p1697237827991629 NO FAQ on Explorer - this has been implemented for mobile.
There was still an FAQ in the codebase, updated it just in case

* [x] P0.5 - Individual validator page should show that this node is changing commission rate
Just need a double check on my logic

I hardcoded a new rate to demonstrate the banner on the individual banner page. The banner won't show up on individual validator pages if the upcoming rate is the same as the current rate

https://github.com/aptos-labs/explorer/assets/694324/011328aa-ed36-4dd8-b439-cbbef5aa4066

