### PR TITLE
Alleviates rate limiting issue on explorer delegation validators page

### DIFF
--- a/src/api/hooks/useGetDelegationNodeCommissionChange.ts
+++ b/src/api/hooks/useGetDelegationNodeCommissionChange.ts
@@ -1,0 +1,34 @@
+import {useQuery} from "@tanstack/react-query";
+import {Types} from "aptos";
+import {getValidatorCommission} from "..";
+import {useGlobalState} from "../../global-config/GlobalConfig";
+import {ResponseError} from "../client";
+import {MoveValue} from "aptos/src/generated";
+
+type DelegationNodeInfoResponse = {
+  nextCommission: number | undefined;
+  isQueryLoading: boolean;
+  error: ResponseError | null;
+};
+
+type DelegationNodeInfoProps = {
+  validatorAddress: Types.Address;
+};
+
+export function useGetDelegationNodeCommissionChange({
+  validatorAddress,
+}: DelegationNodeInfoProps): DelegationNodeInfoResponse {
+  const [{aptos_client: client}] = useGlobalState();
+
+  const query = useQuery<Types.MoveValue[], ResponseError, number>({
+    queryKey: ["validatorCommission", client, validatorAddress],
+    queryFn: () => getValidatorCommission(client, validatorAddress),
+    select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285
+  });
+
+  return {
+    isQueryLoading: query.isLoading,
+    error: query.error,
+    nextCommission: query.data,
+  };
+}

--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -1,10 +1,6 @@
 import {useQuery} from "@tanstack/react-query";
 import {Types} from "aptos";
-import {
-  getValidatorCommission,
-  getValidatorCommissionChange,
-  getValidatorState,
-} from "..";
+import {getValidatorCommission, getValidatorState} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {ResponseError} from "../client";
 import {combineQueries} from "../query-utils";
@@ -12,7 +8,6 @@ import {MoveValue} from "aptos/src/generated";
 
 type DelegationNodeInfoResponse = {
   commission: number | undefined;
-  nextCommission: number | undefined;
   isQueryLoading: boolean;
   validatorStatus: Types.MoveValue[] | undefined;
   error: ResponseError | null;
@@ -29,11 +24,7 @@ export function useGetDelegationNodeInfo({
 
   const {
     combinedQueryState,
-    queries: [
-      validatorCommissionQuery,
-      validatorStateQuery,
-      validatorCommissionChangeQuery,
-    ],
+    queries: [validatorCommissionQuery, validatorStateQuery],
   } = combineQueries([
     useQuery<Types.MoveValue[], ResponseError, number>({
       queryKey: ["validatorCommission", client, validatorAddress],
@@ -44,18 +35,12 @@ export function useGetDelegationNodeInfo({
       ["validatorState", client, validatorAddress],
       () => getValidatorState(client, validatorAddress),
     ),
-    useQuery<Types.MoveValue[], ResponseError, number>({
-      queryKey: ["validatorCommissionChange", client, validatorAddress],
-      queryFn: () => getValidatorCommissionChange(client, validatorAddress),
-      select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285
-    }),
   ]);
 
   return {
     isQueryLoading: combinedQueryState.isLoading,
     error: combinedQueryState.error,
     commission: validatorCommissionQuery.data,
-    nextCommission: validatorCommissionChangeQuery.data,
     validatorStatus: validatorStateQuery.data,
   };
 }

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -20,6 +20,7 @@ import {useEffect, useMemo, useState} from "react";
 import Error from "../Account/Error";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
 import {Banner} from "../../components/Banner";
+import {useGetDelegationNodeCommissionChange} from "../../api/hooks/useGetDelegationNodeCommissionChange";
 
 export default function ValidatorPage() {
   const address = useParams().address ?? "";
@@ -45,7 +46,10 @@ export default function ValidatorPage() {
     (validator) => validator.owner_address === addressHex.hex(),
   );
 
-  const {commission, nextCommission} = useGetDelegationNodeInfo({
+  const {commission} = useGetDelegationNodeInfo({
+    validatorAddress: delegationValidator?.owner_address ?? "",
+  });
+  const {nextCommission} = useGetDelegationNodeCommissionChange({
     validatorAddress: delegationValidator?.owner_address ?? "",
   });
 


### PR DESCRIPTION
[My previous PR](https://github.com/aptos-labs/explorer/pull/650) introduced a regression, causing the delegation page to hit rate limits. I added an additional `view` to [`useDelegationNodeInfo`](https://github.com/aptos-labs/explorer/compare/inc-31?expand=1#diff-ae78229edfd40cc88cd35326bd4731041f41fde373b63acacb9af87949c8526aL47-L51) which bumped us from O(2n) `view` calls on that list page to O(3n). That coupled with the growing list of validators tipped us over the limit. 

This highlights the fragility of the current solution. We should invest some time refactor the queries to use more recently introduced indexer tables. 