### PR TITLE
Fix for expiration timestamp formatting issues

### DIFF
--- a/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/TimestampValue.tsx
@@ -9,10 +9,14 @@ import StyledTooltip from "../../StyledTooltip";
 const TOOLTIP_TIME = 2000; // 2s
 
 type TimestampValueProps = {
+  ensureMilliSeconds: boolean;
   timestamp: string;
 };
 
-export default function TimestampValue({timestamp}: TimestampValueProps) {
+export default function TimestampValue({
+  ensureMilliSeconds,
+  timestamp,
+}: TimestampValueProps) {
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
 
   // TODO: unify colors for the new transaction page
@@ -23,7 +27,7 @@ export default function TimestampValue({timestamp}: TimestampValueProps) {
     return <EmptyValue />;
   }
 
-  const moment = parseTimestamp(timestamp);
+  const moment = parseTimestamp(timestamp, ensureMilliSeconds);
   const timestamp_display = timestampDisplay(moment);
 
   const copyTimestamp = async () => {

--- a/src/pages/Block/Tabs/OverviewTab.tsx
+++ b/src/pages/Block/Tabs/OverviewTab.tsx
@@ -88,7 +88,12 @@ export default function OverviewTab({data}: OverviewTabProps) {
         />
         <ContentRow
           title={"Timestamp:"}
-          value={<TimestampValue timestamp={data.block_timestamp} />}
+          value={
+            <TimestampValue
+              timestamp={data.block_timestamp}
+              ensureMilliSeconds
+            />
+          }
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <BlockMetadataRows blockTxn={blockTxn} />

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -310,7 +310,10 @@ function StakeOperationDialogContent({
               <ContentRowSpaceBetween
                 title={"Next Unlock In"}
                 value={
-                  <TimestampValue timestamp={lockedUntilSecs?.toString()!} />
+                  <TimestampValue
+                    timestamp={lockedUntilSecs?.toString()!}
+                    ensureMilliSeconds
+                  />
                 }
               />
             )}

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -62,7 +62,12 @@ export default function BlockMetadataOverviewTab({
         />
         <ContentRow
           title="Timestamp:"
-          value={<TimestampValue timestamp={transactionData.timestamp} />}
+          value={
+            <TimestampValue
+              timestamp={transactionData.timestamp}
+              ensureMilliSeconds
+            />
+          }
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -9,6 +9,7 @@ import TimestampValue from "../../../components/IndividualPageContent/ContentVal
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {parseExpirationTimestamp} from "../../utils";
 
 type PendingTransactionOverviewTabProps = {
   transaction: Types.Transaction;
@@ -38,7 +39,10 @@ export default function PendingTransactionOverviewTab({
           title="Expiration Timestamp:"
           value={
             <TimestampValue
-              timestamp={transactionData.expiration_timestamp_secs}
+              timestamp={parseExpirationTimestamp(
+                transactionData.expiration_timestamp_secs,
+              )}
+              ensureMilliSeconds={false}
             />
           }
           tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -35,7 +35,12 @@ export default function StateCheckpointOverviewTab({
         {"timestamp" in transactionData && (
           <ContentRow
             title="Timestamp:"
-            value={<TimestampValue timestamp={transactionData.timestamp} />}
+            value={
+              <TimestampValue
+                timestamp={transactionData.timestamp}
+                ensureMilliSeconds
+              />
+            }
             tooltip={getLearnMoreTooltip("timestamp")}
           />
         )}

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -14,6 +14,7 @@ import {getTransactionAmount, getTransactionCounterparty} from "../utils";
 import TransactionFunction from "./Components/TransactionFunction";
 import TransactionBlockRow from "./Components/TransactionBlockRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {parseExpirationTimestamp} from "../../utils";
 
 function UserTransferOrInteractionRows({
   transaction,
@@ -124,14 +125,22 @@ export default function UserTransactionOverviewTab({
           title="Expiration Timestamp:"
           value={
             <TimestampValue
-              timestamp={transactionData.expiration_timestamp_secs}
+              timestamp={parseExpirationTimestamp(
+                transactionData.expiration_timestamp_secs,
+              )}
+              ensureMilliSeconds={false}
             />
           }
           tooltip={getLearnMoreTooltip("expiration_timestamp_secs")}
         />
         <ContentRow
           title="Timestamp:"
-          value={<TimestampValue timestamp={transactionData.timestamp} />}
+          value={
+            <TimestampValue
+              timestamp={transactionData.timestamp}
+              ensureMilliSeconds
+            />
+          }
           tooltip={getLearnMoreTooltip("timestamp")}
         />
         <ContentRow

--- a/src/pages/utils.tsx
+++ b/src/pages/utils.tsx
@@ -14,8 +14,21 @@ function ensureMillisecondTimestamp(timestamp: string): number {
   return parseInt(timestamp);
 }
 
-export function parseTimestamp(timestamp: string): moment.Moment {
-  return moment(ensureMillisecondTimestamp(timestamp));
+export function parseTimestamp(
+  timestamp: string,
+  ensureMilliSeconds: boolean = true,
+): moment.Moment {
+  if (ensureMilliSeconds) {
+    return moment(ensureMillisecondTimestamp(timestamp));
+  } else {
+    return moment(parseInt(timestamp));
+  }
+}
+
+// expiration_timestamp can be user inputted so we don't want to do any ensuring of milliseconds
+// but it comes back at a different factor than what we need for parsing on the frontend
+export function parseExpirationTimestamp(timestamp: string) {
+  return timestamp + "000";
 }
 
 export interface TimestampDisplay {


### PR DESCRIPTION
Summary
Time stamps are kind of wacky coming back from the node. The request here was to not format expiration_timestamp because its user inputted. The previous logic was interesting and seemingly can come back from the node in a different fashion.

Test plan
http://localhost:3000/txn/369869258?network=mainnet
<img width="598" alt="Screenshot 2024-01-25 at 3 14 52 PM" src="https://github.com/aptos-labs/explorer/assets/19931667/65d12c82-0c8c-48ce-8286-489a1fb23708">
