### PR TITLE
Fix for commision rate change showing even though the next commission is null

### DIFF
--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -107,7 +107,7 @@ export default function ValidatorPage() {
                 address={address}
                 isSkeletonLoading={isSkeletonLoading}
               />
-              {commission !== nextCommission && (
+              {nextCommission && commission !== nextCommission && (
                 <Banner
                   pillText="INFO"
                   pillColor="warning"


### PR DESCRIPTION
@kaw2k unsure of when next commission can be null but it seems to be happening a lot.

[
![Screenshot 2024-01-28 at 10 02 05 AM](https://github.com/aptos-labs/explorer/assets/19931667/55565658-a1f5-47bf-b33a-e17b43669f12)
](url)

no more banner when its null: http://localhost:3000/validator/0x9bfd93ebaa1efd65515642942a607eeca53a0188c04c21ced646d2f0b9f551e8?network=mainnet

banner on prod: /validator/0x9bfd93ebaa1efd65515642942a607eeca53a0188c04c21ced646d2f0b9f551e8?network=mainnet
