### PR TITLE
Use node API via API Gateway

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -2,12 +2,11 @@
  * Network
  */
 export const devnetUrl =
-  import.meta.env.APTOS_DEVNET_URL ||
-  "https://fullnode.devnet.aptoslabs.com/v1";
+  import.meta.env.APTOS_DEVNET_URL || "https://api.devnet.aptoslabs.com/v1";
 
 export const networks = {
-  mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
-  testnet: "https://fullnode.testnet.aptoslabs.com/v1",
+  mainnet: "https://api.mainnet.aptoslabs.com/v1",
+  testnet: "https://api.testnet.aptoslabs.com/v1",
   devnet: devnetUrl,
   local: "http://127.0.0.1:8080/v1",
   previewnet: "https://fullnode.previewnet.aptoslabs.com/v1",


### PR DESCRIPTION
### Description
This is part of the migration to API Gateway. More context here: https://www.notion.so/aptoslabs/Migration-1-Legacy-URL-to-API-Gateway-migration-b007742490684b9bab3debd674504a94.

I found the initial files to change like this:
```
rg -l -e 'fullnode\.[a-z]{3,4}net.aptoslabs.com'
```

I then did a find replace from `fullnode.([a-z]{3,6}net).aptoslabs.com` to `api.$1.aptoslabs.com`.

I did some further digging, e.g. for places where we perhaps build the URL, by just looking at every file that references `aptoslabs.com`. Hopefully this is everything.

I haven't touched indexer API, we'll do that in another PR.

I didn't touch randomnet or previewnet.

### Test Plan
CI for now.