### PR TITLE
fix: prevent interval bar text wrap

### DIFF
--- a/src/components/IntervalBar.tsx
+++ b/src/components/IntervalBar.tsx
@@ -50,7 +50,9 @@ export default function IntervalBar({
       case IntervalType.UNLOCK_COUNTDOWN:
         return (
           <span>
-            {days}d {hours}h {minutes}m {seconds}s
+            {days >= 10
+              ? `${days}d ${hours}h ${minutes}m`
+              : `${days}d ${hours}h ${minutes}m ${seconds}s`}
           </span>
         );
     }


### PR DESCRIPTION
Resolves #614

---

**What's the issue?**

Text inside the `IntervalBar` component wraps when the text length is too long.

---

**Solution**

If `days` are greater than `10`, we can remove the `seconds` value to shorten the string and ensure it fits inside the bounds.

---

**Solution screenshots**

|Before|After|
|--|--|
|![](https://github.com/aptos-labs/explorer/assets/12480362/8231c551-c579-4e56-9f67-f8092778b07d)|![](https://github.com/aptos-labs/explorer/assets/12480362/b6ec83da-34d9-48d3-9a21-60e74fb51834)|

---

**Alternative solutions**

|Description|Screenshot|
|--|--|
|Increase bar width by 20px|![](https://github.com/aptos-labs/explorer/assets/12480362/5c64d60c-187d-4a01-86a7-9843a0d881a0)|
|Use `white-space: nowrap`|![](https://github.com/aptos-labs/explorer/assets/12480362/2e434b98-1d6d-4130-aa92-761e9c857dd3)|
|Truncate text|![](https://github.com/aptos-labs/explorer/assets/12480362/af6f9b1d-3760-4720-875a-e313e828b7dd)|

---

If you prefer one of the alternative solutions, let me know, and I'll make changes :)