### PR TITLE
Use indexer API via API Gateway

### DIFF
--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -18,11 +18,11 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
 export function getGraphqlURI(networkName: NetworkName): string | undefined {
   switch (networkName) {
     case "mainnet":
-      return "https://indexer.mainnet.aptoslabs.com/v1/graphql";
+      return "https://api.mainnet.aptoslabs.com/v1/graphql";
     case "testnet":
-      return "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql";
+      return "https://api.testnet.aptoslabs.com/v1/graphql";
     case "devnet":
-      return "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql";
+      return "https://api.devnet.aptoslabs.com/v1/graphql";
     case "local":
       return "http://127.0.0.1:8090/v1/graphql";
     case "randomnet":


### PR DESCRIPTION
### Description
This is part of the migration to API Gateway. More context here: https://www.notion.so/aptoslabs/Migration-1-Legacy-URL-to-API-Gateway-migration-b007742490684b9bab3debd674504a94.

I found the initial files to change like this:
```
rg -l 'aptoslabs.com'
```

### Test Plan
In the preview you can see that a page that relies on the indexer works, e.g. the tokens page for an account: https://deploy-preview-679--aptos-explorer.netlify.app/account/0x232098630cfad4734812fa37dc18d9b8d59242feabe49259e26318d468a99584/tokens?network=mainnet. It uses the new URL correctly.