### PR TITLE
Support nested vector in explorer

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -36,10 +36,7 @@ import {
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
 import {ContentCopy} from "@mui/icons-material";
 import StyledTooltip from "../../../../components/StyledTooltip";
-import {
-  deserializeVector,
-  encodeInputArgsForViewRequest,
-} from "../../../../utils";
+import {encodeInputArgsForViewRequest} from "../../../../utils";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -282,7 +279,7 @@ function RunContractForm({
             ? Array.from(new HexString(arg).toUint8Array()).map((x) =>
                 x.toString(),
               )
-            : deserializeVector(arg);
+            : JSON.parse(arg);
         } else if (type.startsWith("0x1::option::Option")) {
           arg ? {vec: [arg]} : undefined;
         } else return arg;

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -277,6 +277,7 @@ function RunContractForm({
         const type = fnParams[i];
         if (type.includes("vector")) {
           // when it's a vector<u8>, we support both hex and javascript array format
+          console.log(type, arg);
           return type === "vector<u8>" && arg.trim().startsWith("0x")
             ? Array.from(new HexString(arg).toUint8Array()).map((x) =>
                 x.toString(),
@@ -287,6 +288,7 @@ function RunContractForm({
         } else return arg;
       }),
     };
+    console.log(payload);
 
     await submitTransaction(payload);
     if (transactionResponse?.transactionSubmitted) {

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -274,7 +274,6 @@ function RunContractForm({
         const type = fnParams[i];
         if (type.includes("vector")) {
           // when it's a vector<u8>, we support both hex and javascript array format
-          console.log(type, arg);
           return type === "vector<u8>" && arg.trim().startsWith("0x")
             ? Array.from(new HexString(arg).toUint8Array()).map((x) =>
                 x.toString(),

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -288,7 +288,6 @@ function RunContractForm({
         } else return arg;
       }),
     };
-    console.log(payload);
 
     await submitTransaction(payload);
     if (transactionResponse?.transactionSubmitted) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,17 +181,17 @@ export function encodeInputArgsForViewRequest(type: string, value: string) {
 
 // Deserialize "[1,2,3]" or "1,2,3" to ["1", "2", "3"]
 // Also works nested [[1, 2], [3, 4]] to [["1", "2"], ["3", "4"]]
-// TODO: Need to type this recursively
-export function deserializeVector(vectorString: string): any {
+interface DeepArray<T> extends Array<T | DeepArray<T>> {}
+export function deserializeVector(vectorString: string): DeepArray<string> {
   const trimmed = vectorString.trim();
   let inside = "";
-  if (isArrayStr(trimmed)) {
+  if (startsAndEndsWithBrackets(trimmed)) {
     inside = trimmed.slice(1, -1);
   }
   // There's a tradeoff here between empty string, and empty array.  We're going with empty array.
   if (inside.length == 0) {
     return [];
-  } else if (isArrayStr(inside)) {
+  } else if (startsAndEndsWithBrackets(inside)) {
     const innerArrayStrs = [];
     let build = "";
     for (let i = 0; i < inside.length; i++) {
@@ -208,7 +208,7 @@ export function deserializeVector(vectorString: string): any {
   return inside.split(",");
 }
 
-function isArrayStr(str: string): boolean {
+function startsAndEndsWithBrackets(str: string): boolean {
   return str.startsWith("[") && str.endsWith("]");
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,36 +180,16 @@ export function encodeInputArgsForViewRequest(type: string, value: string) {
 }
 
 // Deserialize "[1,2,3]" or "1,2,3" to ["1", "2", "3"]
-// Also works nested [[1, 2], [3, 4]] to [["1", "2"], ["3", "4"]]
-interface DeepArray<T> extends Array<T | DeepArray<T>> {}
-export function deserializeVector(vectorString: string): DeepArray<string> {
-  const trimmed = vectorString.trim();
-  let inside = "";
-  if (startsAndEndsWithBrackets(trimmed)) {
-    inside = trimmed.slice(1, -1);
+export function deserializeVector(vectorString: string): string[] {
+  let result = vectorString.trim();
+  if (result[0] === "[" && result[result.length - 1] === "]") {
+    result = result.slice(1, -1);
   }
   // There's a tradeoff here between empty string, and empty array.  We're going with empty array.
-  if (inside.length == 0) {
+  if (result.length == 0) {
     return [];
-  } else if (startsAndEndsWithBrackets(inside)) {
-    const innerArrayStrs = [];
-    let build = "";
-    for (let i = 0; i < inside.length; i++) {
-      if (inside[i] === "]") {
-        innerArrayStrs.push(build);
-        build = "";
-      } else {
-        build += inside[i];
-      }
-    }
-    return innerArrayStrs.map(deserializeVector);
   }
-
-  return inside.split(",");
-}
-
-function startsAndEndsWithBrackets(str: string): boolean {
-  return str.startsWith("[") && str.endsWith("]");
+  return result.split(",");
 }
 
 function encodeVectorForViewRequest(type: string, value: string) {


### PR DESCRIPTION
Use `JSON.parse` to handle parsing `[]` arguments. 

Previously, `[[abc]]` would be parsed as `["[abc]"], but really, it should be `[["abc"]]`.

The noteworthy change here is that quotes must now be used for literals. E.g. `[0xabc]` used to be acceptable but now must be specified as `["0xabc"]`