### PR TITLE
[account] Allow nonexistent account with tokens

### DIFF
--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -28,6 +28,7 @@ import {Link} from "../routing";
 export enum HashType {
   ACCOUNT = "account",
   TRANSACTION = "transaction",
+  OBJECT = "object",
   OTHERS = "others",
 }
 
@@ -37,6 +38,8 @@ function getHashLinkStr(hash: string, type: HashType): string {
       return `/account/${hash}`;
     case HashType.TRANSACTION:
       return `/txn/${hash}`;
+    case HashType.OBJECT:
+      return `/object/${hash}`;
     case HashType.OTHERS:
       return "";
     default:
@@ -48,6 +51,7 @@ function HashLink(hash: string, type: HashType): JSX.Element {
   switch (type) {
     case HashType.ACCOUNT:
     case HashType.TRANSACTION:
+    case HashType.OBJECT:
       return (
         <Link to={getHashLinkStr(hash, type)} color="inherit">
           {hash}

--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -13,7 +13,8 @@ export default function Error({error, address}: ErrorProps) {
       return (
         <Alert severity="error" sx={{overflowWrap: "break-word"}}>
           {error.message}
-          Account not found: {address}
+          Account not found: {address}. The account may still have tokens or
+          objects associated.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -81,7 +81,15 @@ export default function AccountPage({isObject = false}: AccountPageProps) {
       </Grid>
       <Grid item xs={12} md={12} lg={12} marginTop={4}>
         {error ? (
-          <Error address={address} error={error} />
+          <>
+            <AccountTabs
+              address={address}
+              accountData={data}
+              tabValues={tabValues}
+              isObject={isObject}
+            />
+            <Error address={address} error={error} />
+          </>
         ) : (
           <AccountTabs
             address={address}

--- a/src/pages/Token/Tabs/OverviewTab.tsx
+++ b/src/pages/Token/Tabs/OverviewTab.tsx
@@ -1,6 +1,6 @@
 import {useParams} from "react-router-dom";
 import {Box, Stack, Typography} from "@mui/material";
-import React, {useState} from "react";
+import React, {Fragment, useState} from "react";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
@@ -79,6 +79,31 @@ export default function OverviewTab({data}: OverviewTabProps) {
         />
       </ContentBox>
       <ContentBox>
+        {data.token_standard == "v2" ? (
+          <Fragment>
+            <ContentRow
+              title={"Collection id:"}
+              value={
+                <HashButton
+                  hash={data?.current_collection?.collection_id ?? ""}
+                  type={HashType.OBJECT}
+                />
+              }
+            />
+
+            <ContentRow
+              title={"Token id:"}
+              value={
+                <HashButton
+                  hash={data?.token_data_id ?? ""}
+                  type={HashType.OBJECT}
+                />
+              }
+            />
+          </Fragment>
+        ) : (
+          <Fragment></Fragment>
+        )}
         <ContentRow
           title={"Largest Property Version:"}
           value={data?.largest_property_version_v1}


### PR DESCRIPTION
This adds two functionalities:
1. View tokens for an address if it's not an account or object
2. Add links for token and collection objects directly on the token page for tokenv2.