### PR TITLE
Fix for analytics crashing

### DIFF
--- a/src/pages/Analytics/utils.ts
+++ b/src/pages/Analytics/utils.ts
@@ -23,5 +23,5 @@ export function numberFormatter(num: number, digits: number) {
 }
 
 export function getLabels(data: DailyAnalyticsData[], days: number): string[] {
-  return data.slice(-days).map((dailyData) => dailyData.date.substring(5));
+  return data.slice(-days).map((dailyData) => dailyData.date?.substring(5));
 }


### PR DESCRIPTION
## Description
https://explorer.aptoslabs.com/analytics?network=mainnet

Will fix this more thoughtfully in a folllowup but this stops Explorer from not rendering anything.

## Test Plan
Renders - http://localhost:3000/analytics?network=mainnet (though some data is missing)