### PR TITLE
Fix Explorer and wallet SDK network name comparison for local testnet

### DIFF
--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -36,7 +36,10 @@ const useSubmitTransaction = () => {
   }, [transactionResponse]);
 
   async function submitTransaction(payload: Types.TransactionPayload) {
-    if (network?.name.toLocaleLowerCase() !== state.network_name) {
+    if (
+      network?.name.toLocaleLowerCase() !==
+      (state.network_name === "local" ? "localhost" : state.network_name)
+    ) {
       setTransactionResponse({
         transactionSubmitted: false,
         message:


### PR DESCRIPTION
[bugfix] Resolved bug resulting from differing name conventions of the local testnet between Explorer and wallet SDK.


#### Info
An Explorer user can not run entry functions on-page against their local testnet, due to the conditional network name check. Local testnet had two different names across Explorer and the wallet SDK ("local" and "localhost", respectively), so the check always fails.

I updated the conditional to convert any mention of the Explorer's "local" network into "localhost", during the check. Now, the conditional is properly applied.

Performing a string replacement in this single instance requires fewer modifications across both codebases.