### PR TITLE
[object] Add support for code as objects

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -45,6 +45,14 @@ export default function ExplorerRoutes() {
 
         <Route path="/object">
           <Route
+            path=":address/modules/:modulesTab/:selectedModuleName"
+            element={<AccountPage isObject={true} />}
+          />
+          <Route
+            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            element={<AccountPage isObject={true} />}
+          />
+          <Route
             path=":address/:tab"
             element={<AccountPage isObject={true} />}
           />

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -26,18 +26,26 @@ const TAB_VALUES_FULL: TabValue[] = [
 
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
+// TODO: add ability for object information
 const OBJECT_VALUES_FULL: TabValue[] = [
   "transactions",
-  // TODO: Once indexer supports objects owning coins/tokens (v2?)- uncomment these
-  // "coins",
-  // "tokens",
+  "coins",
+  "tokens",
   "resources",
+  "modules",
 ];
-const OBJECT_TAB_VALUES: TabValue[] = ["transactions", "resources"];
+const OBJECT_TAB_VALUES: TabValue[] = ["transactions", "resources", "modules"];
 
 type AccountPageProps = {
   isObject?: boolean;
 };
+
+export function accountPagePath(isObject: boolean) {
+  if (isObject) {
+    return "object";
+  }
+  return "account";
+}
 
 export default function AccountPage({isObject = false}: AccountPageProps) {
   const isGraphqlClientSupported = useGetIsGraphqlClientSupported();

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -18,6 +18,7 @@ import CoinsTab from "./Tabs/CoinsTab";
 import {Types} from "aptos";
 import {useParams} from "react-router-dom";
 import {useNavigate} from "../../routing";
+import {accountPagePath} from "./Index";
 
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
@@ -74,11 +75,23 @@ type TabPanelProps = {
   value: TabValue;
   address: string;
   accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  isObject: boolean;
 };
 
-function TabPanel({value, address, accountData}: TabPanelProps): JSX.Element {
+function TabPanel({
+  value,
+  address,
+  accountData,
+  isObject,
+}: TabPanelProps): JSX.Element {
   const TabComponent = TabComponents[value];
-  return <TabComponent address={address} accountData={accountData} />;
+  return (
+    <TabComponent
+      address={address}
+      accountData={accountData}
+      isObject={isObject}
+    />
+  );
 }
 
 type AccountTabsProps = {
@@ -107,11 +120,9 @@ export default function AccountTabs({
   }
 
   const handleChange = (event: React.SyntheticEvent, newValue: TabValue) => {
-    if (isObject) {
-      navigate(`/object/${address}/${newValue}`, {replace: true});
-    } else {
-      navigate(`/account/${address}/${newValue}`, {replace: true});
-    }
+    navigate(`/${accountPagePath(isObject)}/${address}/${newValue}`, {
+      replace: true,
+    });
   };
 
   return (
@@ -135,6 +146,7 @@ export default function AccountTabs({
           value={effectiveTab}
           address={address}
           accountData={accountData}
+          isObject={isObject}
         />
       </Box>
     </Box>

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -40,6 +40,7 @@ import {
   deserializeVector,
   encodeInputArgsForViewRequest,
 } from "../../../../utils";
+import {accountPagePath} from "../../Index";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -51,10 +52,19 @@ interface ContractSidebarProps {
   selectedModuleName: string | undefined;
   selectedFnName: string | undefined;
   moduleAndFnsGroup: Record<string, Types.MoveFunction[]>;
-  getLinkToFn(moduleName: string, fnName: string): string;
+  getLinkToFn(moduleName: string, fnName: string, isObject: boolean): string;
+  isObject: boolean;
 }
 
-function Contract({address, isRead}: {address: string; isRead: boolean}) {
+function Contract({
+  address,
+  isObject,
+  isRead,
+}: {
+  address: string;
+  isObject: boolean;
+  isRead: boolean;
+}) {
   const theme = useTheme();
   const {data, isLoading, error} = useGetAccountModules(address);
   const {selectedModuleName, selectedFnName} = useParams();
@@ -105,11 +115,11 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
       )
     : undefined;
 
-  function getLinkToFn(moduleName: string, fnName: string) {
+  function getLinkToFn(moduleName: string, fnName: string, isObject: boolean) {
     // This string implicitly depends on the fact that
     // the `isRead` value is determined by the
     // pathname `view` and `run`.
-    return `/account/${address}/modules/${
+    return `/${accountPagePath(isObject)}/${address}/modules/${
       isRead ? "view" : "run"
     }/${moduleName}/${fnName}`;
   }
@@ -125,6 +135,7 @@ function Contract({address, isRead}: {address: string; isRead: boolean}) {
           selectedFnName={selectedFnName}
           moduleAndFnsGroup={moduleAndFnsGroup}
           getLinkToFn={getLinkToFn}
+          isObject={isObject}
         />
       </Grid>
       <Grid item md={9} xs={12}>
@@ -158,6 +169,7 @@ function ContractSidebar({
   selectedFnName,
   moduleAndFnsGroup,
   getLinkToFn,
+  isObject,
 }: ContractSidebarProps) {
   const theme = useTheme();
   const isWideScreen = useMediaQuery(theme.breakpoints.up("md"));
@@ -207,7 +219,7 @@ function ContractSidebar({
                       return (
                         <SidebarItem
                           key={fn.name}
-                          linkTo={getLinkToFn(moduleName, fn.name)}
+                          linkTo={getLinkToFn(moduleName, fn.name, isObject)}
                           selected={selected}
                           name={fn.name}
                           loggingInfo={{
@@ -234,7 +246,7 @@ function ContractSidebar({
           )}
           onChange={(_, fn) => {
             fn && logEvent("function_name_clicked", fn.fnName);
-            fn && navigate(getLinkToFn(fn.moduleName, fn.fnName));
+            fn && navigate(getLinkToFn(fn.moduleName, fn.fnName, isObject));
           }}
           value={
             selectedModuleName && selectedFnName

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -9,6 +9,7 @@ import ViewCode from "./ViewCode";
 import Contract from "./Contract";
 import {useNavigate} from "../../../../routing";
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
+import {accountPagePath} from "../../Index";
 
 const TabComponents = Object.freeze({
   code: ViewCode,
@@ -34,22 +35,41 @@ function getTabLabel(value: TabValue): string {
 type TabPanelProps = {
   value: TabValue;
   address: string;
+  isObject: boolean;
 };
 
-function RunContract({address}: {address: string}) {
-  return <Contract address={address} isRead={false} />;
+function RunContract({
+  address,
+  isObject,
+}: {
+  address: string;
+  isObject: boolean;
+}) {
+  return <Contract address={address} isObject={isObject} isRead={false} />;
 }
 
-function ReadContract({address}: {address: string}) {
-  return <Contract address={address} isRead />;
+function ReadContract({
+  address,
+  isObject,
+}: {
+  address: string;
+  isObject: boolean;
+}) {
+  return <Contract address={address} isObject={isObject} isRead={true} />;
 }
 
-function TabPanel({value, address}: TabPanelProps): JSX.Element {
+function TabPanel({value, address, isObject}: TabPanelProps): JSX.Element {
   const TabComponent = TabComponents[value];
-  return <TabComponent address={address} />;
+  return <TabComponent address={address} isObject={isObject} />;
 }
 
-function ModulesTabs({address}: {address: string}): JSX.Element {
+function ModulesTabs({
+  address,
+  isObject,
+}: {
+  address: string;
+  isObject: boolean;
+}): JSX.Element {
   const theme = useTheme();
   const tabValues = Object.keys(TabComponents) as TabValue[];
   const {selectedFnName, selectedModuleName, modulesTab} = useParams();
@@ -74,7 +94,7 @@ function ModulesTabs({address}: {address: string}): JSX.Element {
     eventName && logEvent(eventName);
 
     navigate(
-      `/account/${address}/modules/${newValue}/${selectedModuleName}` +
+      `/${accountPagePath(isObject)}/${address}/modules/${newValue}/${selectedModuleName}` +
         (selectedFnName ? `/${selectedFnName}` : ``),
       {replace: true},
     );
@@ -143,7 +163,7 @@ function ModulesTabs({address}: {address: string}): JSX.Element {
         </StyledTabs>
       </Box>
       <Box>
-        <TabPanel value={value} address={address} />
+        <TabPanel value={value} address={address} isObject={isObject} />
       </Box>
     </Box>
   );

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -25,6 +25,7 @@ import {useNavigate} from "../../../../routing";
 import SidebarItem from "../../Components/SidebarItem";
 import {Code} from "../../Components/CodeSnippet";
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
+import {accountPagePath} from "../../Index";
 
 interface ModuleSidebarProps {
   sortedPackages: PackageMetadata[];
@@ -39,7 +40,13 @@ interface ModuleContentProps {
   bytecode: string;
 }
 
-function ViewCode({address}: {address: string}): JSX.Element {
+function ViewCode({
+  address,
+  isObject,
+}: {
+  address: string;
+  isObject: boolean;
+}): JSX.Element {
   const sortedPackages: PackageMetadata[] = useGetAccountPackages(address);
 
   const navigate = useNavigate();
@@ -48,13 +55,13 @@ function ViewCode({address}: {address: string}): JSX.Element {
   useEffect(() => {
     if (!selectedModuleName && sortedPackages.length > 0) {
       navigate(
-        `/account/${address}/modules/code/${sortedPackages[0].modules[0].name}`,
+        `/${accountPagePath(isObject)}/${address}/modules/code/${sortedPackages[0].modules[0].name}`,
         {
           replace: true,
         },
       );
     }
-  }, [selectedModuleName, sortedPackages, address, navigate]);
+  }, [selectedModuleName, sortedPackages, address, navigate, isObject]);
 
   if (sortedPackages.length === 0) {
     return <EmptyTabContent />;
@@ -65,7 +72,7 @@ function ViewCode({address}: {address: string}): JSX.Element {
     .find((module) => module.name === selectedModuleName);
 
   function getLinkToModule(moduleName: string) {
-    return `/account/${address}/modules/code/${moduleName}`;
+    return `/${accountPagePath(isObject)}/${address}/modules/code/${moduleName}`;
   }
 
   function navigateToModule(moduleName: string) {

--- a/src/pages/Account/Tabs/ModulesTab/index.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/index.tsx
@@ -2,8 +2,9 @@ import ModulesTabs from "./Tabs";
 
 type ModulesTabProps = {
   address: string;
+  isObject: boolean;
 };
 
-export default function ModulesTab({address}: ModulesTabProps) {
-  return <ModulesTabs address={address} />;
+export default function ModulesTab({address, isObject}: ModulesTabProps) {
+  return <ModulesTabs address={address} isObject={isObject} />;
 }


### PR DESCRIPTION
This is temporary, ideally we should make an `/address` and simply decide on that page between object and account. Many of the redirects will probably not work correctly from transactions and other places until that is done.

Example here https://deploy-preview-690--aptos-explorer.netlify.app/object/0x3a473af845d46da6356b6d02d7ebf6ecbc62224a0b96407f6c3d2e8502b2b7d3/modules/code/composable_nfts?network=devnet