### PR TITLE
[modules] Handle packages without modules

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -53,7 +53,11 @@ function ViewCode({
 
   const selectedModuleName = useParams().selectedModuleName ?? "";
   useEffect(() => {
-    if (!selectedModuleName && sortedPackages.length > 0) {
+    if (
+      !selectedModuleName &&
+      sortedPackages.length > 0 &&
+      sortedPackages[0].modules.length > 0
+    ) {
       navigate(
         `/${accountPagePath(isObject)}/${address}/modules/code/${sortedPackages[0].modules[0].name}`,
         {


### PR DESCRIPTION
When there are no modules, it crashes trying to access values that don't exist.  Now, it'll skip it accordingly

Example: https://deploy-preview-691--aptos-explorer.netlify.app/object/0xbd27b6ddb1b58075df6f7199bb68506e0fd20b142171e6b2b2c0ea232773f5aa/modules?network=testnet