### PR TITLE
Fix module tab when package is empty

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -53,7 +53,11 @@ function ViewCode({
 
   const selectedModuleName = useParams().selectedModuleName ?? "";
   useEffect(() => {
-    if (!selectedModuleName && sortedPackages.length > 0) {
+    if (
+      !selectedModuleName &&
+      sortedPackages.length > 0 &&
+      sortedPackages[0].modules.length > 0
+    ) {
       navigate(
         `/${accountPagePath(isObject)}/${address}/modules/code/${sortedPackages[0].modules[0].name}`,
         {


### PR DESCRIPTION
**Bug**
Got this [error](https://aptos-labs.sentry.io/issues/5114792971/?project=6249755&referrer=github-pr-bot) on sentry, turns out this account published an empty package. 

[Here's an account with empty package](https://explorer.aptoslabs.com/account/0xbd27b6ddb1b58075df6f7199bb68506e0fd20b142171e6b2b2c0ea232773f5aa/modules?network=testnet). If you switch to module tab, the explorer is broken.

**Fix**
Treat empty package as no package.