### PR TITLE
Fix missing coin amounts

### DIFF
--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -31,7 +31,7 @@ function AmountCell({coin}: CoinCellProps) {
   const amount = coin?.amount;
   const decimals = coin?.metadata?.decimals;
 
-  if (!amount || !decimals) {
+  if (amount == null || decimals == null) {
     return <GeneralTableCell>-</GeneralTableCell>;
   }
 


### PR DESCRIPTION
Fixes #701

Bug was if decimals or amount is `0`, we show the placeholders. Instead, we should explicitly check for `null` and `undefined`