### PR TITLE
Better option handling

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -295,6 +295,8 @@ function RunContractForm({
                   x.toString(),
                 )
               : JSON.parse(arg);
+          } else if (type.startsWith("0x1::option::Option")) {
+            return arg !== "" ? {vec: [arg]} : undefined;
           } else return arg;
         }),
       },


### PR DESCRIPTION
Only case that does not work is if the user wants "" to be the actual value.

We need a non-text input for this to work well