### PR TITLE
[run-function] Fix run functionality, add instructions

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -767,8 +767,7 @@ function ContractForm({
             </Stack>
           )}
           {result}
-          /* TODO: Figure out a better way to show instructions, I tried, and it
-          wasn't pretty */
+          {/* TODO: Figure out a better way to show instructions, I tried, and it wasn't pretty */}
           <Typography fontSize={14} fontWeight={600}>
             How to use:
           </Typography>


### PR DESCRIPTION
This supports two types:

basic inputs 5, 6, 7 or a, b,c

And JSON

[5,6,7] ["a", "b", "c"]

It additionally fixes all options, nested vectors etc.

View functions still probably need some work

You can test the preview page for this same path:

https://deploy-preview-728--aptos-explorer.netlify.app/object/0xdc325741bcf1b2d9bc1de2acf466f1b48ff3de8a39ec82f805fd019d4eb1fc1c/modules/run/wallet_tester/test_bool?network=testnet