### PR TITLE
Update block timestamp

### DIFF
--- a/src/pages/Transaction/helpers.tsx
+++ b/src/pages/Transaction/helpers.tsx
@@ -94,7 +94,7 @@ export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
       return <LearnMoreTooltipPlaceholder />;
     case "timestamp":
       return (
-        <LearnMoreTooltip text="Timestamp is the machine timestamp of when the block is committed." />
+        <LearnMoreTooltip text="Timestamp is the machine timestamp of when consensus is reached for block." />
       );
     case "version":
       return (

--- a/src/pages/Transaction/helpers.tsx
+++ b/src/pages/Transaction/helpers.tsx
@@ -94,7 +94,7 @@ export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
       return <LearnMoreTooltipPlaceholder />;
     case "timestamp":
       return (
-        <LearnMoreTooltip text="Timestamp is the machine timestamp of when consensus is reached for block." />
+        <LearnMoreTooltip text="Timestamp is the machine timestamp of when leader creates and proposes a block for consensus." />
       );
     case "version":
       return (


### PR DESCRIPTION
I'm going off the definitions from here: https://aptos.dev/concepts/blockchain/#proposing-the-block

Would it be accurate to say that the timestamp is right before step 8? (Consensus → Execution)
