### PR TITLE
Use staging API Gateway for devnet and testnet

### DIFF
--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -20,9 +20,9 @@ export function getGraphqlURI(networkName: NetworkName): string | undefined {
     case "mainnet":
       return "https://api.mainnet.aptoslabs.com/v1/graphql";
     case "testnet":
-      return "https://api.testnet.aptoslabs.com/v1/graphql";
+      return "https://api-staging.testnet.aptoslabs.com/v1/graphql";
     case "devnet":
-      return "https://api.devnet.aptoslabs.com/v1/graphql";
+      return "https://api-staging.devnet.aptoslabs.com/v1/graphql";
     case "local":
       return "http://127.0.0.1:8090/v1/graphql";
     case "randomnet":

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -2,11 +2,12 @@
  * Network
  */
 export const devnetUrl =
-  import.meta.env.APTOS_DEVNET_URL || "https://api.devnet.aptoslabs.com/v1";
+  import.meta.env.APTOS_DEVNET_URL ||
+  "https://api-staging.devnet.aptoslabs.com/v1";
 
 export const networks = {
   mainnet: "https://api.mainnet.aptoslabs.com/v1",
-  testnet: "https://api.testnet.aptoslabs.com/v1",
+  testnet: "https://api-staging.testnet.aptoslabs.com/v1",
   devnet: devnetUrl,
   local: "http://127.0.0.1:8080/v1",
   previewnet: "https://fullnode.previewnet.aptoslabs.com/v1",


### PR DESCRIPTION
Internal context: https://www.notion.so/aptoslabs/Route-more-traffic-through-staging-8ac50da7dfcf490fb329b14d9359c6ee.

In short, we want to route more traffic through the staging API Gateway so it is a representative test environment. The explorer is an important but not critical product and a good candidate for this initiative.