### PR TITLE
Configure explorer to use API keys from API Gateway

### DIFF
--- a/src/api/hooks/useGetAccount.ts
+++ b/src/api/hooks/useGetAccount.ts
@@ -12,7 +12,7 @@ export function useGetAccount(
 
   const result = useQuery<Types.AccountData, ResponseError>({
     queryKey: ["account", {address}, state.network_value],
-    queryFn: () => getAccount({address}, state.network_value),
+    queryFn: () => getAccount({address}, state.aptos_client),
     retry: options?.retry ?? false,
   });
 

--- a/src/api/hooks/useGetAccountModule.ts
+++ b/src/api/hooks/useGetAccountModule.ts
@@ -12,7 +12,7 @@ export function useGetAccountModule(
 
   return useQuery<Types.MoveModuleBytecode, ResponseError>({
     queryKey: ["accountModule", {address, moduleName}, state.network_value],
-    queryFn: () => getAccountModule({address, moduleName}, state.network_value),
+    queryFn: () => getAccountModule({address, moduleName}, state.aptos_client),
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountModules.ts
+++ b/src/api/hooks/useGetAccountModules.ts
@@ -11,6 +11,6 @@ export function useGetAccountModules(
 
   return useQuery<Array<Types.MoveModuleBytecode>, ResponseError>({
     queryKey: ["accountModules", {address}, state.network_value],
-    queryFn: () => getAccountModules({address}, state.network_value),
+    queryFn: () => getAccountModules({address}, state.aptos_client),
   });
 }

--- a/src/api/hooks/useGetAccountResource.ts
+++ b/src/api/hooks/useGetAccountResource.ts
@@ -24,10 +24,7 @@ export function useGetAccountResource(
   return useQuery<Types.MoveResource, ResponseError>({
     queryKey: ["accountResource", {address, resource}, state.network_value],
     queryFn: () =>
-      getAccountResource(
-        {address, resourceType: resource},
-        state.network_value,
-      ),
+      getAccountResource({address, resourceType: resource}, state.aptos_client),
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountResources.ts
+++ b/src/api/hooks/useGetAccountResources.ts
@@ -14,7 +14,7 @@ export function useGetAccountResources(
 
   return useQuery<Array<Types.MoveResource>, ResponseError>({
     queryKey: ["accountResources", {address}, state.network_value],
-    queryFn: () => getAccountResources({address}, state.network_value),
+    queryFn: () => getAccountResources({address}, state.aptos_client),
     retry: options?.retry ?? false,
   });
 }

--- a/src/api/hooks/useGetAccountTransactions.ts
+++ b/src/api/hooks/useGetAccountTransactions.ts
@@ -21,7 +21,7 @@ export function useGetAccountTransactions(
       state.network_value,
     ],
     queryFn: () =>
-      getAccountTransactions({address, start, limit}, state.network_value),
+      getAccountTransactions({address, start, limit}, state.aptos_client),
   });
 
   return accountTransactionsResult;

--- a/src/api/hooks/useGetBlock.ts
+++ b/src/api/hooks/useGetBlock.ts
@@ -16,7 +16,7 @@ export function useGetBlockByHeight({
   const result = useQuery<Types.Block, ResponseError>({
     queryKey: ["block", height, state.network_value],
     queryFn: () =>
-      getBlockByHeight({height, withTransactions}, state.network_value),
+      getBlockByHeight({height, withTransactions}, state.aptos_client),
   });
 
   return result;
@@ -34,7 +34,7 @@ export function useGetBlockByVersion({
   const result = useQuery<Types.Block, ResponseError>({
     queryKey: ["block", version, state.network_value],
     queryFn: () =>
-      getBlockByVersion({version, withTransactions}, state.network_value),
+      getBlockByVersion({version, withTransactions}, state.aptos_client),
   });
 
   return result;

--- a/src/api/hooks/useGetCoinSupplyLimit.tsx
+++ b/src/api/hooks/useGetCoinSupplyLimit.tsx
@@ -49,7 +49,7 @@ async function fetchTotalSupply(
       tableHandle: aggregatorData.handle,
       data: tableItemRequest,
     },
-    state.network_value,
+    state.aptos_client,
   );
 
   return parseInt(supplyLimit);

--- a/src/api/hooks/useGetDelegatorStakeInfo.ts
+++ b/src/api/hooks/useGetDelegatorStakeInfo.ts
@@ -1,4 +1,4 @@
-import {AptosClient, Types} from "aptos";
+import {Types} from "aptos";
 import {useState, useEffect} from "react";
 import {getStake} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -11,12 +11,18 @@ export function useGetDelegatorStakeInfo(
   const [stakes, setStakes] = useState<Types.MoveValue[]>([]);
 
   useEffect(() => {
-    const client = new AptosClient(state.network_value);
     const fetchData = async () => {
-      setStakes(await getStake(client, delegatorAddress, validatorAddress));
+      setStakes(
+        await getStake(state.aptos_client, delegatorAddress, validatorAddress),
+      );
     };
     fetchData();
-  }, [state.network_value, delegatorAddress, validatorAddress]);
+  }, [
+    state.network_value,
+    state.aptos_client,
+    delegatorAddress,
+    validatorAddress,
+  ]);
 
   return {stakes};
 }

--- a/src/api/hooks/useGetMostRecentBlocks.ts
+++ b/src/api/hooks/useGetMostRecentBlocks.ts
@@ -11,7 +11,7 @@ export function useGetMostRecentBlocks(count: number) {
 
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.network_value),
+    queryFn: () => getLedgerInfo(state.aptos_client),
   });
   const currentBlockHeight = ledgerData?.block_height;
 
@@ -21,7 +21,7 @@ export function useGetMostRecentBlocks(count: number) {
         const blocks = await getRecentBlocks(
           parseInt(currentBlockHeight),
           count,
-          state.network_value,
+          state.aptos_client,
         );
         setRecentBlocks(blocks);
         setIsLoading(false);

--- a/src/api/hooks/useGetTPS.ts
+++ b/src/api/hooks/useGetTPS.ts
@@ -12,7 +12,7 @@ export function useGetTPS() {
 
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.network_value),
+    queryFn: () => getLedgerInfo(state.aptos_client),
     refetchInterval: 10000,
   });
   const currentBlockHeight = ledgerData?.block_height;

--- a/src/api/hooks/useGetTransaction.ts
+++ b/src/api/hooks/useGetTransaction.ts
@@ -9,7 +9,7 @@ export function useGetTransaction(txnHashOrVersion: string) {
 
   const result = useQuery<Types.Transaction, ResponseError>({
     queryKey: ["transaction", {txnHashOrVersion}, state.network_value],
-    queryFn: () => getTransaction({txnHashOrVersion}, state.network_value),
+    queryFn: () => getTransaction({txnHashOrVersion}, state.aptos_client),
   });
 
   return result;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,9 +6,8 @@ import {withResponseError} from "./client";
 
 export async function getTransactions(
   requestParameters: {start?: number; limit?: number},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Transaction[]> {
-  const client = new AptosClient(nodeUrl);
   const {start, limit} = requestParameters;
   let bigStart;
   if (start !== undefined) {
@@ -26,9 +25,8 @@ export async function getTransactions(
 
 export async function getAccountTransactions(
   requestParameters: {address: string; start?: number; limit?: number},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Transaction[]> {
-  const client = new AptosClient(nodeUrl);
   const {address, start, limit} = requestParameters;
   let bigStart;
   if (start !== undefined) {
@@ -46,7 +44,7 @@ export async function getAccountTransactions(
 
 export function getTransaction(
   requestParameters: {txnHashOrVersion: string | number},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Transaction> {
   const {txnHashOrVersion} = requestParameters;
   if (typeof txnHashOrVersion === "number" || isNumeric(txnHashOrVersion)) {
@@ -54,54 +52,50 @@ export function getTransaction(
       typeof txnHashOrVersion === "number"
         ? txnHashOrVersion
         : parseInt(txnHashOrVersion);
-    return getTransactionByVersion(version, nodeUrl);
+    return getTransactionByVersion(version, client);
   } else {
-    return getTransactionByHash(txnHashOrVersion as string, nodeUrl);
+    return getTransactionByHash(txnHashOrVersion as string, client);
   }
 }
 
 function getTransactionByVersion(
   version: number,
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Transaction> {
-  const client = new AptosClient(nodeUrl);
   return withResponseError(client.getTransactionByVersion(BigInt(version)));
 }
 
 function getTransactionByHash(
   hash: string,
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Transaction> {
-  const client = new AptosClient(nodeUrl);
   return withResponseError(client.getTransactionByHash(hash));
 }
 
-export function getLedgerInfo(nodeUrl: string): Promise<Types.IndexResponse> {
-  const client = new AptosClient(nodeUrl);
+export function getLedgerInfo(
+  client: AptosClient,
+): Promise<Types.IndexResponse> {
   return withResponseError(client.getLedgerInfo());
 }
 
 export function getLedgerInfoWithoutResponseError(
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.IndexResponse> {
-  const client = new AptosClient(nodeUrl);
   return client.getLedgerInfo();
 }
 
 export function getAccount(
   requestParameters: {address: string},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.AccountData> {
-  const client = new AptosClient(nodeUrl);
   const {address} = requestParameters;
   return withResponseError(client.getAccount(address));
 }
 
 export function getAccountResources(
   requestParameters: {address: string; ledgerVersion?: number},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.MoveResource[]> {
-  const client = new AptosClient(nodeUrl);
   const {address, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion !== undefined) {
@@ -118,9 +112,8 @@ export function getAccountResource(
     resourceType: string;
     ledgerVersion?: number;
   },
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.MoveResource> {
-  const client = new AptosClient(nodeUrl);
   const {address, resourceType, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion !== undefined) {
@@ -135,9 +128,8 @@ export function getAccountResource(
 
 export function getAccountModules(
   requestParameters: {address: string; ledgerVersion?: number},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.MoveModuleBytecode[]> {
-  const client = new AptosClient(nodeUrl);
   const {address, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion !== undefined) {
@@ -154,9 +146,8 @@ export function getAccountModule(
     moduleName: string;
     ledgerVersion?: number;
   },
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.MoveModuleBytecode> {
-  const client = new AptosClient(nodeUrl);
   const {address, moduleName, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion !== undefined) {
@@ -171,10 +162,9 @@ export function getAccountModule(
 
 export function view(
   request: Types.ViewRequest,
-  nodeUrl: string,
+  client: AptosClient,
   ledgerVersion?: string,
 ): Promise<Types.MoveValue[]> {
-  const client = new AptosClient(nodeUrl);
   let parsedVersion = ledgerVersion;
 
   // Handle non-numbers, to default to the latest ledger version
@@ -187,37 +177,33 @@ export function view(
 
 export function getTableItem(
   requestParameters: {tableHandle: string; data: Types.TableItemRequest},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<any> {
-  const client = new AptosClient(nodeUrl);
   const {tableHandle, data} = requestParameters;
   return withResponseError(client.getTableItem(tableHandle, data));
 }
 
 export function getBlockByHeight(
   requestParameters: {height: number; withTransactions: boolean},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Block> {
   const {height, withTransactions} = requestParameters;
-  const client = new AptosClient(nodeUrl);
   return withResponseError(client.getBlockByHeight(height, withTransactions));
 }
 
 export function getBlockByVersion(
   requestParameters: {version: number; withTransactions: boolean},
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Block> {
   const {version, withTransactions} = requestParameters;
-  const client = new AptosClient(nodeUrl);
   return withResponseError(client.getBlockByVersion(version, withTransactions));
 }
 
 export async function getRecentBlocks(
   currentBlockHeight: number,
   count: number,
-  nodeUrl: string,
+  client: AptosClient,
 ): Promise<Types.Block[]> {
-  const client = new AptosClient(nodeUrl);
   const blocks = [];
   for (let i = 0; i < count; i++) {
     const block = await client.getBlockByHeight(currentBlockHeight - i, false);

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -16,6 +16,34 @@ export const networks = {
 
 export type NetworkName = keyof typeof networks;
 
+type ApiKeys = {
+  [key in NetworkName]: string | undefined;
+};
+
+/**
+ * Public Client IDs (API keys) from API Gateway. For mainnet, these come from the prod
+ * API Gateway (developers.aptoslabs.com), for testnet and devnet these come from the
+ * staging API Gateway (staging.developers.aptoslabs.com).
+ *
+ * These keys are all generated using the petra@aptoslabs.com account. Learn more:
+ * https://www.notion.so/aptoslabs/API-Gateway-FAQ-for-product-owners-183b29ba6bed41f8922e6049d9d36486
+ *
+ * Some networks aren't configured to use API Gateway, e.g. randomnet. For that, set the
+ * value to `undefined`.
+ */
+const apiKeys: ApiKeys = {
+  mainnet: "AG-4SNLEBS1PFZ3PCMUCA3T3MW5WWF5JWLJX",
+  testnet: "AG-6ZFXBNIVINVKOKLNAHNTFPDHY8WMBBD3X",
+  devnet: "AG-GA6I9F6H8NM1ACW8ZVJGMPUTJUKZ5KN6A",
+  local: undefined,
+  previewnet: undefined,
+  randomnet: undefined,
+};
+
+export function getApiKey(network_name: NetworkName): string | undefined {
+  return apiKeys[network_name];
+}
+
 export function isValidNetworkName(value: string): value is NetworkName {
   return value in networks;
 }

--- a/src/global-config/GlobalConfig.tsx
+++ b/src/global-config/GlobalConfig.tsx
@@ -4,6 +4,7 @@ import {
   FeatureName,
   NetworkName,
   defaultNetworkName,
+  getApiKey,
   networks,
 } from "../constants";
 import {
@@ -46,9 +47,10 @@ function deriveGlobalState({
   network_name: NetworkName;
 }): GlobalState {
   const indexerUri = getGraphqlURI(network_name);
+  const apiKey = getApiKey(network_name);
   let indexerClient = undefined;
   if (indexerUri) {
-    indexerClient = new IndexerClient(indexerUri, {HEADERS});
+    indexerClient = new IndexerClient(indexerUri, {HEADERS, TOKEN: apiKey});
   }
   return {
     feature_name,
@@ -56,13 +58,17 @@ function deriveGlobalState({
     network_value: networks[network_name],
     aptos_client: new AptosClient(networks[network_name], {
       HEADERS,
+      TOKEN: apiKey,
     }),
     indexer_client: indexerClient,
     sdk_v2_client: new Aptos(
       new AptosConfig({
         network: NetworkToNetworkName[network_name],
+        fullnode: networks[network_name],
+        indexer: indexerUri,
         clientConfig: {
           HEADERS,
+          API_KEY: apiKey,
         },
       }),
     ),

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -523,7 +523,7 @@ function ReadContractForm({
     try {
       const result = await view(
         viewRequest,
-        state.network_value,
+        state.aptos_client,
         data.ledgerVersion,
       );
       setResult(result);

--- a/src/pages/Analytics/NetworkInfo/TotalTransactions.tsx
+++ b/src/pages/Analytics/NetworkInfo/TotalTransactions.tsx
@@ -8,7 +8,7 @@ export default function TotalTransactions() {
   const [state] = useGlobalState();
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.network_value),
+    queryFn: () => getLedgerInfo(state.aptos_client),
     refetchInterval: 10000,
   });
   const ledgerVersion = ledgerData?.ledger_version;

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -10,7 +10,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import {AptosClient, Types} from "aptos";
+import {Types} from "aptos";
 import {useContext, useEffect, useState} from "react";
 import {getCanWithdrawPendingInactive} from "../../api";
 import {useGetAccountAPTBalance} from "../../api/hooks/useGetAccountAPTBalance";
@@ -286,16 +286,20 @@ function MyDepositSectionContent({
     useState<Types.MoveValue>(false);
 
   useEffect(() => {
-    const client = new AptosClient(state.network_value);
     async function fetchData() {
       const canWithdraw = await getCanWithdrawPendingInactive(
-        client,
+        state.aptos_client,
         validator!.owner_address,
       );
       setCanWithdrawPendingInactive(canWithdraw[0]);
     }
     fetchData();
-  }, [validator.owner_address, state.network_value, validator]);
+  }, [
+    validator.owner_address,
+    state.network_value,
+    state.aptos_client,
+    validator,
+  ]);
 
   function MyDepositRow({stake, status}: MyDepositRowProps) {
     const [dialogOpen, setDialogOpen] = useState<boolean>(false);

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -31,7 +31,7 @@ import useSubmitStakeOperation, {
 import {OCTA} from "../../constants";
 import {useGetDelegationState} from "../../api/hooks/useGetDelegationState";
 import {DelegationStateContext} from "./context/DelegationContext";
-import {AptosClient, Types} from "aptos";
+import {Types} from "aptos";
 import {getAddStakeFee} from "../../api";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -129,11 +129,10 @@ function StakeOperationDialogContent({
   const logEvent = useLogEventWithBasic();
 
   useEffect(() => {
-    const client = new AptosClient(state.network_value);
     async function fetchData() {
       if (stakeOperation === StakeOperation.STAKE) {
         const fee = await getAddStakeFee(
-          client,
+          state.aptos_client,
           validator!.owner_address,
           Number(amount).toFixed(8),
         );
@@ -141,7 +140,13 @@ function StakeOperationDialogContent({
       }
     }
     fetchData();
-  }, [state.network_value, amount, stakeOperation, validator]);
+  }, [
+    state.network_value,
+    state.aptos_client,
+    amount,
+    stakeOperation,
+    validator,
+  ]);
 
   const onSubmitClick = async () => {
     logEvent("submit_transaction_button_clicked", stakeOperation, {

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -24,7 +24,7 @@ import {DelegationStateContext} from "./context/DelegationContext";
 import {useGetAccountAPTBalance} from "../../api/hooks/useGetAccountAPTBalance";
 import {MINIMUM_APT_IN_POOL_FOR_EXPLORER} from "./constants";
 import {OCTA} from "../../constants";
-import {AptosClient, Types} from "aptos";
+import {Types} from "aptos";
 import {getAddStakeFee} from "../../api";
 import {useGetDelegatorStakeInfo} from "../../api/hooks/useGetDelegatorStakeInfo";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -160,17 +160,16 @@ function StakingBarContent({
         : Number(addStakeFee));
 
   useEffect(() => {
-    const client = new AptosClient(state.network_value);
     async function fetchData() {
       const fee = await getAddStakeFee(
-        client,
+        state.aptos_client,
         validator!.owner_address,
         MINIMUM_APT_IN_POOL_FOR_EXPLORER.toString(),
       );
       setAddStakeFee(fee[0]);
     }
     fetchData();
-  }, [state.network_value, balance, validator]);
+  }, [state.network_value, state.aptos_client, balance, validator]);
 
   const stakeButton = (
     <StyledTooltip

--- a/src/pages/LandingPage/TransactionsPreview.tsx
+++ b/src/pages/LandingPage/TransactionsPreview.tsx
@@ -26,7 +26,7 @@ export default function TransactionsPreview() {
   const limit = PREVIEW_LIMIT;
   const result = useQuery({
     queryKey: ["transactions", {limit}, state.network_value],
-    queryFn: () => getTransactions({limit}, state.network_value),
+    queryFn: () => getTransactions({limit}, state.aptos_client),
   });
   const augmentTo = useAugmentToWithGlobalSearchParams();
 

--- a/src/pages/Transaction/Index.tsx
+++ b/src/pages/Transaction/Index.tsx
@@ -17,7 +17,7 @@ export default function TransactionPage() {
 
   const {isLoading, data, error} = useQuery<Types.Transaction, ResponseError>({
     queryKey: ["transaction", {txnHashOrVersion}, state.network_value],
-    queryFn: () => getTransaction({txnHashOrVersion}, state.network_value),
+    queryFn: () => getTransaction({txnHashOrVersion}, state.aptos_client),
   });
 
   if (isLoading) {

--- a/src/pages/Transactions/AllTransactions.tsx
+++ b/src/pages/Transactions/AllTransactions.tsx
@@ -85,7 +85,7 @@ function TransactionsPageInner({data}: UseQueryResult<Types.IndexResponse>) {
 
   const result = useQuery({
     queryKey: ["transactions", {start, limit}, state.network_value],
-    queryFn: () => getTransactions({start, limit}, state.network_value),
+    queryFn: () => getTransactions({start, limit}, state.aptos_client),
     placeholderData: keepPreviousData,
   });
 
@@ -115,7 +115,7 @@ export default function AllTransactions() {
 
   const result = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.network_value),
+    queryFn: () => getLedgerInfo(state.aptos_client),
     refetchInterval: 10000,
   });
 

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -102,7 +102,7 @@ export default function HeaderSearch() {
         // It's either an account OR an object: we query both at once to save time
         const accountPromise = await getAccount(
           {address: searchText},
-          state.network_value,
+          state.aptos_client,
         )
           .then((): SearchResult => {
             return {
@@ -117,7 +117,7 @@ export default function HeaderSearch() {
 
         const resourcePromise = await getAccountResources(
           {address: searchText},
-          state.network_value,
+          state.aptos_client,
         )
           .then((resources): SearchResult | undefined => {
             let hasObjectCore = false;
@@ -144,7 +144,7 @@ export default function HeaderSearch() {
       if (isValidTxnHashOrVer) {
         const txnPromise = getTransaction(
           {txnHashOrVersion: searchText},
-          state.network_value,
+          state.aptos_client,
         )
           .then((): SearchResult => {
             return {
@@ -162,7 +162,7 @@ export default function HeaderSearch() {
       if (isValidBlockHeightOrVer) {
         const blockByHeightPromise = getBlockByHeight(
           {height: parseInt(searchText), withTransactions: false},
-          state.network_value,
+          state.aptos_client,
         )
           .then((): SearchResult => {
             return {
@@ -177,7 +177,7 @@ export default function HeaderSearch() {
 
         const blockByVersionPromise = getBlockByVersion(
           {version: parseInt(searchText), withTransactions: false},
-          state.network_value,
+          state.aptos_client,
         )
           .then((block): SearchResult => {
             return {


### PR DESCRIPTION
## Summary
We want to make the explorer start attaching API keys to requests to API Gateway. This way we can identify the traffic more easily and do other smart things to be discussed elsewhere.

While here I also address some misconfiguration where the v2 TS SDK client is created using the default URLs, rather than the URLS in `networks` and `getGraphqlURI` like we want.

I also make the hooks use the pre-existing client rather than build a new one, since the new clients were made without any of the intended configuration. I make the ApolloClient include a key too (woof we build clients in lots of places).

Further context: https://aptos-org.slack.com/archives/C040LV2NWQ4/p1718884516800459.

I gave the keys effectively unlimited ratelimit (2 billion requests per 5 minutes). Each IP is still subject to the usual ratelimit.

## Test Plan
I ran the explorer locally as per the README (and built) and saw that all requests now go to the correct APIs and have the key attached. I tested that both networks with keys and those without (e.g. localnet) work.