### PR TITLE
Fix useGetChainIdAndCache

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -79,8 +79,12 @@ export function getLedgerInfo(
 }
 
 export function getLedgerInfoWithoutResponseError(
-  client: AptosClient,
+  nodeUrl: string,
 ): Promise<Types.IndexResponse> {
+  // This is a special case where we don't use the pre-existing client. This means we
+  // do not attach an API key to the request, but it's okay for just this request to be
+  // sent anonymously.
+  const client = new AptosClient(nodeUrl);
   return client.getLedgerInfo();
 }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -5,7 +5,7 @@ export const devnetUrl =
   import.meta.env.APTOS_DEVNET_URL ||
   "https://api-staging.devnet.aptoslabs.com/v1";
 
-export const networks = {
+export const networks: Record<string, string> = {
   mainnet: "https://api.mainnet.aptoslabs.com/v1",
   testnet: "https://api-staging.testnet.aptoslabs.com/v1",
   devnet: devnetUrl,


### PR DESCRIPTION
This fixes the bug with the dropdown not loading up all the networks: https://aptos-org.slack.com/archives/C040LV2NWQ4/p1718911297644989?thread_ts=1718884516.800459&cid=C040LV2NWQ4.

The typechecker did not catch that I was passing a string where a client was required, something about `[]` into an object I guess doesn't result in a strong type. The new type bound I added on `networks` makes the previous bug an actual type checking error. This helped me confirm there are no other issues similar to this still floating around.