### PR TITLE
[refactor] Upgrade to SDK v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@apollo/client": "^3.8.9",
     "@aptos-labs/aptos-names-connector": "^0.0.2",
-    "@aptos-labs/ts-sdk": "1.19.0",
-    "@aptos-labs/wallet-adapter-mui-design": "^2.9.1",
-    "@aptos-labs/wallet-adapter-react": "^3.4.1",
+    "@aptos-labs/ts-sdk": "1.22.2",
+    "@aptos-labs/wallet-adapter-mui-design": "^2.9.2",
+    "@aptos-labs/wallet-adapter-react": "^3.4.2",
     "@bitget-wallet/aptos-wallet-adapter": "^0.1.2",
     "@blocto/aptos-wallet-adapter-plugin": "^0.2.8",
     "@download/blockies": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,14 +19,14 @@ dependencies:
     specifier: ^0.0.2
     version: 0.0.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.48)(react-copy-to-clipboard@5.1.0)(react-dom@18.2.0)(react@18.2.0)
   "@aptos-labs/ts-sdk":
-    specifier: 1.19.0
-    version: 1.19.0
+    specifier: 1.22.2
+    version: 1.22.2
   "@aptos-labs/wallet-adapter-mui-design":
-    specifier: ^2.9.1
-    version: 2.9.1(@aptos-labs/ts-sdk@1.19.0)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react-dom@18.2.0)(react-router-dom@6.21.3)(react@18.2.0)
+    specifier: ^2.9.2
+    version: 2.9.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react-dom@18.2.0)(react-router-dom@6.21.3)(react@18.2.0)
   "@aptos-labs/wallet-adapter-react":
-    specifier: ^3.4.1
-    version: 3.4.1(@aptos-labs/ts-sdk@1.19.0)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0)
+    specifier: ^3.4.2
+    version: 3.4.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0)
   "@bitget-wallet/aptos-wallet-adapter":
     specifier: ^0.1.2
     version: 0.1.2(@aptos-labs/wallet-adapter-core@3.5.0)(aptos@1.21.0)
@@ -47,7 +47,7 @@ dependencies:
     version: 0.0.5
   "@msafe/aptos-wallet-adapter":
     specifier: ^1.1.3
-    version: 1.1.3(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
+    version: 1.1.3(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
   "@mui/icons-material":
     specifier: ^5.15.4
     version: 5.15.5(@mui/material@5.15.5)(@types/react@18.2.48)(react@18.2.0)
@@ -308,7 +308,7 @@ packages:
       zen-observable-ts: 1.2.5
     dev: false
 
-  /@aptos-connect/wallet-adapter-plugin@1.0.0(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@aptos-connect/wallet-adapter-plugin@1.0.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-9Mii1izvp8xp5eDSUZIotSWfoUDGvngkDJ4qPspUzLEFLy44iftTpNbcM1P/J+G7lBU6XvtIgCLLmppt3Hiqhg==,
@@ -318,18 +318,39 @@ packages:
       "@aptos-labs/wallet-standard": ^0.1.0
       aptos: ^1.21.0
     dependencies:
-      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-labs/ts-sdk": 1.19.0
-      "@aptos-labs/wallet-adapter-core": 3.12.0(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0)
-      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
-      "@identity-connect/crypto": 0.2.3(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@identity-connect/dapp-sdk": 0.9.0(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-adapter-core": 3.12.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
+      "@identity-connect/crypto": 0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@identity-connect/dapp-sdk": 0.9.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
       aptos: 1.21.0
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@aptos-connect/wallet-adapter-plugin@1.0.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution:
+      {
+        integrity: sha512-yrnzO9gWMPqhgV0hz3Qv9XP98hefX/V7Pcj911SLM3NWktc+mL/5CW6BKz4VKcqnhewotd2Tek43VDZTSHKoeQ==,
+      }
+    peerDependencies:
+      "@aptos-labs/ts-sdk": 1.18.1
+      "@aptos-labs/wallet-standard": ^0.1.0
+      aptos: ^1.21.0
+    dependencies:
+      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-adapter-core": 3.12.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
+      "@identity-connect/crypto": 0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@identity-connect/dapp-sdk": 0.9.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      aptos: 1.21.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-If666Wz7m+ZK/RzDhm5Wy3oDkhnv14wKHW0jEVtXtHwTzYEgaOdC92RhZHqzPAqysipKSatBJJNVk58PzJLAUQ==,
@@ -339,13 +360,13 @@ packages:
       "@aptos-labs/wallet-standard": ^0.1.0
       aptos: ^1.20.0
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
-      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
       "@identity-connect/api": 0.6.1
       aptos: 1.21.0
     dev: false
 
-  /@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-4dYv/696bEZc75041ewKsWxg48/dTEDqP0TpIfK3KndGepKWDM9q3Lj8iZo+8Z9nhzxwulEqiAO7c0nvzXxVFA==,
@@ -355,17 +376,17 @@ packages:
       "@aptos-labs/wallet-standard": ^0.1.0
       aptos: ^1.20.0
     dependencies:
-      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-labs/ts-sdk": 1.19.0
-      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
+      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
       aptos: 1.21.0
       uuid: 9.0.1
     dev: false
 
-  /@aptos-labs/aptos-cli@0.1.2:
+  /@aptos-labs/aptos-cli@0.1.9:
     resolution:
       {
-        integrity: sha512-MCi+9xPDG/Fx6c6b9ACqyQBYJLHqKJQKB8lay/1sUNJ2mNBB2OU1Lkmd5pmjUG1JbZ5cg2Fmgid5iMKdTnphhA==,
+        integrity: sha512-76uPNZ6JrpruN9H8bEU37GVhAHwdhmvp7ZXpMTFnlFOJnBYt0LHCxR3x+HCk4WZ1CRrPQ57lmO+5A58PiGuweA==,
       }
     hasBin: true
     dev: false
@@ -424,14 +445,14 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/ts-sdk@1.19.0:
+  /@aptos-labs/ts-sdk@1.22.2:
     resolution:
       {
-        integrity: sha512-ReTQNh1heap8VpK9Js4FVUVflRs/zSol+jtMDFwHk6IY7eNkdtVck9rqp17/vghBGkQw7b0YZERFOz0UdcE5zA==,
+        integrity: sha512-EUGFT6Emyrc8xqBxZB7fO6Xha98+Q3WWJNw56IOVbiMYaga5w7Dzj8rTYYHxvxyBfEbnNQHn4QcQfaciU2N4qA==,
       }
     engines: {node: ">=11.0.0"}
     dependencies:
-      "@aptos-labs/aptos-cli": 0.1.2
+      "@aptos-labs/aptos-cli": 0.1.9
       "@aptos-labs/aptos-client": 0.1.0
       "@noble/curves": 1.4.0
       "@noble/hashes": 1.4.0
@@ -517,7 +538,7 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-core@3.12.0(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0):
+  /@aptos-labs/wallet-adapter-core@3.12.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-ck8z8Zqq9mjXLHWJwjyz/6yu0vcc9lDzSLQxAfQ+RjYQbN+V33Br/r99ZdWYLK628/iH9kOgOG2AAxUqph9Iqg==,
@@ -526,7 +547,7 @@ packages:
       "@aptos-labs/ts-sdk": ^1.13.2
       aptos: ^1.21.0
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       "@aptos-labs/wallet-standard": 0.0.11
       aptos: 1.21.0
       buffer: 6.0.3
@@ -536,7 +557,7 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-core@3.5.0(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0):
+  /@aptos-labs/wallet-adapter-core@3.5.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-aA2kND9ikLOVx8yMS804S/atLZqmPe+Ldw/v9yG5osTHm+samv9H1NBha0rRGvArndeBcN4dGl9C/nc/SXyNcQ==,
@@ -545,14 +566,14 @@ packages:
       "@aptos-labs/ts-sdk": ^1.3.0
       aptos: ^1.21.0
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       aptos: 1.21.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
     dev: false
 
-  /@aptos-labs/wallet-adapter-core@4.8.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
+  /@aptos-labs/wallet-adapter-core@4.8.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-gQXQmi0zlNnsMDmVQv/3bUAYJ3rYxg0xHzzr8hmQ8+qwb4WyCCqHOh3g5CnszSJfktP4sZI2OSaUv4ba8K7cMA==,
@@ -561,10 +582,10 @@ packages:
       "@aptos-labs/ts-sdk": ^1.18.1
       aptos: ^1.21.0
     dependencies:
-      "@aptos-connect/wallet-adapter-plugin": 1.0.0(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-labs/ts-sdk": 1.19.0
-      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
-      "@atomrigslab/aptos-wallet-adapter": 0.1.12(@aptos-labs/ts-sdk@1.19.0)
+      "@aptos-connect/wallet-adapter-plugin": 1.0.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
+      "@atomrigslab/aptos-wallet-adapter": 0.1.12(@aptos-labs/ts-sdk@1.22.2)
       aptos: 1.21.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
@@ -574,17 +595,39 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-mui-design@2.9.1(@aptos-labs/ts-sdk@1.19.0)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react-dom@18.2.0)(react-router-dom@6.21.3)(react@18.2.0):
+  /@aptos-labs/wallet-adapter-core@4.8.2(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
     resolution:
       {
-        integrity: sha512-A4FPzdaKdDzw9lQt/fmmErd7wKIcBu3Ehxu17r06mq8BcZjXV2pLYPsIc4buAYLHxIFFgNCqFWPPKff5YVQaTw==,
+        integrity: sha512-sbAJcBvXCtE/4hBBdG1zviwmaYVusstDLiCE1gzdGI8Fa4BoqykHhpkWTEJtsCrxKMNZc08A6ZszkkxaOaG/tw==,
+      }
+    peerDependencies:
+      "@aptos-labs/ts-sdk": ^1.18.1
+      aptos: ^1.21.0
+    dependencies:
+      "@aptos-connect/wallet-adapter-plugin": 1.0.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
+      "@atomrigslab/aptos-wallet-adapter": 0.1.12(@aptos-labs/ts-sdk@1.22.2)
+      aptos: 1.21.0
+      buffer: 6.0.3
+      eventemitter3: 4.0.7
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - "@wallet-standard/core"
+      - debug
+    dev: false
+
+  /@aptos-labs/wallet-adapter-mui-design@2.9.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react-dom@18.2.0)(react-router-dom@6.21.3)(react@18.2.0):
+    resolution:
+      {
+        integrity: sha512-KKiZVpPvd1gO4+Lh75OFIY6cXhpJLuwWoYXRF9LymaIVWwqgAgHJsCfhOOXWnZe4DsI6iw05ap8E6gu4qQ9Apg==,
       }
     peerDependencies:
       react: ^18
       react-dom: ^18
       react-router-dom: ^6.8.0
     dependencies:
-      "@aptos-labs/wallet-adapter-react": 3.4.1(@aptos-labs/ts-sdk@1.19.0)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0)
+      "@aptos-labs/wallet-adapter-react": 3.4.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0)
       "@emotion/react": 11.11.3(@types/react@18.2.48)(react@18.2.0)
       "@emotion/styled": 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.48)(react@18.2.0)
       "@mui/icons-material": 5.15.5(@mui/material@5.15.5)(@types/react@18.2.48)(react@18.2.0)
@@ -600,15 +643,15 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-react@3.4.1(@aptos-labs/ts-sdk@1.19.0)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0):
+  /@aptos-labs/wallet-adapter-react@3.4.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.2.48)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.2.0):
     resolution:
       {
-        integrity: sha512-cGQqi06M//z+RvEQz9DiI9MUEACMEGxm8oU91AC4TiNh9N6gxFL1SVSmFY7OaSbqeWwbS6Qoux9WQ78Amd0KTw==,
+        integrity: sha512-AFJC1gQLG1Kku939fFlWcKw1LskbPQ8HkSdF5kCqBD2W++jOI59LlsYbgOVUmXsIK8YmLoDtDZ4Jwxf5SAjDCw==,
       }
     peerDependencies:
       react: ^18
     dependencies:
-      "@aptos-labs/wallet-adapter-core": 4.8.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      "@aptos-labs/wallet-adapter-core": 4.8.2(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       "@radix-ui/react-slot": 1.0.2(@types/react@18.2.48)(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
@@ -625,13 +668,13 @@ packages:
         integrity: sha512-8dygyPBby7TaMJjUSyeVP4R1WC9D/FPpX9gVMMLaqTKCXrSbkzhGDxcuwbMZ3ziEwRmx3zz+d6BIJbDhd0hm5g==,
       }
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       "@wallet-standard/core": 1.0.3
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3):
+  /@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3):
     resolution:
       {
         integrity: sha512-DC4cWuvgXKBVQC+seGQc/nwIZoggZmGOIoN8EtEKHBSBMijwVfgRjD6cXPx8xWaXANyr5d32BGnWvYfMyWk3Pg==,
@@ -640,11 +683,11 @@ packages:
       "@aptos-labs/ts-sdk": ^1.17.0
       "@wallet-standard/core": ^1.0.3
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       "@wallet-standard/core": 1.0.3
     dev: false
 
-  /@atomrigslab/aptos-wallet-adapter@0.1.12(@aptos-labs/ts-sdk@1.19.0):
+  /@atomrigslab/aptos-wallet-adapter@0.1.12(@aptos-labs/ts-sdk@1.22.2):
     resolution:
       {
         integrity: sha512-fxkinFLitXaq7UDtfA4BgFMW4DL9dg/tHI14Du7a+tGHUL2cCmUhRIS29X6gsAiPUNHE/gsrDODvcU1QdE1dWQ==,
@@ -652,7 +695,7 @@ packages:
     peerDependencies:
       "@aptos-labs/ts-sdk": ^1.9.0
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       "@aptos-labs/wallet-standard": 0.0.11
       "@atomrigslab/dekey-web-wallet-provider": 1.2.0
     transitivePeerDependencies:
@@ -1172,7 +1215,7 @@ packages:
       "@aptos-labs/wallet-adapter-core": 3.5.0
       aptos: ^1.21.0
     dependencies:
-      "@aptos-labs/wallet-adapter-core": 3.5.0(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0)
+      "@aptos-labs/wallet-adapter-core": 3.5.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
       aptos: 1.21.0
     dev: false
 
@@ -2015,7 +2058,7 @@ packages:
       }
     dev: false
 
-  /@identity-connect/crypto@0.2.3(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@identity-connect/crypto@0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-HJmsNz4YeJg/BFgu94x9cbNUrlKTmk50yVuoF2Ry1+SwC2c6Vhy2CeaZa1SeevjHsk9hjSrqk42q+EZMZAuaJA==,
@@ -2023,8 +2066,8 @@ packages:
     peerDependencies:
       "@aptos-labs/ts-sdk": 1.18.1
     dependencies:
-      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
       "@noble/hashes": 1.4.0
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -2033,7 +2076,7 @@ packages:
       - aptos
     dev: false
 
-  /@identity-connect/dapp-sdk@0.9.0(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@identity-connect/dapp-sdk@0.9.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-EYB9PMyEagt3PCjJTwX3V34vyXi/asj7dAD22rvUJarlx+TIRPYODxTWoUR2jc7F9Q83cZbU7Iv/EL77diqYYQ==,
@@ -2042,13 +2085,13 @@ packages:
       "@aptos-labs/ts-sdk": 1.18.1
       "@aptos-labs/wallet-standard": ^0.1.0
     dependencies:
-      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-connect/web-transport": 0.0.7(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@aptos-labs/ts-sdk": 1.19.0
-      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)
+      "@aptos-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-connect/web-transport": 0.0.7(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@aptos-labs/ts-sdk": 1.22.2
+      "@aptos-labs/wallet-standard": 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
       "@identity-connect/api": 0.6.1
-      "@identity-connect/crypto": 0.2.3(@aptos-labs/ts-sdk@1.19.0)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      "@identity-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0)
+      "@identity-connect/crypto": 0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      "@identity-connect/wallet-api": 0.1.1(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
       axios: 1.6.5
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -2056,7 +2099,7 @@ packages:
       - debug
     dev: false
 
-  /@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0):
+  /@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0):
     resolution:
       {
         integrity: sha512-PGcJQrSnk6PLr/w5D1FKRP/Ip0DH8nvDuWe/5ZfStrGwKhG0L8yDZPbAmDfSOH2mUvVtafmayRYv/FOnqGtLLw==,
@@ -2065,7 +2108,7 @@ packages:
       "@aptos-labs/ts-sdk": 1.18.1
       aptos: ^1.20.0
     dependencies:
-      "@aptos-labs/ts-sdk": 1.19.0
+      "@aptos-labs/ts-sdk": 1.22.2
       aptos: 1.21.0
     dev: false
 
@@ -2329,13 +2372,13 @@ packages:
       }
     dev: false
 
-  /@msafe/aptos-wallet-adapter@1.1.3(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3):
+  /@msafe/aptos-wallet-adapter@1.1.3(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3):
     resolution:
       {
         integrity: sha512-/5ftbNac9j2Vc6YOqET4IdkhiJnMzuy9LcnGP8ptLWHVuye5P/pAjIpv0A07gOM4/siUJQzlXkBxXdLYF9p8wQ==,
       }
     dependencies:
-      "@aptos-labs/wallet-adapter-core": 4.8.0(@aptos-labs/ts-sdk@1.19.0)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      "@aptos-labs/wallet-adapter-core": 4.8.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       "@msafe/aptos-wallet": 6.1.1
       aptos: 1.21.0
     transitivePeerDependencies:
@@ -2873,11 +2916,11 @@ packages:
     engines: {node: ">=16"}
     dependencies:
       "@mysten/bcs": 0.7.3
-      "@noble/curves": 1.3.0
-      "@noble/hashes": 1.3.3
+      "@noble/curves": 1.4.0
+      "@noble/hashes": 1.4.0
       "@open-rpc/client-js": 1.8.1
-      "@scure/bip32": 1.3.3
-      "@scure/bip39": 1.2.2
+      "@scure/bip32": 1.4.0
+      "@scure/bip39": 1.3.0
       "@suchipi/femver": 1.0.0
       events: 3.3.0
       superstruct: 1.0.3
@@ -3023,7 +3066,7 @@ packages:
       "@aptos-labs/wallet-adapter-core": 3.5.0
       aptos: ^1.21.0
     dependencies:
-      "@aptos-labs/wallet-adapter-core": 3.5.0(@aptos-labs/ts-sdk@1.19.0)(aptos@1.21.0)
+      "@aptos-labs/wallet-adapter-core": 3.5.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
       aptos: 1.21.0
     dev: false
 
@@ -3346,7 +3389,7 @@ packages:
     dependencies:
       "@noble/curves": 1.1.0
       "@noble/hashes": 1.3.3
-      "@scure/base": 1.1.5
+      "@scure/base": 1.1.6
     dev: false
 
   /@scure/bip32@1.3.3:

--- a/src/api/hooks/useGetAccount.ts
+++ b/src/api/hooks/useGetAccount.ts
@@ -1,8 +1,8 @@
-import {Types} from "aptos";
 import {useQuery} from "@tanstack/react-query";
 import {getAccount} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, AccountData} from "@aptos-labs/ts-sdk";
 
 export function useGetAccount(
   address: string,
@@ -10,9 +10,10 @@ export function useGetAccount(
 ) {
   const [state] = useGlobalState();
 
-  const result = useQuery<Types.AccountData, ResponseError>({
+  const result = useQuery<AccountData, ResponseError>({
     queryKey: ["account", {address}, state.network_value],
-    queryFn: () => getAccount({address}, state.aptos_client),
+    queryFn: () =>
+      getAccount({address: AccountAddress.from(address)}, state.sdk_v2_client),
     retry: options?.retry ?? false,
   });
 

--- a/src/api/hooks/useGetAccountAPTBalance.ts
+++ b/src/api/hooks/useGetAccountAPTBalance.ts
@@ -1,4 +1,3 @@
-import {Types} from "aptos";
 import {useGetAccountResources} from "./useGetAccountResources";
 
 interface CoinStore {
@@ -7,7 +6,7 @@ interface CoinStore {
   };
 }
 
-export function useGetAccountAPTBalance(address: Types.Address) {
+export function useGetAccountAPTBalance(address: string) {
   const {isLoading, data, error} = useGetAccountResources(address);
 
   if (isLoading || error || !data) {

--- a/src/api/hooks/useGetAccountModule.ts
+++ b/src/api/hooks/useGetAccountModule.ts
@@ -1,18 +1,22 @@
-import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import {getAccountModule} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, MoveModuleBytecode} from "@aptos-labs/ts-sdk";
 
 export function useGetAccountModule(
   address: string,
   moduleName: string,
-): UseQueryResult<Types.MoveModuleBytecode, ResponseError> {
+): UseQueryResult<MoveModuleBytecode, ResponseError> {
   const [state] = useGlobalState();
 
-  return useQuery<Types.MoveModuleBytecode, ResponseError>({
+  return useQuery<MoveModuleBytecode, ResponseError>({
     queryKey: ["accountModule", {address, moduleName}, state.network_value],
-    queryFn: () => getAccountModule({address, moduleName}, state.aptos_client),
+    queryFn: () =>
+      getAccountModule(
+        {address: AccountAddress.from(address), moduleName},
+        state.sdk_v2_client,
+      ),
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountModules.ts
+++ b/src/api/hooks/useGetAccountModules.ts
@@ -1,16 +1,20 @@
-import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import {getAccountModules} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, MoveModuleBytecode} from "@aptos-labs/ts-sdk";
 
 export function useGetAccountModules(
   address: string,
-): UseQueryResult<Types.MoveModuleBytecode[], ResponseError> {
+): UseQueryResult<MoveModuleBytecode[], ResponseError> {
   const [state] = useGlobalState();
 
-  return useQuery<Array<Types.MoveModuleBytecode>, ResponseError>({
+  return useQuery<Array<MoveModuleBytecode>, ResponseError>({
     queryKey: ["accountModules", {address}, state.network_value],
-    queryFn: () => getAccountModules({address}, state.aptos_client),
+    queryFn: () =>
+      getAccountModules(
+        {address: AccountAddress.from(address)},
+        state.sdk_v2_client,
+      ),
   });
 }

--- a/src/api/hooks/useGetAccountResource.ts
+++ b/src/api/hooks/useGetAccountResource.ts
@@ -1,9 +1,9 @@
-import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import {getAccountResource} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {orderBy} from "lodash";
+import {AccountAddress, MoveResource} from "@aptos-labs/ts-sdk";
 
 export type ModuleMetadata = {
   name: string;
@@ -18,13 +18,16 @@ export type PackageMetadata = {
 export function useGetAccountResource(
   address: string,
   resource: string,
-): UseQueryResult<Types.MoveResource, ResponseError> {
+): UseQueryResult<MoveResource, ResponseError> {
   const [state] = useGlobalState();
 
-  return useQuery<Types.MoveResource, ResponseError>({
+  return useQuery<MoveResource, ResponseError>({
     queryKey: ["accountResource", {address, resource}, state.network_value],
     queryFn: () =>
-      getAccountResource({address, resourceType: resource}, state.aptos_client),
+      getAccountResource(
+        {address: AccountAddress.from(address), resourceType: resource},
+        state.sdk_v2_client,
+      ),
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountResources.ts
+++ b/src/api/hooks/useGetAccountResources.ts
@@ -1,20 +1,24 @@
-import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import {getAccountResources} from "../../api";
 import {ResponseError} from "../../api/client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, MoveResource} from "@aptos-labs/ts-sdk";
 
 export function useGetAccountResources(
   address: string,
   options?: {
     retry?: number | boolean;
   },
-): UseQueryResult<Types.MoveResource[], ResponseError> {
+): UseQueryResult<MoveResource[], ResponseError> {
   const [state] = useGlobalState();
 
-  return useQuery<Array<Types.MoveResource>, ResponseError>({
+  return useQuery<Array<MoveResource>, ResponseError>({
     queryKey: ["accountResources", {address}, state.network_value],
-    queryFn: () => getAccountResources({address}, state.aptos_client),
+    queryFn: () =>
+      getAccountResources(
+        {address: AccountAddress.from(address)},
+        state.sdk_v2_client,
+      ),
     retry: options?.retry ?? false,
   });
 }

--- a/src/api/hooks/useGetAccountTransactions.ts
+++ b/src/api/hooks/useGetAccountTransactions.ts
@@ -1,18 +1,18 @@
-import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import {getAccountTransactions} from "..";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, TransactionResponse} from "@aptos-labs/ts-sdk";
 
 export function useGetAccountTransactions(
   address: string,
   start?: number,
   limit?: number,
-): UseQueryResult<Array<Types.Transaction>, ResponseError> {
+): UseQueryResult<Array<TransactionResponse>, ResponseError> {
   const [state] = useGlobalState();
 
   const accountTransactionsResult = useQuery<
-    Array<Types.Transaction>,
+    Array<TransactionResponse>,
     ResponseError
   >({
     queryKey: [
@@ -21,7 +21,10 @@ export function useGetAccountTransactions(
       state.network_value,
     ],
     queryFn: () =>
-      getAccountTransactions({address, start, limit}, state.aptos_client),
+      getAccountTransactions(
+        {address: AccountAddress.from(address), start, limit},
+        state.sdk_v2_client,
+      ),
   });
 
   return accountTransactionsResult;

--- a/src/api/hooks/useGetBlock.ts
+++ b/src/api/hooks/useGetBlock.ts
@@ -1,8 +1,8 @@
-import {Types} from "aptos";
 import {useQuery} from "@tanstack/react-query";
 import {getBlockByHeight, getBlockByVersion} from "../../api";
 import {ResponseError} from "../../api/client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {Block} from "@aptos-labs/ts-sdk";
 
 export function useGetBlockByHeight({
   height,
@@ -13,10 +13,10 @@ export function useGetBlockByHeight({
 }) {
   const [state] = useGlobalState();
 
-  const result = useQuery<Types.Block, ResponseError>({
+  const result = useQuery<Block, ResponseError>({
     queryKey: ["block", height, state.network_value],
     queryFn: () =>
-      getBlockByHeight({height, withTransactions}, state.aptos_client),
+      getBlockByHeight({height, withTransactions}, state.sdk_v2_client),
   });
 
   return result;
@@ -31,10 +31,10 @@ export function useGetBlockByVersion({
 }) {
   const [state] = useGlobalState();
 
-  const result = useQuery<Types.Block, ResponseError>({
+  const result = useQuery<Block, ResponseError>({
     queryKey: ["block", version, state.network_value],
     queryFn: () =>
-      getBlockByVersion({version, withTransactions}, state.aptos_client),
+      getBlockByVersion({version, withTransactions}, state.sdk_v2_client),
   });
 
   return result;

--- a/src/api/hooks/useGetCoinSupplyLimit.tsx
+++ b/src/api/hooks/useGetCoinSupplyLimit.tsx
@@ -1,8 +1,8 @@
 import {GlobalState, useGlobalState} from "../../global-config/GlobalConfig";
 import {getTableItem} from "..";
-import {Types} from "aptos";
 import {useEffect, useState} from "react";
 import {useGetAccountResource} from "./useGetAccountResource";
+import {TableItemRequest} from "@aptos-labs/ts-sdk";
 
 interface CoinInfo {
   decimals: number;
@@ -42,14 +42,14 @@ async function fetchTotalSupply(
     key_type: "address",
     value_type: "u128",
     key: aggregatorData.key,
-  } as Types.TableItemRequest;
+  } as TableItemRequest;
 
   const supplyLimit = await getTableItem(
     {
       tableHandle: aggregatorData.handle,
       data: tableItemRequest,
     },
-    state.aptos_client,
+    state.sdk_v2_client,
   );
 
   return parseInt(supplyLimit);

--- a/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
+++ b/src/api/hooks/useGetDelegatedStakeOperationActivities.ts
@@ -1,13 +1,12 @@
 import {ApolloError, gql, useQuery as useGraphqlQuery} from "@apollo/client";
-import {Types} from "aptos";
 import {normalizeAddress} from "../../utils";
 
 export interface DelegatedStakingActivity {
   amount: number;
-  delegator_address: Types.Address;
+  delegator_address: string;
   event_index: number;
   event_type: string;
-  pool_address: Types.Address;
+  pool_address: string;
   transaction_version: bigint;
 }
 
@@ -34,8 +33,8 @@ const DELEGATED_STAKING_ACTIVITY_QUERY = gql`
 `;
 
 export function useGetDelegatedStakeOperationActivities(
-  delegatorAddress: Types.Address,
-  poolAddress: Types.Address,
+  delegatorAddress: string,
+  poolAddress: string,
 ): {
   activities: DelegatedStakingActivity[] | undefined;
   loading: boolean;

--- a/src/api/hooks/useGetDelegationNodeCommissionChange.ts
+++ b/src/api/hooks/useGetDelegationNodeCommissionChange.ts
@@ -1,9 +1,8 @@
 import {useQuery} from "@tanstack/react-query";
-import {Types} from "aptos";
 import {getValidatorCommissionChange} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {ResponseError} from "../client";
-import {MoveValue} from "aptos/src/generated";
+import {MoveValue} from "@aptos-labs/ts-sdk";
 
 type DelegationNodeInfoResponse = {
   nextCommission: number | undefined;
@@ -12,15 +11,15 @@ type DelegationNodeInfoResponse = {
 };
 
 type DelegationNodeInfoProps = {
-  validatorAddress: Types.Address;
+  validatorAddress: string;
 };
 
 export function useGetDelegationNodeCommissionChange({
   validatorAddress,
 }: DelegationNodeInfoProps): DelegationNodeInfoResponse {
-  const [{aptos_client: client}] = useGlobalState();
+  const [{sdk_v2_client: client}] = useGlobalState();
 
-  const query = useQuery<Types.MoveValue[], ResponseError, number>({
+  const query = useQuery<MoveValue[], ResponseError, number>({
     queryKey: ["validatorCommissionChange", client, validatorAddress],
     queryFn: () => getValidatorCommissionChange(client, validatorAddress),
     select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285

--- a/src/api/hooks/useGetDelegationNodeInfo.ts
+++ b/src/api/hooks/useGetDelegationNodeInfo.ts
@@ -1,37 +1,36 @@
 import {useQuery} from "@tanstack/react-query";
-import {Types} from "aptos";
 import {getValidatorCommission, getValidatorState} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {ResponseError} from "../client";
 import {combineQueries} from "../query-utils";
-import {MoveValue} from "aptos/src/generated";
+import {MoveValue} from "@aptos-labs/ts-sdk";
 
 type DelegationNodeInfoResponse = {
   commission: number | undefined;
   isQueryLoading: boolean;
-  validatorStatus: Types.MoveValue[] | undefined;
+  validatorStatus: MoveValue[] | undefined;
   error: ResponseError | null;
 };
 
 type DelegationNodeInfoProps = {
-  validatorAddress: Types.Address;
+  validatorAddress: string;
 };
 
 export function useGetDelegationNodeInfo({
   validatorAddress,
 }: DelegationNodeInfoProps): DelegationNodeInfoResponse {
-  const [{aptos_client: client}] = useGlobalState();
+  const [{sdk_v2_client: client}] = useGlobalState();
 
   const {
     combinedQueryState,
     queries: [validatorCommissionQuery, validatorStateQuery],
   } = combineQueries([
-    useQuery<Types.MoveValue[], ResponseError, number>({
+    useQuery<MoveValue[], ResponseError, number>({
       queryKey: ["validatorCommission", client, validatorAddress],
       queryFn: () => getValidatorCommission(client, validatorAddress),
       select: (res: MoveValue[]) => Number(res ? res[0] : 0) / 100, // commission rate: 22.85% is represented as 2285
     }),
-    useQuery<Types.MoveValue[], ResponseError>({
+    useQuery<MoveValue[], ResponseError>({
       queryKey: ["validatorState", client, validatorAddress],
       queryFn: () => getValidatorState(client, validatorAddress),
     }),

--- a/src/api/hooks/useGetDelegationState.tsx
+++ b/src/api/hooks/useGetDelegationState.tsx
@@ -1,10 +1,10 @@
-import {Types} from "aptos";
 import {ValidatorData} from "./useGetValidators";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {getLockedUtilSecs} from "../../pages/DelegatoryValidator/utils";
 import {useGetAccountAPTBalance} from "./useGetAccountAPTBalance";
 import {useGetNumberOfDelegators} from "./useGetNumberOfDelegators";
 import {useGetStakingRewardsRate} from "./useGetStakingRewardsRate";
+import {MoveResource} from "@aptos-labs/ts-sdk";
 
 export type DelegationState = {
   lockedUntilSecs: bigint | null;
@@ -14,7 +14,7 @@ export type DelegationState = {
 };
 
 export function useGetDelegationState(
-  accountResource: Types.MoveResource,
+  accountResource: MoveResource,
   validator: ValidatorData,
 ): DelegationState {
   const {account} = useWallet();

--- a/src/api/hooks/useGetDelegatorStakeInfo.ts
+++ b/src/api/hooks/useGetDelegatorStakeInfo.ts
@@ -1,25 +1,34 @@
-import {Types} from "aptos";
 import {useState, useEffect} from "react";
 import {getStake} from "..";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {AccountAddress, MoveValue} from "@aptos-labs/ts-sdk";
 
 export function useGetDelegatorStakeInfo(
-  delegatorAddress: Types.Address,
-  validatorAddress: Types.Address,
+  delegatorAddress: string | undefined,
+  validatorAddress: string,
 ) {
   const [state] = useGlobalState();
-  const [stakes, setStakes] = useState<Types.MoveValue[]>([]);
+  const [stakes, setStakes] = useState<MoveValue[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
+      if (delegatorAddress === undefined || delegatorAddress === null) {
+        setStakes([]);
+        return;
+      }
+
       setStakes(
-        await getStake(state.aptos_client, delegatorAddress, validatorAddress),
+        await getStake(
+          state.sdk_v2_client,
+          AccountAddress.from(delegatorAddress),
+          AccountAddress.from(validatorAddress),
+        ),
       );
     };
     fetchData();
   }, [
     state.network_value,
-    state.aptos_client,
+    state.sdk_v2_client,
     delegatorAddress,
     validatorAddress,
   ]);

--- a/src/api/hooks/useGetMostRecentBlocks.ts
+++ b/src/api/hooks/useGetMostRecentBlocks.ts
@@ -2,16 +2,16 @@ import {useGlobalState} from "../../global-config/GlobalConfig";
 import {useEffect, useState} from "react";
 import {useQuery} from "@tanstack/react-query";
 import {getLedgerInfo, getRecentBlocks} from "..";
-import {Types} from "aptos";
+import {Block} from "@aptos-labs/ts-sdk";
 
 export function useGetMostRecentBlocks(count: number) {
   const [state] = useGlobalState();
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [recentBlocks, setRecentBlocks] = useState<Types.Block[]>([]);
+  const [recentBlocks, setRecentBlocks] = useState<Block[]>([]);
 
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.aptos_client),
+    queryFn: () => getLedgerInfo(state.sdk_v2_client),
   });
   const currentBlockHeight = ledgerData?.block_height;
 
@@ -21,7 +21,7 @@ export function useGetMostRecentBlocks(count: number) {
         const blocks = await getRecentBlocks(
           parseInt(currentBlockHeight),
           count,
-          state.aptos_client,
+          state.sdk_v2_client,
         );
         setRecentBlocks(blocks);
         setIsLoading(false);

--- a/src/api/hooks/useGetNumberOfDelegators.ts
+++ b/src/api/hooks/useGetNumberOfDelegators.ts
@@ -1,4 +1,3 @@
-import {Types} from "aptos";
 import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
 import {normalizeAddress} from "../../utils";
 
@@ -16,7 +15,7 @@ const NUMBER_OF_DELEGATORS_QUERY = gql`
   }
 `;
 
-export function useGetNumberOfDelegators(poolAddress: Types.Address) {
+export function useGetNumberOfDelegators(poolAddress: string) {
   const poolAddress64Hash = normalizeAddress(poolAddress);
 
   const {loading, error, data} = useGraphqlQuery(NUMBER_OF_DELEGATORS_QUERY, {

--- a/src/api/hooks/useGetTPS.ts
+++ b/src/api/hooks/useGetTPS.ts
@@ -12,7 +12,7 @@ export function useGetTPS() {
 
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.aptos_client),
+    queryFn: () => getLedgerInfo(state.sdk_v2_client),
     refetchInterval: 10000,
   });
   const currentBlockHeight = ledgerData?.block_height;

--- a/src/api/hooks/useGetTPSByBlockHeight.ts
+++ b/src/api/hooks/useGetTPSByBlockHeight.ts
@@ -1,12 +1,12 @@
 import moment from "moment";
 import {useEffect, useState} from "react";
-import {Types} from "aptos";
 import {useGetBlockByHeight} from "./useGetBlock";
 import {parseTimestamp} from "../../pages/utils";
+import {Block} from "@aptos-labs/ts-sdk";
 
 const TPS_FREQUENCY = 600; // calculate tps every 600 blocks
 
-function calculateTps(startBlock: Types.Block, endBlock: Types.Block): number {
+function calculateTps(startBlock: Block, endBlock: Block): number {
   const startTransactionVersion = parseInt(startBlock.last_version);
   const endTransactionVersion = parseInt(endBlock.last_version);
 

--- a/src/api/hooks/useGetTransaction.ts
+++ b/src/api/hooks/useGetTransaction.ts
@@ -1,15 +1,15 @@
-import {Types} from "aptos";
 import {useQuery} from "@tanstack/react-query";
 import {getTransaction} from "../../api";
 import {ResponseError} from "../../api/client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 export function useGetTransaction(txnHashOrVersion: string) {
   const [state] = useGlobalState();
 
-  const result = useQuery<Types.Transaction, ResponseError>({
+  const result = useQuery<TransactionResponse, ResponseError>({
     queryKey: ["transaction", {txnHashOrVersion}, state.network_value],
-    queryFn: () => getTransaction({txnHashOrVersion}, state.aptos_client),
+    queryFn: () => getTransaction({txnHashOrVersion}, state.sdk_v2_client),
   });
 
   return result;

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -1,10 +1,10 @@
-import {FailedTransactionError} from "aptos";
 import {useEffect, useState} from "react";
 import {
   useWallet,
   InputTransactionData,
 } from "@aptos-labs/wallet-adapter-react";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {FailedTransactionError} from "aptos";
 
 export type TransactionResponse =
   | TransactionResponseOnSubmission
@@ -69,8 +69,11 @@ const useSubmitTransaction = () => {
 
         // transaction submit succeed
         if ("hash" in response) {
-          await state.aptos_client.waitForTransaction(response["hash"], {
-            checkSuccess: true,
+          await state.sdk_v2_client.waitForTransaction({
+            transactionHash: response["hash"],
+            options: {
+              checkSuccess: true,
+            },
           });
           return {
             transactionSubmitted: true,
@@ -81,6 +84,7 @@ const useSubmitTransaction = () => {
         // transaction failed
         return {...responseOnError, message: response.message};
       } catch (error) {
+        // TODO: Need to check / replace the error format here
         if (error instanceof FailedTransactionError) {
           return {
             transactionSubmitted: true,

--- a/src/components/snakebar/FailureSnackbar.tsx
+++ b/src/components/snakebar/FailureSnackbar.tsx
@@ -1,12 +1,12 @@
 import {Snackbar, Alert, Typography} from "@mui/material";
 import {CloseAction} from "./TransactionResponseSnackbar";
-import {Types} from "aptos";
 import React from "react";
 import {Link} from "../../routing";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 type FailureSnackbarProps = {
   onCloseSnackbar: () => void;
-  data: Types.Transaction;
+  data: TransactionResponse;
 };
 
 export default function FailureSnackbar({

--- a/src/global-config/GlobalConfig.tsx
+++ b/src/global-config/GlobalConfig.tsx
@@ -1,4 +1,3 @@
-import {AptosClient, IndexerClient} from "aptos";
 import React, {useMemo} from "react";
 import {
   FeatureName,
@@ -27,11 +26,7 @@ export type GlobalState = {
   /** derived from network_name - url to connect to network */
   readonly network_value: string;
   /** derived from network_value */
-  readonly aptos_client: AptosClient;
-  /** derived from network_value */
-  readonly indexer_client?: IndexerClient;
-  /** derived from network_value */
-  readonly sdk_v2_client?: Aptos;
+  readonly sdk_v2_client: Aptos;
 };
 
 type GlobalActions = {
@@ -48,19 +43,10 @@ function deriveGlobalState({
 }): GlobalState {
   const indexerUri = getGraphqlURI(network_name);
   const apiKey = getApiKey(network_name);
-  let indexerClient = undefined;
-  if (indexerUri) {
-    indexerClient = new IndexerClient(indexerUri, {HEADERS, TOKEN: apiKey});
-  }
   return {
     feature_name,
     network_name,
     network_value: networks[network_name],
-    aptos_client: new AptosClient(networks[network_name], {
-      HEADERS,
-      TOKEN: apiKey,
-    }),
-    indexer_client: indexerClient,
     sdk_v2_client: new Aptos(
       new AptosConfig({
         network: NetworkToNetworkName[network_name],

--- a/src/pages/Account/Components/AccountTransactions.tsx
+++ b/src/pages/Account/Components/AccountTransactions.tsx
@@ -4,7 +4,7 @@ import TransactionsTable from "../../Transactions/TransactionsTable";
 import Error from "../Error";
 import {useGetAccountTransactions} from "../../../api/hooks/useGetAccountTransactions";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
-import {Types} from "aptos";
+import {AccountData} from "@aptos-labs/ts-sdk";
 
 const TXN_PER_PAGE = 25;
 
@@ -90,7 +90,7 @@ function TransactionsPaginationTable({
 
 type AccountTransactionsProps = {
   address: string;
-  accountData: Types.AccountData | undefined;
+  accountData: AccountData | undefined;
 };
 
 export default function AccountTransactions({

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -11,9 +11,8 @@ import LoadingModal from "../../components/LoadingModal";
 import Error from "./Error";
 import {AptosNamesBanner} from "./Components/AptosNamesBanner";
 import {useGlobalState} from "../../global-config/GlobalConfig";
-import {Network} from "aptos";
 import {useGetAccountResources} from "../../api/hooks/useGetAccountResources";
-import {AccountAddress} from "@aptos-labs/ts-sdk";
+import {AccountAddress, Network} from "@aptos-labs/ts-sdk";
 import {useNavigate} from "../../routing";
 
 const TAB_VALUES_FULL: TabValue[] = [
@@ -106,7 +105,9 @@ export default function AccountPage({isObject = false}: AccountPageProps) {
         <BalanceCard address={address} />
       </Grid>
       <Grid item xs={12} md={8} lg={12} marginTop={4} alignSelf="center">
-        {state.network_name === Network.MAINNET && <AptosNamesBanner />}
+        {state.network_name.toLowerCase() === Network.MAINNET && (
+          <AptosNamesBanner />
+        )}
       </Grid>
       <Grid item xs={12} md={12} lg={12} marginTop={4}>
         {error ? (

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -15,10 +15,10 @@ import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
 import TokensTab from "./Tabs/TokensTab";
 import CoinsTab from "./Tabs/CoinsTab";
-import {Types} from "aptos";
 import {useParams} from "react-router-dom";
 import {useNavigate} from "../../routing";
 import {accountPagePath} from "./Index";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
 
@@ -74,7 +74,7 @@ function getTabIcon(value: TabValue): JSX.Element {
 type TabPanelProps = {
   value: TabValue;
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
   isObject: boolean;
 };
 
@@ -96,7 +96,7 @@ function TabPanel({
 
 type AccountTabsProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
   tabValues?: TabValue[];
   isObject?: boolean;
 };

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import {gql, useQuery} from "@apollo/client";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
-import {Types} from "aptos";
 import {CoinsTable} from "../Components/CoinsTable";
 import {normalizeAddress} from "../../../utils";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 const COINS_QUERY = gql`
   query CoinsData($owner_address: String, $limit: Int, $offset: Int) {
@@ -25,7 +25,7 @@ const COINS_QUERY = gql`
 
 type TokenTabsProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
 };
 
 export default function CoinsTab({address}: TokenTabsProps) {

--- a/src/pages/Account/Tabs/InfoTab.tsx
+++ b/src/pages/Account/Tabs/InfoTab.tsx
@@ -1,14 +1,14 @@
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import React from "react";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {getLearnMoreTooltip} from "../../Transaction/helpers";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 type InfoTabProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
 };
 
 export default function InfoTab({accountData}: InfoTabProps) {

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -1,4 +1,3 @@
-import {Types} from "aptos";
 import {ReactNode, useEffect, useMemo, useState} from "react";
 import Error from "../../Error";
 import {useGetAccountModules} from "../../../../api/hooks/useGetAccountModules";
@@ -41,7 +40,13 @@ import {ContentCopy} from "@mui/icons-material";
 import StyledTooltip from "../../../../components/StyledTooltip";
 import {encodeInputArgsForViewRequest, sortPetraFirst} from "../../../../utils";
 import {accountPagePath} from "../../Index";
-import {parseTypeTag} from "@aptos-labs/ts-sdk";
+import {
+  MoveFunction,
+  MoveModule,
+  MoveValue,
+  parseTypeTag,
+  ViewFunctionJsonPayload,
+} from "@aptos-labs/ts-sdk";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -52,7 +57,7 @@ type ContractFormType = {
 interface ContractSidebarProps {
   selectedModuleName: string | undefined;
   selectedFnName: string | undefined;
-  moduleAndFnsGroup: Record<string, Types.MoveFunction[]>;
+  moduleAndFnsGroup: Record<string, MoveFunction[]>;
 
   getLinkToFn(moduleName: string, fnName: string, isObject: boolean): string;
 
@@ -106,9 +111,9 @@ function Contract({
       return {
         ...acc,
         [moduleName]: fns,
-      } as Record<string, Types.MoveFunction[]>;
+      } as Record<string, MoveFunction[]>;
     },
-    {} as Record<string, Types.MoveFunction[]>,
+    {} as Record<string, MoveFunction[]>,
   );
 
   const module = modules.find((m) => m.abi?.name === selectedModuleName)?.abi;
@@ -266,13 +271,7 @@ function ContractSidebar({
   );
 }
 
-function RunContractForm({
-  module,
-  fn,
-}: {
-  module: Types.MoveModule;
-  fn: Types.MoveFunction;
-}) {
+function RunContractForm({module, fn}: {module: MoveModule; fn: MoveFunction}) {
   const [state] = useGlobalState();
   const {connected} = useWallet();
   const logEvent = useLogEventWithBasic();
@@ -475,11 +474,11 @@ function ReadContractForm({
   module,
   fn,
 }: {
-  module: Types.MoveModule;
-  fn: Types.MoveFunction;
+  module: MoveModule;
+  fn: MoveFunction;
 }) {
   const [state] = useGlobalState();
-  const [result, setResult] = useState<Types.MoveValue[]>();
+  const [result, setResult] = useState<MoveValue[]>();
   const theme = useTheme();
   const isWideScreen = useMediaQuery(theme.breakpoints.up("md"));
   const [errMsg, setErrMsg] = useState<string>();
@@ -507,12 +506,12 @@ function ReadContractForm({
 
   const onSubmit: SubmitHandler<ContractFormType> = async (data) => {
     logEvent("read_button_clicked", fn.name);
-    let viewRequest: Types.ViewRequest;
+    let viewRequest: ViewFunctionJsonPayload;
     try {
       viewRequest = {
         function: `${module.address}::${module.name}::${fn.name}`,
-        type_arguments: data.typeArgs,
-        arguments: data.args.map((arg, i) => {
+        typeArguments: data.typeArgs as "${string}::${string}::${string}"[], // TODO: this is annoying
+        functionArguments: data.args.map((arg, i) => {
           return encodeInputArgsForViewRequest(fn.params[i], arg);
         }),
       };
@@ -524,7 +523,7 @@ function ReadContractForm({
     try {
       const result = await view(
         viewRequest,
-        state.aptos_client,
+        state.sdk_v2_client,
         data.ledgerVersion,
       );
       setResult(result);
@@ -663,7 +662,7 @@ function ContractForm({
   result,
   isView,
 }: {
-  fn: Types.MoveFunction;
+  fn: MoveFunction;
   onSubmit: SubmitHandler<ContractFormType>;
   setFormValid: (valid: boolean) => void;
   result: ReactNode;
@@ -797,7 +796,7 @@ function ContractForm({
   );
 }
 
-function removeSignerParam(fn: Types.MoveFunction) {
+function removeSignerParam(fn: MoveFunction) {
   return fn.params.filter((p) => p !== "signer" && p !== "&signer");
 }
 

--- a/src/pages/Account/Tabs/ResourcesTab.tsx
+++ b/src/pages/Account/Tabs/ResourcesTab.tsx
@@ -1,4 +1,3 @@
-import {Types} from "aptos";
 import React from "react";
 import Error from "../Error";
 import {useGetAccountResources} from "../../../api/hooks/useGetAccountResources";
@@ -7,13 +6,14 @@ import useExpandedList from "../../../components/hooks/useExpandedList";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 function ResourcesContent({
   data,
 }: {
-  data: Types.MoveResource[] | undefined;
+  data: MoveResource[] | undefined;
 }): JSX.Element {
-  const resources: Types.MoveResource[] = data ?? [];
+  const resources: MoveResource[] = data ?? [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(resources.length);
@@ -45,7 +45,7 @@ function ResourcesContent({
 
 type ResourcesTabProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
 };
 
 export default function ResourcesTab({address}: ResourcesTabProps) {

--- a/src/pages/Account/Tabs/TokensTab.tsx
+++ b/src/pages/Account/Tabs/TokensTab.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import {TokensTable} from "../Components/TokensTable";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
-import {Types} from "aptos";
 import {
   useGetAccountTokens,
   useGetAccountTokensCount,
 } from "../../../api/hooks/useGetAccountTokens";
 import {useSearchParams} from "react-router-dom";
 import {Box, Pagination, Stack} from "@mui/material";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 const LIMIT = 20;
 
@@ -76,7 +76,7 @@ export function AccountTokensWithPagination({
 
 type TokenTabsProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
 };
 
 export default function TokenTabs({address}: TokenTabsProps) {

--- a/src/pages/Account/Tabs/TransactionsTab.tsx
+++ b/src/pages/Account/Tabs/TransactionsTab.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import {Types} from "aptos";
 import AccountTransactions from "../Components/AccountTransactions";
 import {useGetIsGraphqlClientSupported} from "../../../api/hooks/useGraphqlClient";
 import AccountAllTransactions from "../Components/AccountAllTransactions";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {AccountData, MoveResource} from "@aptos-labs/ts-sdk";
 
 type TransactionsTabProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: AccountData | MoveResource[] | undefined;
 };
 
 export default function TransactionsTab({

--- a/src/pages/Analytics/NetworkInfo/TotalTransactions.tsx
+++ b/src/pages/Analytics/NetworkInfo/TotalTransactions.tsx
@@ -8,7 +8,7 @@ export default function TotalTransactions() {
   const [state] = useGlobalState();
   const {data: ledgerData} = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.aptos_client),
+    queryFn: () => getLedgerInfo(state.sdk_v2_client),
     refetchInterval: 10000,
   });
   const ledgerVersion = ledgerData?.ledger_version;

--- a/src/pages/Block/Tabs.tsx
+++ b/src/pages/Block/Tabs.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import OverviewTab from "./Tabs/OverviewTab";
 import TransactionsTab from "./Tabs/TransactionsTab";
@@ -10,6 +9,7 @@ import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
 import {useParams} from "react-router-dom";
 import {useNavigate} from "../../routing";
+import {Block} from "@aptos-labs/ts-sdk";
 
 const TAB_VALUES: TabValue[] = ["overview", "transactions"];
 
@@ -44,7 +44,7 @@ function getTabIcon(value: TabValue): JSX.Element {
 
 type TabPanelProps = {
   value: TabValue;
-  data: Types.Block;
+  data: Block;
 };
 
 function TabPanel({value, data}: TabPanelProps): JSX.Element {
@@ -53,7 +53,7 @@ function TabPanel({value, data}: TabPanelProps): JSX.Element {
 }
 
 type AccountTabsProps = {
-  data: Types.Block;
+  data: Block;
   tabValues?: TabValue[];
 };
 

--- a/src/pages/Block/Tabs/OverviewTab.tsx
+++ b/src/pages/Block/Tabs/OverviewTab.tsx
@@ -1,5 +1,4 @@
 import {Box} from "@mui/material";
-import {Types} from "aptos";
 import React from "react";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
@@ -7,17 +6,13 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import {Link} from "../../../routing";
 import {getLearnMoreTooltip} from "../../Transaction/helpers";
+import {
+  Block,
+  isBlockMetadataTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
-function isBlockMetadataTransaction(
-  txn: Types.Transaction,
-): txn is Types.Transaction_BlockMetadataTransaction {
-  return (
-    (txn as Types.Transaction_BlockMetadataTransaction).type ===
-    "block_metadata_transaction"
-  );
-}
-
-function VersionValue({data}: {data: Types.Block}) {
+function VersionValue({data}: {data: Block}) {
   const {first_version, last_version} = data;
   return (
     <>
@@ -35,29 +30,30 @@ function VersionValue({data}: {data: Types.Block}) {
 function BlockMetadataRows({
   blockTxn,
 }: {
-  blockTxn: Types.Transaction | undefined;
+  blockTxn: TransactionResponse | undefined;
 }) {
   if (!blockTxn) {
     return null;
   }
-
-  const txn = blockTxn as Types.Transaction_BlockMetadataTransaction;
+  if (!isBlockMetadataTransactionResponse(blockTxn)) {
+    return null;
+  }
 
   return (
     <>
       <ContentRow
         title="Proposer:"
-        value={<HashButton hash={txn.proposer} type={HashType.ACCOUNT} />}
+        value={<HashButton hash={blockTxn.proposer} type={HashType.ACCOUNT} />}
         tooltip={getLearnMoreTooltip("proposer")}
       />
       <ContentRow
         title="Epoch:"
-        value={txn.epoch}
+        value={blockTxn.epoch}
         tooltip={getLearnMoreTooltip("epoch")}
       />
       <ContentRow
         title="Round:"
-        value={txn.round}
+        value={blockTxn.round}
         tooltip={getLearnMoreTooltip("round")}
       />
     </>
@@ -65,13 +61,13 @@ function BlockMetadataRows({
 }
 
 type OverviewTabProps = {
-  data: Types.Block;
+  data: Block;
 };
 
 export default function OverviewTab({data}: OverviewTabProps) {
-  const blockTxn: Types.Transaction | undefined = (
+  const blockTxn: TransactionResponse | undefined = (
     data.transactions ?? []
-  ).find(isBlockMetadataTransaction);
+  ).find(isBlockMetadataTransactionResponse);
 
   return (
     <Box marginBottom={3}>

--- a/src/pages/Block/Tabs/TransactionsTab.tsx
+++ b/src/pages/Block/Tabs/TransactionsTab.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import {Types} from "aptos";
 import TransactionsTable from "../../Transactions/TransactionsTable";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {Block} from "@aptos-labs/ts-sdk";
 
 type TransactionsTabProps = {
-  data: Types.Block;
+  data: Block;
 };
 
 export default function TransactionsTab({data}: TransactionsTabProps) {

--- a/src/pages/Blocks/Table.tsx
+++ b/src/pages/Blocks/Table.tsx
@@ -4,14 +4,14 @@ import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../utils";
 import HashButton, {HashType} from "../../components/HashButton";
-import {Types} from "aptos";
 import {parseTimestamp} from "../utils";
 import moment from "moment";
 import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
 import {Link, useAugmentToWithGlobalSearchParams} from "../../routing";
+import {Block} from "@aptos-labs/ts-sdk";
 
-function getAgeInSeconds(block: Types.Block): string {
+function getAgeInSeconds(block: Block): string {
   const blockTimestamp = parseTimestamp(block.block_timestamp);
   const nowTimestamp = parseTimestamp(moment.now().toString());
   const duration = moment.duration(nowTimestamp.diff(blockTimestamp));
@@ -20,7 +20,7 @@ function getAgeInSeconds(block: Types.Block): string {
 }
 
 type BlockCellProps = {
-  block: Types.Block;
+  block: Block;
 };
 
 function BlockHeightCell({block}: BlockCellProps) {
@@ -92,7 +92,7 @@ const DEFAULT_COLUMNS: Column[] = [
 ];
 
 type BlockRowProps = {
-  block: Types.Block;
+  block: Block;
   columns: Column[];
 };
 
@@ -131,7 +131,7 @@ function BlockHeaderCell({column}: BlockHeaderCellProps) {
 }
 
 type BlocksTableProps = {
-  blocks: Types.Block[];
+  blocks: Block[];
   columns?: Column[];
 };
 

--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -15,8 +15,8 @@ import {useGetDelegationState} from "../../api/hooks/useGetDelegationState";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
 import {DelegationStateContext} from "./context/DelegationContext";
 import {useContext} from "react";
-import {Types} from "aptos";
 import {ValidatorData} from "../../api/hooks/useGetValidators";
+import {MoveResource} from "@aptos-labs/ts-sdk";
 
 type ValidatorDetailProps = {
   isSkeletonLoading: boolean;
@@ -45,7 +45,7 @@ function ValidatorDetailCardContent({
   accountResource,
   validator,
 }: ValidatorDetailProps & {
-  accountResource: Types.MoveResource;
+  accountResource: MoveResource;
   validator: ValidatorData;
 }) {
   const theme = useTheme();

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -31,7 +31,6 @@ import useSubmitStakeOperation, {
 import {OCTA} from "../../constants";
 import {useGetDelegationState} from "../../api/hooks/useGetDelegationState";
 import {DelegationStateContext} from "./context/DelegationContext";
-import {Types} from "aptos";
 import {getAddStakeFee} from "../../api";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -39,14 +38,15 @@ import {MINIMUM_APT_IN_POOL} from "./constants";
 import {ValidatorData} from "../../api/hooks/useGetValidators";
 import {useLogEventWithBasic} from "../Account/hooks/useLogEventWithBasic";
 import TooltipTypography from "../../components/TooltipTypography";
+import {MoveResource, MoveValue} from "@aptos-labs/ts-sdk";
 
 type StakeOperationDialogProps = {
   handleDialogClose: () => void;
   isDialogOpen: boolean;
   stakeOperation: StakeOperation;
   commission?: number | undefined;
-  canWithdrawPendingInactive: Types.MoveValue;
-  stakes: Types.MoveValue[];
+  canWithdrawPendingInactive: MoveValue;
+  stakes: MoveValue[];
 };
 
 export default function StakeOperationDialog({
@@ -87,7 +87,7 @@ function StakeOperationDialogContent({
   accountResource,
   validator,
 }: StakeOperationDialogProps & {
-  accountResource: Types.MoveResource;
+  accountResource: MoveResource;
   validator: ValidatorData;
 }) {
   const {balance, lockedUntilSecs, rewardsRateYearly} = useGetDelegationState(
@@ -125,24 +125,25 @@ function StakeOperationDialogContent({
   };
 
   const [state] = useGlobalState();
-  const [addStakeFee, setAddStakeFee] = useState<Types.MoveValue>(0);
+  const [addStakeFee, setAddStakeFee] = useState<MoveValue>(0);
   const logEvent = useLogEventWithBasic();
 
   useEffect(() => {
     async function fetchData() {
       if (stakeOperation === StakeOperation.STAKE) {
         const fee = await getAddStakeFee(
-          state.aptos_client,
+          state.sdk_v2_client,
           validator!.owner_address,
           Number(amount).toFixed(8),
         );
         setAddStakeFee(fee[0]);
       }
     }
+
     fetchData();
   }, [
     state.network_value,
-    state.aptos_client,
+    state.sdk_v2_client,
     amount,
     stakeOperation,
     validator,

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -24,7 +24,6 @@ import {DelegationStateContext} from "./context/DelegationContext";
 import {useGetAccountAPTBalance} from "../../api/hooks/useGetAccountAPTBalance";
 import {MINIMUM_APT_IN_POOL_FOR_EXPLORER} from "./constants";
 import {OCTA} from "../../constants";
-import {Types} from "aptos";
 import {getAddStakeFee} from "../../api";
 import {useGetDelegatorStakeInfo} from "../../api/hooks/useGetDelegatorStakeInfo";
 import {useGlobalState} from "../../global-config/GlobalConfig";
@@ -32,6 +31,7 @@ import {ValidatorData} from "../../api/hooks/useGetValidators";
 import {useLogEventWithBasic} from "../Account/hooks/useLogEventWithBasic";
 import {useGetValidatorSet} from "../../api/hooks/useGetValidatorSet";
 import {calculateNetworkPercentage} from "./utils";
+import {MoveValue} from "@aptos-labs/ts-sdk";
 
 type ValidatorStakingBarProps = {
   setIsStakingBarSkeletonLoading: (arg: boolean) => void;
@@ -149,7 +149,7 @@ function StakingBarContent({
     account?.address!,
     validator.owner_address,
   );
-  const [addStakeFee, setAddStakeFee] = useState<Types.MoveValue>(0);
+  const [addStakeFee, setAddStakeFee] = useState<MoveValue>(0);
   // disable stake button when balance is less than minimum stake amount and add_stake fee computed from the minimum stake amount
   // or when balance is less than add_stake fee if minimum stake amount is already met
   const buttonDisabled =
@@ -162,14 +162,15 @@ function StakingBarContent({
   useEffect(() => {
     async function fetchData() {
       const fee = await getAddStakeFee(
-        state.aptos_client,
+        state.sdk_v2_client,
         validator!.owner_address,
         MINIMUM_APT_IN_POOL_FOR_EXPLORER.toString(),
       );
       setAddStakeFee(fee[0]);
     }
+
     fetchData();
-  }, [state.network_value, state.aptos_client, balance, validator]);
+  }, [state.network_value, state.sdk_v2_client, balance, validator]);
 
   const stakeButton = (
     <StyledTooltip

--- a/src/pages/DelegatoryValidator/Title.tsx
+++ b/src/pages/DelegatoryValidator/Title.tsx
@@ -1,13 +1,12 @@
 import {Stack, Typography, Skeleton} from "@mui/material";
 import React from "react";
-import {Types} from "aptos";
 import TitleHashButton, {HashType} from "../../components/TitleHashButton";
 import ValidatorStatusIcon from "./Components/ValidatorStatusIcon";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
 import {getValidatorStatus} from "./utils";
 
 type ValidatorTitleProps = {
-  address: Types.Address;
+  address: string;
   isSkeletonLoading: boolean;
 };
 

--- a/src/pages/DelegatoryValidator/context/DelegationContext.tsx
+++ b/src/pages/DelegatoryValidator/context/DelegationContext.tsx
@@ -1,9 +1,9 @@
-import {Types} from "aptos";
 import {createContext} from "react";
 import {ValidatorData} from "../../../api/hooks/useGetValidators";
+import {MoveResource} from "@aptos-labs/ts-sdk";
 
 type DelegationState = {
-  accountResource: Types.MoveResource | undefined;
+  accountResource: MoveResource | undefined;
   validator: ValidatorData | undefined;
 };
 

--- a/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
+++ b/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import {StakeOperation} from "../../../api/hooks/useSubmitStakeOperation";
 import {MINIMUM_APT_IN_POOL} from "../constants";
 import {OCTA} from "../../../constants";
-import {Types} from "aptos";
+import {MoveValue} from "@aptos-labs/ts-sdk";
 
 function sanitizeInput(input: string): string {
   const digitsAndDecimals = /[0-9.]/g;
@@ -44,7 +44,7 @@ const useAmountInput = (stakeOperation: StakeOperation) => {
   }
 
   function renderAmountTextField(
-    stakes: Types.MoveValue[],
+    stakes: MoveValue[],
     balance?: string | null,
   ): JSX.Element {
     function getWarnMessage() {

--- a/src/pages/DelegatoryValidator/index.tsx
+++ b/src/pages/DelegatoryValidator/index.tsx
@@ -4,7 +4,6 @@ import PageHeader from "../layout/PageHeader";
 import ValidatorTitle from "./Title";
 import ValidatorDetailCard from "./DetailCard";
 import ValidatorStakingBar from "./StakingBar";
-import {HexString} from "aptos";
 import {
   useGetValidators,
   ValidatorData,
@@ -21,14 +20,15 @@ import Error from "../Account/Error";
 import {useGetDelegationNodeInfo} from "../../api/hooks/useGetDelegationNodeInfo";
 import {Banner} from "../../components/Banner";
 import {useGetDelegationNodeCommissionChange} from "../../api/hooks/useGetDelegationNodeCommissionChange";
+import {AccountAddress} from "@aptos-labs/ts-sdk";
 
 export default function ValidatorPage() {
   const address = useParams().address ?? "";
-  const addressHex = useMemo(() => new HexString(address), [address]);
+  const addressHex = useMemo(() => AccountAddress.from(address), [address]);
   const {validators} = useGetValidators();
   const {connected} = useWallet();
   const {data: accountResource, error} = useGetAccountResource(
-    addressHex.hex(),
+    addressHex.toString(),
     "0x1::stake::StakePool",
   );
   const {
@@ -43,7 +43,7 @@ export default function ValidatorPage() {
   const [delegationValidator, setDelegationValidator] =
     useState<ValidatorData>();
   const validator = validators.find(
-    (validator) => validator.owner_address === addressHex.hex(),
+    (validator) => AccountAddress.from(validator.owner_address) === addressHex,
   );
 
   const {commission} = useGetDelegationNodeInfo({
@@ -61,7 +61,9 @@ export default function ValidatorPage() {
       const delegatedStakingPoolsNotInValidators: ValidatorData[] =
         delegatedStakingPools
           .filter((pool) => {
-            return addressHex.hex() === pool.staking_pool_address;
+            return (
+              addressHex === AccountAddress.from(pool.staking_pool_address)
+            );
           })
           .map((pool) => ({
             owner_address: pool.staking_pool_address,

--- a/src/pages/DelegatoryValidator/utils.tsx
+++ b/src/pages/DelegatoryValidator/utils.tsx
@@ -1,4 +1,3 @@
-import {Types} from "aptos";
 import {DelegatedStakingActivity} from "../../api/hooks/useGetDelegatedStakeOperationActivities";
 import {StakeOperation} from "../../api/hooks/useSubmitStakeOperation";
 import {OCTA} from "../../constants";
@@ -7,7 +6,7 @@ import {
   MINIMUM_APT_IN_POOL,
 } from "./constants";
 import {ApolloError} from "@apollo/client";
-import {MoveValue} from "aptos/src/generated";
+import {MoveResource, MoveValue} from "@aptos-labs/ts-sdk";
 
 interface AccountResourceData {
   locked_until_secs: bigint;
@@ -15,7 +14,7 @@ interface AccountResourceData {
 
 // returns seconds till locked staking funds getting unlocked
 export function getLockedUtilSecs(
-  accountResource?: Types.MoveResource | undefined,
+  accountResource?: MoveResource | undefined,
 ): bigint | null {
   return accountResource
     ? BigInt((accountResource.data as AccountResourceData).locked_until_secs)
@@ -135,7 +134,7 @@ export type APTRequirement = {
 };
 
 export function getStakeOperationAPTRequirement(
-  stakes: Types.MoveValue[],
+  stakes: MoveValue[],
   stakeOperation: StakeOperation,
   balance: number,
 ): APTRequirement {

--- a/src/pages/LandingPage/TransactionsPreview.tsx
+++ b/src/pages/LandingPage/TransactionsPreview.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
 import Button from "@mui/material/Button";
-import {Types} from "aptos";
 import {getTransactions} from "../../api";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import Box from "@mui/material/Box";
@@ -9,10 +8,13 @@ import * as RRD from "react-router-dom";
 import {Stack} from "@mui/material";
 import TransactionsTable from "../Transactions/TransactionsTable";
 import {useAugmentToWithGlobalSearchParams} from "../../routing";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 const PREVIEW_LIMIT = 10;
 
-function TransactionContent({data}: UseQueryResult<Array<Types.Transaction>>) {
+function TransactionContent({
+  data,
+}: UseQueryResult<Array<TransactionResponse>>) {
   if (!data) {
     // TODO: error handling!
     return null;
@@ -26,7 +28,7 @@ export default function TransactionsPreview() {
   const limit = PREVIEW_LIMIT;
   const result = useQuery({
     queryKey: ["transactions", {limit}, state.network_value],
-    queryFn: () => getTransactions({limit}, state.aptos_client),
+    queryFn: () => getTransactions({limit}, state.sdk_v2_client),
   });
   const augmentTo = useAugmentToWithGlobalSearchParams();
 

--- a/src/pages/Token/Index.tsx
+++ b/src/pages/Token/Index.tsx
@@ -14,21 +14,21 @@ export default function TokenPage() {
     // TODO: error handling
     return null;
   }
-  const tokenDatas = data ?? [];
-  if (tokenDatas.length === 0) {
+  try {
+    const token = data ?? [];
+    return (
+      <Grid container spacing={1}>
+        <PageHeader />
+        <Grid item xs={12}>
+          <Stack direction="column" spacing={4} marginTop={2}>
+            <TokenTitle name={token?.token_name} />
+            <TokenTabs data={token} />
+          </Stack>
+        </Grid>
+      </Grid>
+    );
+  } catch {
+    // TODO: error handling
     return <EmptyTabContent />;
   }
-  const token = tokenDatas[0];
-
-  return (
-    <Grid container spacing={1}>
-      <PageHeader />
-      <Grid item xs={12}>
-        <Stack direction="column" spacing={4} marginTop={2}>
-          <TokenTitle name={token?.token_name} />
-          <TokenTabs data={token} />
-        </Stack>
-      </Grid>
-    </Grid>
-  );
 }

--- a/src/pages/Token/Tabs/OverviewTab.tsx
+++ b/src/pages/Token/Tabs/OverviewTab.tsx
@@ -6,22 +6,24 @@ import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {Link} from "../../../routing";
-import {useGetTokenOwners} from "../../../api/hooks/useGetAccountTokens";
+import {useGetTokenOwner} from "../../../api/hooks/useGetAccountTokens";
 import {Current_Token_Datas_V2} from "aptos";
 import {isValidUrl} from "../../utils";
 
 function OwnersRow() {
   const {tokenId} = useParams();
-  const {data: owners} = useGetTokenOwners(tokenId);
+  const {data: owner} = useGetTokenOwner(tokenId);
 
   return (
     <ContentRow
       title={"Owner(s):"}
       value={
         <Stack direction="row" spacing={1}>
-          {(owners ?? []).map((owner: {owner_address: string}) => (
-            <HashButton hash={owner?.owner_address} type={HashType.ACCOUNT} />
-          ))}
+          {owner ? (
+            <HashButton hash={owner.owner_address} type={HashType.ACCOUNT} />
+          ) : (
+            <Typography>Unable to fetch owner</Typography>
+          )}
         </Stack>
       }
     />

--- a/src/pages/Transaction/Index.tsx
+++ b/src/pages/Transaction/Index.tsx
@@ -1,5 +1,4 @@
 import {Stack, Grid, Alert} from "@mui/material";
-import {Types} from "aptos";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {useParams} from "react-router-dom";
 import {useQuery} from "@tanstack/react-query";
@@ -9,16 +8,19 @@ import Error from "./Error";
 import TransactionTitle from "./Title";
 import TransactionTabs from "./Tabs";
 import PageHeader from "../layout/PageHeader";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 export default function TransactionPage() {
   const [state] = useGlobalState();
   const {txnHashOrVersion: txnParam} = useParams();
   const txnHashOrVersion = txnParam ?? "";
 
-  const {isLoading, data, error} = useQuery<Types.Transaction, ResponseError>({
-    queryKey: ["transaction", {txnHashOrVersion}, state.network_value],
-    queryFn: () => getTransaction({txnHashOrVersion}, state.aptos_client),
-  });
+  const {isLoading, data, error} = useQuery<TransactionResponse, ResponseError>(
+    {
+      queryKey: ["transaction", {txnHashOrVersion}, state.network_value],
+      queryFn: () => getTransaction({txnHashOrVersion}, state.sdk_v2_client),
+    },
+  );
 
   if (isLoading) {
     return null;

--- a/src/pages/Transaction/Tabs.tsx
+++ b/src/pages/Transaction/Tabs.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {Box} from "@mui/material";
-import {Types} from "aptos";
 import {assertNever} from "../../utils";
 import StyledTabs from "../../components/StyledTabs";
 import StyledTab from "../../components/StyledTab";
@@ -22,8 +21,9 @@ import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import BalanceChangeTab from "./Tabs/BalanceChangeTab";
 import {useParams} from "react-router-dom";
 import {useNavigate} from "../../routing";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
-function getTabValues(transaction: Types.Transaction): TabValue[] {
+function getTabValues(transaction: TransactionResponse): TabValue[] {
   switch (transaction.type) {
     case "user_transaction":
       return [
@@ -109,7 +109,7 @@ function getTabIcon(value: TabValue): JSX.Element {
 
 type TabPanelProps = {
   value: TabValue;
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 function TabPanel({value, transaction}: TabPanelProps): JSX.Element {
@@ -118,7 +118,7 @@ function TabPanel({value, transaction}: TabPanelProps): JSX.Element {
 }
 
 type TransactionTabsProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
   tabValues?: TabValue[];
 };
 

--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -1,11 +1,11 @@
-import {Types} from "aptos";
 import React from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {getCoinBalanceChanges} from "../utils";
 import {CoinBalanceChangeTable} from "./Components/CoinBalanceChangeTable";
+import {TransactionResponse, UserTransactionResponse} from "@aptos-labs/ts-sdk";
 
 type BalanceChangeTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
@@ -18,7 +18,7 @@ export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
   return (
     <CoinBalanceChangeTable
       balanceChanges={balanceChanges}
-      transaction={transaction as Types.UserTransaction}
+      transaction={transaction as UserTransactionResponse} // TODO: This is not always true, but the shape should be good enough
     />
   );
 }

--- a/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/BlockMetadataOverviewTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
@@ -8,63 +7,65 @@ import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import TransactionBlockRow from "./Components/TransactionBlockRow";
+import {
+  isBlockMetadataTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 type BlockMetadataOverviewTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function BlockMetadataOverviewTab({
   transaction,
 }: BlockMetadataOverviewTabProps) {
-  const transactionData =
-    transaction as Types.Transaction_BlockMetadataTransaction;
+  if (!isBlockMetadataTransactionResponse(transaction)) {
+    return <></>;
+  }
 
   return (
     <Box marginBottom={3}>
       <ContentBox padding={4}>
         <ContentRow
           title={"Version:"}
-          value={<Box sx={{fontWeight: 600}}>{transactionData.version}</Box>}
+          value={<Box sx={{fontWeight: 600}}>{transaction.version}</Box>}
           tooltip={getLearnMoreTooltip("version")}
         />
         <ContentRow
           title="Status:"
-          value={<TransactionStatus success={transactionData.success} />}
+          value={<TransactionStatus success={transaction.success} />}
           tooltip={getLearnMoreTooltip("status")}
         />
         <ContentRow
           title="Proposer:"
           value={
-            <HashButton
-              hash={transactionData.proposer}
-              type={HashType.ACCOUNT}
-            />
+            <HashButton hash={transaction.proposer} type={HashType.ACCOUNT} />
           }
           tooltip={getLearnMoreTooltip("proposer")}
         />
         <ContentRow
           title="ID:"
-          value={transactionData.id}
+          value={transaction.id}
           tooltip={getLearnMoreTooltip("id")}
         />
       </ContentBox>
       <ContentBox>
-        <TransactionBlockRow version={transactionData.version} />
+        <TransactionBlockRow version={transaction.version} />
         <ContentRow
           title="Epoch:"
-          value={transactionData.epoch}
+          value={transaction.epoch}
           tooltip={getLearnMoreTooltip("epoch")}
         />
         <ContentRow
           title="Round:"
-          value={transactionData.round}
+          value={transaction.round}
           tooltip={getLearnMoreTooltip("round")}
         />
         <ContentRow
           title="Timestamp:"
           value={
             <TimestampValue
-              timestamp={transactionData.timestamp}
+              timestamp={transaction.timestamp}
               ensureMilliSeconds
             />
           }
@@ -72,24 +73,24 @@ export default function BlockMetadataOverviewTab({
         />
         <ContentRow
           title="VM Status:"
-          value={transactionData.vm_status}
+          value={transaction.vm_status}
           tooltip={getLearnMoreTooltip("vm_status")}
         />
       </ContentBox>
       <ContentBox>
         <ContentRow
           title="State Change Hash:"
-          value={transactionData.state_change_hash}
+          value={transaction.state_change_hash}
           tooltip={getLearnMoreTooltip("state_change_hash")}
         />
         <ContentRow
           title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          value={transaction.event_root_hash}
           tooltip={getLearnMoreTooltip("event_root_hash")}
         />
         <ContentRow
           title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
+          value={transaction.accumulator_root_hash}
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>

--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
@@ -12,13 +11,14 @@ import {
   objectCoreAddress,
   tokenV2Address,
 } from "../../../constants";
+import {TransactionResponse, WriteSetChange} from "@aptos-labs/ts-sdk";
 
 type ChangesTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function ChangesTab({transaction}: ChangesTabProps) {
-  const changes: Types.WriteSetChange[] =
+  const changes: WriteSetChange[] =
     "changes" in transaction ? transaction.changes : [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =

--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -10,24 +10,24 @@ import {
   negativeColor,
   primary,
 } from "../../../../themes/colors/aptosColorPalette";
-import {Types} from "aptos";
 import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
+import {UserTransactionResponse} from "@aptos-labs/ts-sdk";
 
 function getIsSender(
   address: string,
-  transaction: Types.UserTransaction,
+  transaction: UserTransactionResponse,
 ): boolean {
   return transaction.sender === address;
 }
 
-function getGas(transaction: Types.UserTransaction): bigint {
+function getGas(transaction: UserTransactionResponse): bigint {
   return BigInt(transaction.gas_unit_price) * BigInt(transaction.gas_used);
 }
 
 type BalanceChangeCellProps = {
   balanceChange: BalanceChange;
-  transaction: Types.UserTransaction;
+  transaction: UserTransactionResponse;
 };
 
 function AddressCell({balanceChange}: BalanceChangeCellProps) {
@@ -122,7 +122,7 @@ const DEFAULT_COLUMNS: Column[] = [
 
 type BalanceChangeRowProps = {
   balanceChange: BalanceChange;
-  transaction: Types.UserTransaction;
+  transaction: UserTransactionResponse;
   columns: Column[];
 };
 
@@ -174,7 +174,7 @@ function BalanceChangeHeaderCell({column}: BalanceChangeHeaderCellProps) {
 
 type CoinBalanceChangeTableProps = {
   balanceChanges: BalanceChange[];
-  transaction: Types.UserTransaction;
+  transaction: UserTransactionResponse;
   columns?: Column[];
 };
 

--- a/src/pages/Transaction/Tabs/Components/TransactionActions.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionActions.tsx
@@ -1,9 +1,8 @@
-import {Types} from "aptos";
 import ContentBox from "../../../../components/IndividualPageContent/ContentBox";
 import ContentRow from "../../../../components/IndividualPageContent/ContentRow";
 import {truncateAddress} from "../../../utils";
 import {Link} from "../../../../routing";
-import {AccountAddress} from "@aptos-labs/ts-sdk";
+import {AccountAddress, Event, TransactionResponse} from "@aptos-labs/ts-sdk";
 
 const AddressLink: React.FC<{
   address: string;
@@ -14,7 +13,7 @@ const AddressLink: React.FC<{
   </Link>
 );
 
-const mapEventToTransactionAction = (event: Types.Event) => {
+const mapEventToTransactionAction = (event: Event) => {
   if (
     event.type === "0x4::collection::MintEvent" ||
     event.type === "0x4::collection::Mint"
@@ -48,11 +47,10 @@ const mapEventToTransactionAction = (event: Types.Event) => {
   return null;
 };
 
-export const TransactionActions: React.FC<{transaction: Types.Transaction}> = ({
-  transaction,
-}) => {
-  const events: Types.Event[] =
-    "events" in transaction ? transaction.events : [];
+export const TransactionActions: React.FC<{
+  transaction: TransactionResponse;
+}> = ({transaction}) => {
+  const events: Event[] = "events" in transaction ? transaction.events : [];
   const listItems = events
     .map((event) => mapEventToTransactionAction(event))
     .filter((li) => li !== null);

--- a/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionFunction.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import {Box, Stack, SxProps, Theme} from "@mui/material";
-import {Types} from "aptos";
 import CurrencyExchangeOutlinedIcon from "@mui/icons-material/CurrencyExchangeOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import {CodeLineBox} from "../../../../components/CodeLineBox";
 import {Link} from "../../../../routing";
 import {codeBlockColorClickableOnHover} from "../../../../themes/colors/aptosColorPalette";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 function CoinTransferCodeLine({
   sx,
@@ -49,7 +49,7 @@ export default function TransactionFunction({
   transaction,
   sx,
 }: {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
   sx?: SxProps<Theme>;
 }) {
   if (!("payload" in transaction)) {

--- a/src/pages/Transaction/Tabs/EventsTab.tsx
+++ b/src/pages/Transaction/Tabs/EventsTab.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import {Types} from "aptos";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
@@ -7,14 +6,14 @@ import useExpandedList from "../../../components/hooks/useExpandedList";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import HashButton, {HashType} from "../../../components/HashButton";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {Event, TransactionResponse} from "@aptos-labs/ts-sdk";
 
 type EventsTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function EventsTab({transaction}: EventsTabProps) {
-  const events: Types.Event[] =
-    "events" in transaction ? transaction.events : [];
+  const events: Event[] = "events" in transaction ? transaction.events : [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(events.length);

--- a/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/GenesisTransactionOverviewTab.tsx
@@ -1,55 +1,60 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
 import TransactionBlockRow from "./Components/TransactionBlockRow";
+import {
+  isGenesisTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 type GenesisTransactionOverviewTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function GenesisTransactionOverviewTab({
   transaction,
 }: GenesisTransactionOverviewTabProps) {
-  const transactionData = transaction as Types.Transaction_GenesisTransaction;
+  if (!isGenesisTransactionResponse(transaction)) {
+    return <></>;
+  }
 
   return (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow
           title={"Version:"}
-          value={<Box sx={{fontWeight: 600}}>{transactionData.version}</Box>}
+          value={<Box sx={{fontWeight: 600}}>{transaction.version}</Box>}
           tooltip={getLearnMoreTooltip("version")}
         />
         <ContentRow
           title="Status:"
-          value={<TransactionStatus success={transactionData.success} />}
+          value={<TransactionStatus success={transaction.success} />}
           tooltip={getLearnMoreTooltip("status")}
         />
-        <TransactionBlockRow version={transactionData.version} />
+        <TransactionBlockRow version={transaction.version} />
         <ContentRow
           title="VM Status:"
-          value={transactionData.vm_status}
+          value={transaction.vm_status}
           tooltip={getLearnMoreTooltip("vm_status")}
         />
       </ContentBox>
       <ContentBox>
         <ContentRow
           title="State Change Hash:"
-          value={transactionData.state_change_hash}
+          value={transaction.state_change_hash}
           tooltip={getLearnMoreTooltip("state_change_hash")}
         />
         <ContentRow
           title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          value={transaction.event_root_hash}
           tooltip={getLearnMoreTooltip("event_root_hash")}
         />
         <ContentRow
           title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
+          value={transaction.accumulator_root_hash}
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>

--- a/src/pages/Transaction/Tabs/PayloadTab.tsx
+++ b/src/pages/Transaction/Tabs/PayloadTab.tsx
@@ -1,12 +1,12 @@
 import React, {useState} from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 type PayloadTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function PayloadTab({transaction}: PayloadTabProps) {

--- a/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
@@ -10,15 +9,21 @@ import {APTCurrencyValue} from "../../../components/IndividualPageContent/Conten
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {parseExpirationTimestamp} from "../../utils";
+import {
+  isPendingTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 type PendingTransactionOverviewTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function PendingTransactionOverviewTab({
   transaction,
 }: PendingTransactionOverviewTabProps) {
-  const transactionData = transaction as Types.Transaction_PendingTransaction;
+  if (!isPendingTransactionResponse(transaction)) {
+    return <></>;
+  }
 
   return (
     <Box marginBottom={3}>
@@ -26,13 +31,13 @@ export default function PendingTransactionOverviewTab({
         <ContentRow
           title="Sender:"
           value={
-            <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
+            <HashButton hash={transaction.sender} type={HashType.ACCOUNT} />
           }
           tooltip={getLearnMoreTooltip("sender")}
         />
         <ContentRow
           title="Sequence Number:"
-          value={transactionData.sequence_number}
+          value={transaction.sequence_number}
           tooltip={getLearnMoreTooltip("sequence_number")}
         />
         <ContentRow
@@ -40,7 +45,7 @@ export default function PendingTransactionOverviewTab({
           value={
             <TimestampValue
               timestamp={parseExpirationTimestamp(
-                transactionData.expiration_timestamp_secs,
+                transaction.expiration_timestamp_secs,
               )}
               ensureMilliSeconds={false}
             />
@@ -49,18 +54,18 @@ export default function PendingTransactionOverviewTab({
         />
         <ContentRow
           title="Gas Unit Price:"
-          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
+          value={<APTCurrencyValue amount={transaction.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow
           title="Max Gas Limit:"
-          value={<GasValue gas={transactionData.max_gas_amount} />}
+          value={<GasValue gas={transaction.max_gas_amount} />}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="Signature:"
           value={
-            <JsonViewCard data={transactionData.signature} collapsedByDefault />
+            <JsonViewCard data={transaction.signature} collapsedByDefault />
           }
           tooltip={getLearnMoreTooltip("signature")}
         />

--- a/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/StateCheckpointOverviewTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
@@ -7,37 +6,42 @@ import {TransactionStatus} from "../../../components/TransactionStatus";
 import {getLearnMoreTooltip} from "../helpers";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
 import TransactionBlockRow from "./Components/TransactionBlockRow";
+import {
+  isStateCheckpointTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 type StateCheckpointOverviewTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function StateCheckpointOverviewTab({
   transaction,
 }: StateCheckpointOverviewTabProps) {
-  const transactionData =
-    transaction as Types.Transaction_StateCheckpointTransaction;
+  if (!isStateCheckpointTransactionResponse(transaction)) {
+    return <></>;
+  }
 
   return (
     <Box marginBottom={3}>
       <ContentBox>
         <ContentRow
           title={"Version:"}
-          value={<Box sx={{fontWeight: 600}}>{transactionData.version}</Box>}
+          value={<Box sx={{fontWeight: 600}}>{transaction.version}</Box>}
           tooltip={getLearnMoreTooltip("version")}
         />
         <ContentRow
           title="Status:"
-          value={<TransactionStatus success={transactionData.success} />}
+          value={<TransactionStatus success={transaction.success} />}
           tooltip={getLearnMoreTooltip("status")}
         />
-        <TransactionBlockRow version={transactionData.version} />
-        {"timestamp" in transactionData && (
+        <TransactionBlockRow version={transaction.version} />
+        {"timestamp" in transaction && (
           <ContentRow
             title="Timestamp:"
             value={
               <TimestampValue
-                timestamp={transactionData.timestamp}
+                timestamp={transaction.timestamp}
                 ensureMilliSeconds
               />
             }
@@ -46,24 +50,24 @@ export default function StateCheckpointOverviewTab({
         )}
         <ContentRow
           title="VM Status:"
-          value={transactionData.vm_status}
+          value={transaction.vm_status}
           tooltip={getLearnMoreTooltip("vm_status")}
         />
       </ContentBox>
       <ContentBox>
         <ContentRow
           title="State Change Hash:"
-          value={transactionData.state_change_hash}
+          value={transaction.state_change_hash}
           tooltip={getLearnMoreTooltip("state_change_hash")}
         />
         <ContentRow
           title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          value={transaction.event_root_hash}
           tooltip={getLearnMoreTooltip("event_root_hash")}
         />
         <ContentRow
           title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
+          value={transaction.accumulator_root_hash}
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>

--- a/src/pages/Transaction/Tabs/UnknownTab.tsx
+++ b/src/pages/Transaction/Tabs/UnknownTab.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Alert, Stack, Box} from "@mui/material";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 type UnknownTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function UnknownTab({transaction}: UnknownTabProps) {

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {Types} from "aptos";
 import {Box} from "@mui/material";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
@@ -16,11 +15,15 @@ import TransactionBlockRow from "./Components/TransactionBlockRow";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {parseExpirationTimestamp} from "../../utils";
 import {TransactionActions} from "./Components/TransactionActions";
+import {
+  isUserTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 function UserTransferOrInteractionRows({
   transaction,
 }: {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 }) {
   const counterparty = getTransactionCounterparty(transaction);
 
@@ -55,7 +58,7 @@ function UserTransferOrInteractionRows({
 function TransactionFunctionRow({
   transaction,
 }: {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 }) {
   return (
     <ContentRow
@@ -66,7 +69,11 @@ function TransactionFunctionRow({
   );
 }
 
-function TransactionAmountRow({transaction}: {transaction: Types.Transaction}) {
+function TransactionAmountRow({
+  transaction,
+}: {
+  transaction: TransactionResponse;
+}) {
   const amount = getTransactionAmount(transaction);
 
   return (
@@ -83,43 +90,45 @@ function TransactionAmountRow({transaction}: {transaction: Types.Transaction}) {
 }
 
 type UserTransactionOverviewTabProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function UserTransactionOverviewTab({
   transaction,
 }: UserTransactionOverviewTabProps) {
-  const transactionData = transaction as Types.Transaction_UserTransaction;
+  if (!isUserTransactionResponse(transaction)) {
+    return <></>;
+  }
 
   return (
     <Box marginBottom={3}>
       <ContentBox padding={4}>
         <ContentRow
           title={"Version:"}
-          value={<Box sx={{fontWeight: 600}}>{transactionData.version}</Box>}
+          value={<Box sx={{fontWeight: 600}}>{transaction.version}</Box>}
           tooltip={getLearnMoreTooltip("version")}
         />
         <ContentRow
           title="Status:"
-          value={<TransactionStatus success={transactionData.success} />}
+          value={<TransactionStatus success={transaction.success} />}
           tooltip={getLearnMoreTooltip("status")}
         />
         <ContentRow
           title="Sender:"
           value={
-            <HashButton hash={transactionData.sender} type={HashType.ACCOUNT} />
+            <HashButton hash={transaction.sender} type={HashType.ACCOUNT} />
           }
           tooltip={getLearnMoreTooltip("sender")}
         />
-        <UserTransferOrInteractionRows transaction={transactionData} />
-        <TransactionFunctionRow transaction={transactionData} />
-        <TransactionAmountRow transaction={transactionData} />
+        <UserTransferOrInteractionRows transaction={transaction} />
+        <TransactionFunctionRow transaction={transaction} />
+        <TransactionAmountRow transaction={transaction} />
       </ContentBox>
       <ContentBox>
-        <TransactionBlockRow version={transactionData.version} />
+        <TransactionBlockRow version={transaction.version} />
         <ContentRow
           title="Sequence Number:"
-          value={transactionData.sequence_number}
+          value={transaction.sequence_number}
           tooltip={getLearnMoreTooltip("sequence_number")}
         />
         <ContentRow
@@ -127,7 +136,7 @@ export default function UserTransactionOverviewTab({
           value={
             <TimestampValue
               timestamp={parseExpirationTimestamp(
-                transactionData.expiration_timestamp_secs,
+                transaction.expiration_timestamp_secs,
               )}
               ensureMilliSeconds={false}
             />
@@ -138,7 +147,7 @@ export default function UserTransactionOverviewTab({
           title="Timestamp:"
           value={
             <TimestampValue
-              timestamp={transactionData.timestamp}
+              timestamp={transaction.timestamp}
               ensureMilliSeconds
             />
           }
@@ -148,8 +157,8 @@ export default function UserTransactionOverviewTab({
           title="Gas Fee:"
           value={
             <GasFeeValue
-              gasUsed={transactionData.gas_used}
-              gasUnitPrice={transactionData.gas_unit_price}
+              gasUsed={transaction.gas_used}
+              gasUnitPrice={transaction.gas_unit_price}
               showGasUsed
             />
           }
@@ -157,17 +166,17 @@ export default function UserTransactionOverviewTab({
         />
         <ContentRow
           title="Gas Unit Price:"
-          value={<APTCurrencyValue amount={transactionData.gas_unit_price} />}
+          value={<APTCurrencyValue amount={transaction.gas_unit_price} />}
           tooltip={getLearnMoreTooltip("gas_unit_price")}
         />
         <ContentRow
           title="Max Gas Limit:"
-          value={<GasValue gas={transactionData.max_gas_amount} />}
+          value={<GasValue gas={transaction.max_gas_amount} />}
           tooltip={getLearnMoreTooltip("max_gas_amount")}
         />
         <ContentRow
           title="VM Status:"
-          value={transactionData.vm_status}
+          value={transaction.vm_status}
           tooltip={getLearnMoreTooltip("vm_status")}
         />
       </ContentBox>
@@ -175,23 +184,23 @@ export default function UserTransactionOverviewTab({
         <ContentRow
           title="Signature:"
           value={
-            <JsonViewCard data={transactionData.signature} collapsedByDefault />
+            <JsonViewCard data={transaction.signature} collapsedByDefault />
           }
           tooltip={getLearnMoreTooltip("signature")}
         />
         <ContentRow
           title="State Change Hash:"
-          value={transactionData.state_change_hash}
+          value={transaction.state_change_hash}
           tooltip={getLearnMoreTooltip("state_change_hash")}
         />
         <ContentRow
           title="Event Root Hash:"
-          value={transactionData.event_root_hash}
+          value={transaction.event_root_hash}
           tooltip={getLearnMoreTooltip("event_root_hash")}
         />
         <ContentRow
           title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
+          value={transaction.accumulator_root_hash}
           tooltip={getLearnMoreTooltip("accumulator_root_hash")}
         />
       </ContentBox>

--- a/src/pages/Transaction/Title.tsx
+++ b/src/pages/Transaction/Title.tsx
@@ -1,11 +1,11 @@
 import {Stack, Typography} from "@mui/material";
 import React from "react";
-import {Types} from "aptos";
 import TitleHashButton, {HashType} from "../../components/TitleHashButton";
 import {TransactionType} from "../../components/TransactionType";
+import {TransactionResponse} from "@aptos-labs/ts-sdk";
 
 type TransactionTitleProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
 };
 
 export default function TransactionTitle({transaction}: TransactionTitleProps) {

--- a/src/pages/Transactions/AllTransactions.tsx
+++ b/src/pages/Transactions/AllTransactions.tsx
@@ -4,13 +4,13 @@ import {
   useQuery,
   UseQueryResult,
 } from "@tanstack/react-query";
-import {Types} from "aptos";
 import {getLedgerInfo, getTransactions} from "../../api";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import Box from "@mui/material/Box";
 import {useSearchParams} from "react-router-dom";
 import {Pagination, Stack} from "@mui/material";
 import TransactionsTable from "./TransactionsTable";
+import {LedgerInfo, TransactionResponse} from "@aptos-labs/ts-sdk";
 
 const LIMIT = 20;
 
@@ -62,7 +62,9 @@ function RenderPagination({
   );
 }
 
-function TransactionContent({data}: UseQueryResult<Array<Types.Transaction>>) {
+function TransactionContent({
+  data,
+}: UseQueryResult<Array<TransactionResponse>>) {
   if (!data) {
     // TODO: error handling!
     return null;
@@ -71,7 +73,7 @@ function TransactionContent({data}: UseQueryResult<Array<Types.Transaction>>) {
   return <TransactionsTable transactions={data} />;
 }
 
-function TransactionsPageInner({data}: UseQueryResult<Types.IndexResponse>) {
+function TransactionsPageInner({data}: UseQueryResult<LedgerInfo>) {
   const maxVersion = parseInt(data?.ledger_version ?? "");
   const limit = LIMIT;
   const [state] = useGlobalState();
@@ -85,7 +87,7 @@ function TransactionsPageInner({data}: UseQueryResult<Types.IndexResponse>) {
 
   const result = useQuery({
     queryKey: ["transactions", {start, limit}, state.network_value],
-    queryFn: () => getTransactions({start, limit}, state.aptos_client),
+    queryFn: () => getTransactions({start, limit}, state.sdk_v2_client),
     placeholderData: keepPreviousData,
   });
 
@@ -115,7 +117,7 @@ export default function AllTransactions() {
 
   const result = useQuery({
     queryKey: ["ledgerInfo", state.network_value],
-    queryFn: () => getLedgerInfo(state.aptos_client),
+    queryFn: () => getLedgerInfo(state.sdk_v2_client),
     refetchInterval: 10000,
   });
 

--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -7,7 +7,6 @@ import Typography from "@mui/material/Typography";
 import GeneralTableRow from "../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCell";
 import HashButton, {HashType} from "../../components/HashButton";
-import {Types} from "aptos";
 import {assertNever} from "../../utils";
 import {TableTransactionType} from "../../components/TransactionType";
 import {TableTransactionStatus} from "../../components/TransactionStatus";
@@ -30,9 +29,14 @@ import {
   getTransactionCounterparty,
 } from "../Transaction/utils";
 import {Link} from "../../routing";
+import {
+  isBlockMetadataTransactionResponse,
+  isUserTransactionResponse,
+  TransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 type TransactionCellProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
   address?: string;
 };
 
@@ -87,10 +91,10 @@ function TransactionTimestampCell({transaction}: TransactionCellProps) {
 
 function TransactionSenderCell({transaction}: TransactionCellProps) {
   let sender;
-  if (transaction.type === "user_transaction") {
-    sender = (transaction as Types.UserTransaction).sender;
-  } else if (transaction.type === "block_metadata_transaction") {
-    sender = (transaction as Types.BlockMetadataTransaction).proposer;
+  if (isUserTransactionResponse(transaction)) {
+    sender = transaction.sender;
+  } else if (isBlockMetadataTransactionResponse(transaction)) {
+    sender = transaction.proposer;
   }
 
   return (
@@ -134,7 +138,7 @@ function TransactionAmount({
   transaction,
   address,
 }: {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
   address?: string;
 }) {
   const isAccountTransactionTable = typeof address === "string";
@@ -184,7 +188,7 @@ function TransactionAmountGasCell({
         <Box sx={{fontSize: 11, color: grey[450]}}>
           {"gas_used" in transaction && "gas_unit_price" in transaction ? (
             <>
-              <>Gas </>
+              <>Gas</>
               <GasFeeValue
                 gasUsed={transaction.gas_used}
                 gasUnitPrice={transaction.gas_unit_price}
@@ -221,7 +225,7 @@ const DEFAULT_COLUMNS: TransactionColumn[] = [
 ];
 
 type TransactionRowProps = {
-  transaction: Types.Transaction;
+  transaction: TransactionResponse;
   columns: TransactionColumn[];
 };
 
@@ -301,7 +305,7 @@ function TransactionHeaderCell({column}: TransactionHeaderCellProps) {
 }
 
 type TransactionsTableProps = {
-  transactions: Types.Transaction[];
+  transactions: TransactionResponse[];
   columns?: TransactionColumn[];
   address?: string;
 };

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -12,7 +12,6 @@ import GeneralTableHeaderCell from "../../components/Table/GeneralTableHeaderCel
 import {assertNever} from "../../utils";
 import GeneralTableBody from "../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../components/Table/GeneralTableCell";
-import {Types} from "aptos";
 import {
   ValidatorData,
   useGetValidators,
@@ -42,6 +41,7 @@ import {
 } from "../DelegatoryValidator/utils";
 import {useLogEventWithBasic} from "../Account/hooks/useLogEventWithBasic";
 import {useGetValidatorSet} from "../../api/hooks/useGetValidatorSet";
+import {MoveValue} from "@aptos-labs/ts-sdk";
 
 function getSortedValidators(
   validators: ValidatorData[],
@@ -323,7 +323,7 @@ function ViewCell() {
 }
 
 function MyDepositCell({validator}: ValidatorCellProps) {
-  const [totalDeposit, setTotalDeposit] = useState<Types.MoveValue>();
+  const [totalDeposit, setTotalDeposit] = useState<MoveValue>();
   const {account} = useWallet();
   const {stakes} = useGetDelegatorStakeInfo(
     account?.address!,
@@ -379,14 +379,14 @@ function ValidatorRow({
     totalVotingPower,
   );
 
-  const rowClick = (address: Types.Address) => {
+  const rowClick = (address: string) => {
     logEvent("delegation_validators_row_clicked", address, {
       commission: commission?.toString() ?? "",
       delegated_stake_amount: validatorVotingPower ?? "",
       network_percentage: networkPercentage ?? "",
       wallet_address: account?.address ?? "",
       wallet_name: wallet?.name ?? "",
-      validator_status: validatorStatus ? validatorStatus[0].toString() : "",
+      validator_status: validatorStatus ? validatorStatus.toString() : "",
     });
   };
 

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -23,6 +23,7 @@ import {
   isNumeric,
   truncateAddress,
 } from "../../utils";
+import {AccountAddress} from "@aptos-labs/ts-sdk";
 
 export type SearchResult = {
   label: string;
@@ -99,11 +100,9 @@ export default function HeaderSearch() {
       } catch (e) {}
     } else {
       if (isValidAccountAddr) {
+        const address = AccountAddress.from(searchText);
         // It's either an account OR an object: we query both at once to save time
-        const accountPromise = await getAccount(
-          {address: searchText},
-          state.aptos_client,
-        )
+        const accountPromise = await getAccount({address}, state.sdk_v2_client)
           .then((): SearchResult => {
             return {
               label: `Account ${searchText}`,
@@ -116,8 +115,8 @@ export default function HeaderSearch() {
           });
 
         const resourcePromise = await getAccountResources(
-          {address: searchText},
-          state.aptos_client,
+          {address},
+          state.sdk_v2_client,
         )
           .then((resources): SearchResult | undefined => {
             let hasObjectCore = false;
@@ -144,7 +143,7 @@ export default function HeaderSearch() {
       if (isValidTxnHashOrVer) {
         const txnPromise = getTransaction(
           {txnHashOrVersion: searchText},
-          state.aptos_client,
+          state.sdk_v2_client,
         )
           .then((): SearchResult => {
             return {
@@ -162,7 +161,7 @@ export default function HeaderSearch() {
       if (isValidBlockHeightOrVer) {
         const blockByHeightPromise = getBlockByHeight(
           {height: parseInt(searchText), withTransactions: false},
-          state.aptos_client,
+          state.sdk_v2_client,
         )
           .then((): SearchResult => {
             return {
@@ -177,7 +176,7 @@ export default function HeaderSearch() {
 
         const blockByVersionPromise = getBlockByVersion(
           {version: parseInt(searchText), withTransactions: false},
-          state.aptos_client,
+          state.sdk_v2_client,
         )
           .then((block): SearchResult => {
             return {


### PR DESCRIPTION
This is an attempt at getting rid of the legacy SDK usage in the explorer, as a preparation for deprecating the legacy TypeScript SDK.

It showed many of the challenges in migrating, and a lot of the custom logic that plagued the codebase.

My home computer tends to get rate limited pretty quickly, but it looks like a few pages seem to break, and will need some fixing