### PR TITLE
Fixes petra names not showing up in search

### DIFF
--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -73,8 +73,8 @@ export default function HeaderSearch() {
 
     const promises = [];
 
-    const isAnsName =
-      searchText.endsWith(".apt") || searchText.endsWith(".petra");
+    if (searchText.endsWith(".petra")) searchText = searchText.concat(".apt");
+    const isAnsName = searchText.endsWith(".apt");
 
     if (isAnsName) {
       try {

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -81,20 +81,16 @@ export default function HeaderSearch() {
         const name = await state.sdk_v2_client?.getName({
           name: searchText,
         });
-        const address = name?.registered_address;
-        const primaryName = await state.sdk_v2_client?.getPrimaryName({
-          address: name?.owner_address ?? "",
-        });
 
-        if (!primaryName || !name || !address) {
-          throw new Error("Primary name not found");
+        const address = name?.registered_address ?? name?.owner_address;
+
+        if (!name || !address) {
+          throw new Error("Name not found");
         }
 
         promises.push({
-          label: `Account ${truncateAddress(address)}${
-            primaryName ? ` | ${primaryName}.apt` : ``
-          }`,
-          to: `/account/${name.owner_address}`,
+          label: `Account ${truncateAddress(address)} ${searchText}`,
+          to: `/account/${address}`,
         });
       } catch (e) {}
     } else {


### PR DESCRIPTION
## UPDATED
This PR updates the search logic to always take you to the target address of the name in question, and if that isn't present it tries the owner address of the name. Previously it would take two searches, first to get the name, then the primary name of the owner of the original name. 

<img width="1098" alt="Screenshot 2024-10-07 at 11 22 27 AM" src="https://github.com/user-attachments/assets/9a78106f-0f34-4f01-820e-96c3c78171c0">
<img width="1106" alt="Screenshot 2024-10-07 at 11 22 34 AM" src="https://github.com/user-attachments/assets/2d86bdab-fb2a-4ab8-b241-b9a568e9fbda">


## DEPRECATED
Petra names were not showing up in the search bar. This was a combination of issues:
1. An existing issue with the indexer and ans contract
2. We were using an outdated ANS query that was held on to by the TS SDK
3. We had not appended `.apt` to the search text before passing it to the TS SDK.

NOTE: This won't work until `1` gets resolved. 