### PR TITLE
Handles potentially null states for coin balance changes

### DIFF
--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -35,7 +35,9 @@ type BalanceChangeCellProps = {
 function AddressCell({balanceChange}: BalanceChangeCellProps) {
   return (
     <GeneralTableCell>
-      <HashButton hash={balanceChange.address} type={HashType.ACCOUNT} />
+      {balanceChange.address ? (
+        <HashButton hash={balanceChange.address} type={HashType.ACCOUNT} />
+      ) : null}
     </GeneralTableCell>
   );
 }

--- a/src/pages/Transaction/utils.tsx
+++ b/src/pages/Transaction/utils.tsx
@@ -235,8 +235,8 @@ export function useTransactionBalanceChanges(txn_version: string) {
             ? BigInt(-a.amount)
             : BigInt(a.amount),
         asset: {
-          decimals: a.metadata.decimals,
-          symbol: a.metadata.symbol,
+          decimals: a.metadata?.decimals,
+          symbol: a.metadata?.symbol,
         },
       })) ?? [];
 


### PR DESCRIPTION
@ying-w found a transaction with both null `owner_address` as well as associated `asset_type`. This PR adds null checking and an empty state for that case. Note the asset type on the second row is gone for the amount. Also, the address on the far left is absent. Previously this would just crash the page. 

![image](https://github.com/user-attachments/assets/3843e8d2-931d-4ce5-91cc-b6b3f7778892)
