### PR TITLE
[run/view] Fix null ABI to not show blank page

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -91,7 +91,7 @@ function Contract({
 
   const moduleAndFnsGroup = modules.reduce(
     (acc, module) => {
-      if (module.abi === undefined) {
+      if (!module.abi) {
         return acc;
       }
 


### PR DESCRIPTION
With modules that don't obey certain rules, they can show no ABI. In that event, the page will go blank, and this fixes it by handling null with undefined

Resolves: https://github.com/aptos-labs/explorer/issues/799