### PR TITLE
[run-function] Fix type tag parsing to allow generics

### DIFF
--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -292,7 +292,7 @@ function RunContractForm({
       arg = "";
     }
     arg = arg.trim();
-    const typeTag = parseTypeTag(type);
+    const typeTag = parseTypeTag(type, {allowGenerics: true});
     if (typeTag.isVector()) {
       const innerTag = typeTag.value;
       if (innerTag.isVector()) {


### PR DESCRIPTION
Without this, you get an error saying `T0` cannot be parsed as a type tag.  This allows generics to be run as functions.

![Uploading Screenshot 2024-10-03 at 9.35.24 AM.png…]()
