### PR TITLE
[account] Add proper handling for invalid account addresses

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,13 +1,11 @@
 export enum ResponseErrorType {
-  NOT_FOUND = "Not found",
+  NOT_FOUND = "Not Found",
+  INVALID_INPUT = "Invalid Input",
   UNHANDLED = "Unhandled",
-  TOO_MANY_REQUESTS = "To Many Requests",
+  TOO_MANY_REQUESTS = "Too Many Requests",
 }
 
-export type ResponseError =
-  | {type: ResponseErrorType.NOT_FOUND; message?: string}
-  | {type: ResponseErrorType.UNHANDLED; message: string}
-  | {type: ResponseErrorType.TOO_MANY_REQUESTS; message?: string};
+export type ResponseError = {type: ResponseErrorType; message?: string};
 
 export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
   return await promise.catch((error) => {

--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -17,6 +17,12 @@ export default function Error({error, address}: ErrorProps) {
           objects associated.
         </Alert>
       );
+    case ResponseErrorType.INVALID_INPUT:
+      return (
+        <Alert severity="error">
+          ({error.type}): {error.message}
+        </Alert>
+      );
     case ResponseErrorType.UNHANDLED:
       if (address) {
         return (


### PR DESCRIPTION
As found in sentry, this is one of the number one errors, where there's an invalid account address, and an unhelpful message appears.  Now, it gives a simple error

<img width="487" alt="Screenshot 2024-10-03 at 12 40 12 PM" src="https://github.com/user-attachments/assets/af20b8f5-1620-41de-8e2a-9ba337d41392">
