### PR TITLE
[balance changes] Fix fee payer, and remove confusing gas column

### DIFF
--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -5,9 +5,7 @@ import GeneralTableHeaderCell from "../../../../components/Table/GeneralTableHea
 import {assertNever} from "../../../../utils";
 import HashButton, {HashType} from "../../../../components/HashButton";
 import {BalanceChange} from "../../utils";
-import CurrencyValue, {
-  APTCurrencyValue,
-} from "../../../../components/IndividualPageContent/ContentValue/CurrencyValue";
+import CurrencyValue from "../../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import {
   negativeColor,
   primary,
@@ -15,17 +13,6 @@ import {
 import {Types} from "aptos";
 import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
-
-function getIsSender(
-  address: string,
-  transaction: Types.UserTransaction,
-): boolean {
-  return transaction.sender === address;
-}
-
-function getGas(transaction: Types.UserTransaction): bigint {
-  return BigInt(transaction.gas_unit_price) * BigInt(transaction.gas_used);
-}
 
 type BalanceChangeCellProps = {
   balanceChange: BalanceChange;
@@ -42,22 +29,14 @@ function AddressCell({balanceChange}: BalanceChangeCellProps) {
   );
 }
 
-function GasCell({balanceChange, transaction}: BalanceChangeCellProps) {
-  const isSender = getIsSender(balanceChange.address, transaction);
-
-  if (!isSender) {
-    return <GeneralTableCell />;
-  }
-
+function TypeCell({balanceChange}: BalanceChangeCellProps) {
   return (
     <GeneralTableCell
       sx={{
         textAlign: "right",
-        color: negativeColor,
       }}
     >
-      {"-"}
-      <APTCurrencyValue amount={getGas(transaction).toString()} />
+      {balanceChange.type}
     </GeneralTableCell>
   );
 }
@@ -86,13 +65,13 @@ function AmountCell({balanceChange}: BalanceChangeCellProps) {
 
 const BalanceChangeCells = Object.freeze({
   address: AddressCell,
-  gas: GasCell,
+  type: TypeCell,
   amount: AmountCell,
 });
 
 type Column = keyof typeof BalanceChangeCells;
 
-const DEFAULT_COLUMNS: Column[] = ["address", "gas", "amount"];
+const DEFAULT_COLUMNS: Column[] = ["address", "type", "amount"];
 
 type BalanceChangeRowProps = {
   balanceChange: BalanceChange;
@@ -129,8 +108,8 @@ function BalanceChangeHeaderCell({column}: BalanceChangeHeaderCellProps) {
   switch (column) {
     case "address":
       return <GeneralTableHeaderCell header="Account" />;
-    case "gas":
-      return <GeneralTableHeaderCell header="Gas" textAlignRight={true} />;
+    case "type":
+      return <GeneralTableHeaderCell header="Type" textAlignRight={true} />;
     case "amount":
       return <GeneralTableHeaderCell header="Change" textAlignRight={true} />;
     default:

--- a/src/pages/Transaction/utils.tsx
+++ b/src/pages/Transaction/utils.tsx
@@ -86,6 +86,7 @@ type ChangeData = {
 export type BalanceChange = {
   address: string;
   amount: bigint;
+  type: string;
   asset: {
     decimals: number;
     symbol: string;
@@ -230,11 +231,14 @@ export function useTransactionBalanceChanges(txn_version: string) {
     data?.fungible_asset_activities
       .filter((a) => a.amount !== null)
       .map((a) => ({
-        address: a.owner_address,
+        address: a.type.includes("GasFeeEvent")
+          ? a.gas_fee_payer_address ?? a.owner_address
+          : a.owner_address,
         amount:
           a.type.includes("GasFeeEvent") || a.type.includes("Withdraw")
             ? BigInt(-a.amount)
             : BigInt(a.amount),
+        type: a.type,
         asset: {
           decimals: a.metadata?.decimals,
           symbol: a.metadata?.symbol,


### PR DESCRIPTION
Now, there's a type column, which has the event name.  We can make it simpler to say "deposit" or "withdraw", but this should be simple for now.

Resolves: https://github.com/aptos-labs/explorer/issues/783 by fixing which account has a gas fee


https://deploy-preview-808--aptos-explorer.netlify.app/txn/1770138261/balanceChange?network=mainnet
Example with fee payer
<img width="971" alt="Screenshot 2024-10-07 at 1 37 56 PM" src="https://github.com/user-attachments/assets/d8a43dea-3064-4c94-b562-18bba907d6ad">
