### PR TITLE
[coin balance changes] Add coin balance change verification

### DIFF
--- a/src/api/hooks/useGetCoinList.ts
+++ b/src/api/hooks/useGetCoinList.ts
@@ -1,0 +1,49 @@
+import {useQuery} from "@tanstack/react-query";
+import {ResponseError} from "../client";
+
+export type CoinDescription = {
+  chainId: number;
+  tokenAddress: string | null;
+  faAddress: string | null;
+  name: string;
+  symbol: string;
+  decimals: number;
+  bridge: string | null;
+  panoraSymbol: string | null;
+  logoUrl: string;
+  websiteUrl: string | null;
+  category: string;
+  isInPanoraTokenList: boolean;
+  isBanned: boolean;
+  panoraOrderIndex: number;
+  coinGeckoId: string | null;
+  coinMarketCapId: number | null;
+};
+
+export function useGetCoinList(options?: {retry?: number | boolean}) {
+  return useQuery<{data: CoinDescription[]}, ResponseError>({
+    queryKey: ["coinList"],
+    queryFn: async (): Promise<any> => {
+      const end_point = "https://api.panora.exchange/tokenlist";
+
+      const query = {};
+
+      const headers = {
+        "x-api-key":
+          "a4^KV_EaTf4MW#ZdvgGKX#HUD^3IFEAOV_kzpIE^3BQGA8pDnrkT7JcIy#HNlLGi",
+      };
+
+      const queryString = new URLSearchParams(query);
+      const url = `${end_point}?${queryString}`;
+
+      const ret = await (
+        await fetch(url, {
+          method: "GET",
+          headers: headers,
+        })
+      ).json();
+      return ret;
+    },
+    retry: options?.retry ?? false,
+  });
+}

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -77,6 +77,7 @@ interface HashButtonProps extends BoxProps {
   type: HashType;
   size?: "small" | "large";
   isValidator?: boolean;
+  img?: string;
 }
 
 export default function HashButton({
@@ -84,6 +85,7 @@ export default function HashButton({
   type,
   size = "small",
   isValidator = false,
+  img,
   ...props
 }: HashButtonProps) {
   if (type === HashType.ACCOUNT || type === HashType.OBJECT) {
@@ -97,7 +99,15 @@ export default function HashButton({
       />
     );
   } else {
-    return <HashButtonInner hash={hash} type={type} size={size} {...props} />;
+    return (
+      <HashButtonInner
+        hash={hash}
+        type={type}
+        size={size}
+        img={img}
+        {...props}
+      />
+    );
   }
 }
 
@@ -184,6 +194,7 @@ interface HashButtonInnerProps extends BoxProps {
   hash: string;
   type: HashType;
   size?: "small" | "large";
+  img?: string;
 }
 
 function HashButtonInner({
@@ -191,6 +202,7 @@ function HashButtonInner({
   hash,
   type,
   size = "small",
+  img,
   ...props
 }: HashButtonInnerProps) {
   const theme = useTheme();
@@ -236,6 +248,7 @@ function HashButtonInner({
         variant="contained"
         endIcon={<ChevronRightRoundedIcon sx={{opacity: "0.75", m: 0}} />}
       >
+        {img ? <img src={img} height={20} width={20} /> : null}
         {label ? label : truncateHash}
       </Button>
 

--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -2,16 +2,112 @@ import {Types} from "aptos";
 import React from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {CoinBalanceChangeTable} from "./Components/CoinBalanceChangeTable";
-import {useTransactionBalanceChanges} from "../utils";
+import {
+  BalanceChange,
+  FungibleAssetActivity,
+  useTransactionBalanceChanges,
+} from "../utils";
+import {
+  CoinDescription,
+  useGetCoinList,
+} from "../../../api/hooks/useGetCoinList";
+import {AccountAddress} from "@aptos-labs/ts-sdk";
 
 type BalanceChangeTabProps = {
   transaction: Types.Transaction;
 };
 
 export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
-  const {data: balanceChanges} = useTransactionBalanceChanges(
+  const {data: coinData} = useGetCoinList();
+
+  const {data: transactionChangesResponse} = useTransactionBalanceChanges(
     "version" in transaction ? transaction.version : transaction.hash,
   );
+
+  function convertAddress(a: FungibleAssetActivity) {
+    return a.type.includes("GasFeeEvent")
+      ? a.gas_fee_payer_address ?? a.owner_address
+      : a.owner_address;
+  }
+
+  function convertType(activity: FungibleAssetActivity) {
+    if (activity.type.includes("GasFee")) {
+      return "Gas Fee";
+    }
+    if (activity.type.includes("Withdraw")) {
+      return "Withdraw";
+    }
+    if (activity.type.includes("Deposit")) {
+      return "Deposit";
+    }
+    if (activity.type.includes("StorageRefund")) {
+      return "Storage Refund";
+    }
+
+    return "Unknown";
+  }
+
+  function convertAmount(activity: FungibleAssetActivity) {
+    if (activity.type.includes("GasFeeEvent")) {
+      return -BigInt(activity.amount);
+    }
+    if (activity.type.includes("Withdraw")) {
+      return BigInt(-activity.amount);
+    }
+    return BigInt(activity.amount);
+  }
+
+  const balanceChanges: BalanceChange[] =
+    transactionChangesResponse?.fungible_asset_activities
+      .filter((a) => a.amount !== null)
+      .map((a) => {
+        const entry = findCoinData(coinData?.data, a.asset_type);
+
+        return {
+          address: convertAddress(a),
+          amount: convertAmount(a),
+          type: convertType(a),
+          asset: {
+            decimals: a.metadata?.decimals,
+            symbol: entry?.panoraSymbol
+              ? entry.panoraSymbol !== a.metadata.symbol
+                ? `${entry.panoraSymbol} (${a.metadata.symbol})`
+                : a.metadata.symbol
+              : a.metadata.symbol,
+            type: a.type,
+            id: entry?.tokenAddress ?? a.asset_type,
+          },
+          known: entry !== undefined,
+          isInPanoraTokenList: entry?.isInPanoraTokenList,
+          isBanned: entry?.isBanned,
+          logoUrl: entry?.logoUrl,
+          panoraSymbol: entry?.panoraSymbol,
+        };
+      }) ?? [];
+
+  // Find gas fee and add a storage refund event
+  const gasFeeEvent =
+    transactionChangesResponse?.fungible_asset_activities.find((a) =>
+      a.type.includes("GasFeeEvent"),
+    );
+  if (gasFeeEvent) {
+    balanceChanges.push({
+      address: gasFeeEvent.gas_fee_payer_address ?? gasFeeEvent.owner_address,
+      amount: BigInt(gasFeeEvent.storage_refund_amount),
+      type: "Storage Refund",
+      asset: {
+        decimals: gasFeeEvent.metadata?.decimals,
+        symbol: gasFeeEvent.metadata?.symbol,
+        type: "v1",
+        id: gasFeeEvent.asset_type,
+      },
+      known: true,
+      isBanned: false,
+      isInPanoraTokenList: true,
+      logoUrl:
+        "https://raw.githubusercontent.com/PanoraExchange/Aptos-Tokens/main/logos/APT.svg",
+    });
+  }
 
   if (balanceChanges.length === 0) {
     return <EmptyTabContent />;
@@ -23,4 +119,29 @@ export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
       transaction={transaction as Types.UserTransaction}
     />
   );
+}
+
+export function findCoinData(
+  coinData: CoinDescription[] | undefined,
+  asset_type: string,
+): CoinDescription | undefined {
+  let entry: CoinDescription | undefined;
+  if (coinData) {
+    const coinType = asset_type.includes("::") ? asset_type : undefined;
+    const faAddress =
+      asset_type && AccountAddress.isValid({input: asset_type}).valid
+        ? AccountAddress.from(asset_type)
+        : undefined;
+    entry = coinData.find((c) => {
+      const isMatchingFa =
+        faAddress &&
+        c.faAddress &&
+        AccountAddress.isValid({input: c.faAddress}).valid &&
+        AccountAddress.from(c.faAddress).equals(faAddress);
+      const isMatchingCoin =
+        coinType && c.tokenAddress && c.tokenAddress === coinType;
+      return isMatchingCoin || isMatchingFa;
+    });
+  }
+  return entry;
 }

--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {Table, TableHead, TableRow} from "@mui/material";
+import {Stack, Table, TableHead, TableRow} from "@mui/material";
 import GeneralTableRow from "../../../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../../components/Table/GeneralTableHeaderCell";
 import {assertNever} from "../../../../utils";
@@ -13,6 +13,16 @@ import {
 import {Types} from "aptos";
 import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
+import VerifiedOutlined from "@mui/icons-material/VerifiedOutlined";
+import {
+  WarningOutlined,
+  DangerousOutlined,
+  VerifiedUserOutlined,
+  WarningAmberOutlined,
+} from "@mui/icons-material";
+import StyledTooltip from "../../../../components/StyledTooltip";
+import {LearnMoreTooltip} from "../../../../components/IndividualPageContent/LearnMoreTooltip";
+import {APTOS_COIN} from "@aptos-labs/ts-sdk";
 
 type BalanceChangeCellProps = {
   balanceChange: BalanceChange;
@@ -33,10 +43,94 @@ function TypeCell({balanceChange}: BalanceChangeCellProps) {
   return (
     <GeneralTableCell
       sx={{
-        textAlign: "right",
+        textAlign: "left",
       }}
     >
       {balanceChange.type}
+    </GeneralTableCell>
+  );
+}
+
+enum VerifiedType {
+  NATIVE_TOKEN,
+  COMMUNITY_VERIFIED,
+  UNVERIFIED,
+  BANNED,
+  UNKNOWN,
+}
+
+function verifiedLevel(balanceChange: BalanceChange): VerifiedType {
+  if (
+    balanceChange?.asset?.id === APTOS_COIN ||
+    balanceChange?.asset?.id === "0xA"
+  ) {
+    return VerifiedType.NATIVE_TOKEN;
+  } else if (balanceChange?.isBanned) {
+    return VerifiedType.BANNED;
+  } else if (balanceChange.isInPanoraTokenList) {
+    return VerifiedType.COMMUNITY_VERIFIED;
+  } else if (balanceChange.known) {
+    return VerifiedType.UNVERIFIED;
+  } else {
+    return VerifiedType.UNKNOWN;
+  }
+}
+
+function VerifiedCell({balanceChange}: BalanceChangeCellProps) {
+  const level = verifiedLevel(balanceChange);
+  return (
+    <GeneralTableCell
+      sx={{
+        textAlign: "left",
+      }}
+    >
+      {level === VerifiedType.NATIVE_TOKEN ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <StyledTooltip title="This asset is verified as a native token of Aptos.">
+            <VerifiedUserOutlined fontSize="small" />
+          </StyledTooltip>
+        </Stack>
+      ) : level === VerifiedType.COMMUNITY_VERIFIED ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <StyledTooltip title="This asset is verified by the community on the Panora token list.">
+            <VerifiedOutlined fontSize="small" />
+          </StyledTooltip>
+        </Stack>
+      ) : level === VerifiedType.BANNED ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <StyledTooltip title="This asset has been banned on the Panora token list, please use with caution.">
+            <DangerousOutlined fontSize="small" />
+          </StyledTooltip>
+        </Stack>
+      ) : level === VerifiedType.UNVERIFIED ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <StyledTooltip title="This asset is recognized, but not been verified by the community.">
+            <WarningAmberOutlined fontSize="small" />
+          </StyledTooltip>
+        </Stack>
+      ) : (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <StyledTooltip title="This asset is not verified, it may or may not be recognized by the community.">
+            <WarningOutlined fontSize="small" />
+          </StyledTooltip>
+        </Stack>
+      )}
+    </GeneralTableCell>
+  );
+}
+
+function TokenInfoCell({balanceChange}: BalanceChangeCellProps) {
+  return (
+    <GeneralTableCell sx={{}}>
+      <HashButton
+        hash={balanceChange.asset.id}
+        type={
+          balanceChange.asset.id.includes("::")
+            ? HashType.COIN
+            : HashType.FUNGIBLE_ASSET
+        }
+        img={balanceChange.logoUrl}
+      />
     </GeneralTableCell>
   );
 }
@@ -66,12 +160,20 @@ function AmountCell({balanceChange}: BalanceChangeCellProps) {
 const BalanceChangeCells = Object.freeze({
   address: AddressCell,
   type: TypeCell,
+  tokenInfo: TokenInfoCell,
+  verified: VerifiedCell,
   amount: AmountCell,
 });
 
 type Column = keyof typeof BalanceChangeCells;
 
-const DEFAULT_COLUMNS: Column[] = ["address", "type", "amount"];
+const DEFAULT_COLUMNS: Column[] = [
+  "address",
+  "type",
+  "tokenInfo",
+  "verified",
+  "amount",
+];
 
 type BalanceChangeRowProps = {
   balanceChange: BalanceChange;
@@ -109,7 +211,22 @@ function BalanceChangeHeaderCell({column}: BalanceChangeHeaderCellProps) {
     case "address":
       return <GeneralTableHeaderCell header="Account" />;
     case "type":
-      return <GeneralTableHeaderCell header="Type" textAlignRight={true} />;
+      return <GeneralTableHeaderCell header="Event Type" />;
+    case "tokenInfo":
+      return <GeneralTableHeaderCell header="Asset" />;
+    case "verified":
+      return (
+        <GeneralTableHeaderCell
+          header="Verified"
+          tooltip={
+            <LearnMoreTooltip
+              text="This uses the Panora token list to verify authenticity of known assets on-chain.  It does not guarantee anything else about the asset."
+              link="https://github.com/PanoraExchange/Aptos-Tokens"
+            />
+          }
+          isTableTooltip={true}
+        />
+      );
     case "amount":
       return <GeneralTableHeaderCell header="Change" textAlignRight={true} />;
     default:


### PR DESCRIPTION
To differentiate between known coins and unknown coins, it will now pull from the Panora coin list to give more information.

Note that, right now, this is a beta feature... There are FAs that are actually migrated coins that need to be updated in the feature.

Partially resolves https://github.com/aptos-labs/explorer/issues/826

Follow-ups:
1. Coin details page
2. FA details page
3. Coin balances on accounts page