### PR TITLE
[balance change] Hide storage refund on balance change page

### DIFF
--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -90,7 +90,7 @@ export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
     transactionChangesResponse?.fungible_asset_activities.find((a) =>
       a.type.includes("GasFeeEvent"),
     );
-  if (gasFeeEvent) {
+  if (gasFeeEvent && (gasFeeEvent?.storage_refund_amount ?? 0) > 0) {
     balanceChanges.push({
       address: gasFeeEvent.gas_fee_payer_address ?? gasFeeEvent.owner_address,
       amount: BigInt(gasFeeEvent.storage_refund_amount),


### PR DESCRIPTION
Previous PR missed the balance change page, but it fixed the overview