### PR TITLE
Verified names

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -5,10 +5,19 @@ import {
   fetchJsonResponse,
   getLocalStorageWithExpiry,
   setLocalStorageWithExpiry,
+  standardizeAddress,
 } from "../../utils";
 import {ResponseError} from "../client";
 
 const TTL = 60000; // 1 minute
+
+// This is an override of ANS names, in case we want to display a verified name for an address
+// TODO: this probably belongs somewhere else... but, for now, it's here
+const knownAddresses: Record<string, string> = {
+  "0xa": "AptosCoin",
+  "0x000000000000000000000000000000000000000000000000000000000000000a":
+    "AptosCoin",
+};
 
 function getFetchNameUrl(
   network: NetworkName,
@@ -33,11 +42,22 @@ export function useGetNameFromAddress(
   const queryResult = useQuery<string | null, ResponseError>({
     queryKey: ["ANSName", address, shouldCache, state.network_name],
     queryFn: () => {
+      const standardizedAddress = standardizeAddress(address);
+      const knownName = knownAddresses[standardizedAddress.toLowerCase()];
+      if (knownName) {
+        return knownName;
+      }
       const cachedName = getLocalStorageWithExpiry(address);
       if (cachedName) {
         return cachedName;
       }
-      return genANSName(address, shouldCache, state.network_name, isValidator);
+      // Ensure there's always .apt at the end
+      return genANSName(
+        address,
+        shouldCache,
+        state.network_name,
+        isValidator,
+      ).then((name) => (name ? `${name}.apt` : null));
     },
   });
 

--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -47,7 +47,9 @@ export function useGetNameFromAddress(
       if (knownName) {
         return knownName;
       }
-      const cachedName = getLocalStorageWithExpiry(address);
+
+      // Change cache key specifically to invalidate all previous cached keys
+      const cachedName = getLocalStorageWithExpiry(`${address}:name`);
       if (cachedName) {
         return cachedName;
       }

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -158,7 +158,7 @@ function AccountHashButtonInner({
         }}
       >
         <Tooltip title={hash} enterDelay={500} enterNextDelay={500}>
-          <span>{name ?? truncateHash}</span>
+          <span>{name ? `${name}.apt` : truncateHash}</span>
         </Tooltip>
         <Tooltip title="Copied" open={copyTooltipOpen}>
           <Button

--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -158,7 +158,7 @@ function AccountHashButtonInner({
         }}
       >
         <Tooltip title={hash} enterDelay={500} enterNextDelay={500}>
-          <span>{name ? `${name}.apt` : truncateHash}</span>
+          <span>{name ?? truncateHash}</span>
         </Tooltip>
         <Tooltip title="Copied" open={copyTooltipOpen}>
           <Button

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -121,6 +121,7 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
   if (!name) {
     return null;
   }
+  const isAns = name.endsWith(".apt") || name.endsWith(".petra");
 
   return (
     <Box>
@@ -136,7 +137,7 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
           padding: "0.15rem 1rem 0.15rem 1rem",
         }}
       >
-        {name.endsWith(".apt") ? (
+        {isAns ? (
           <Link
             href={`https://www.aptosnames.com/name/${name}`}
             target="_blank"
@@ -145,14 +146,12 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
             {name}
           </Link>
         ) : (
-          <>
-            <Typography>
-              {name}{" "}
-              <Tooltip title={"This is a verified address label."}>
-                <VerifiedOutlined fontSize="small" />
-              </Tooltip>
-            </Typography>
-          </>
+          <Typography sx={{display: "flex", alignItems: "row", gap: 1}}>
+            <span>{name}</span>
+            <Tooltip title={"This is a verified address label."}>
+              <VerifiedOutlined fontSize="small" />
+            </Tooltip>
+          </Typography>
         )}
       </Stack>
     </Box>

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -149,7 +149,7 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
           <Typography sx={{display: "flex", alignItems: "row", gap: 1}}>
             <span>{name}</span>
             <Tooltip title={"This is a verified address label."}>
-              <VerifiedOutlined fontSize="small" />
+              <VerifiedOutlined fontSize="small" sx={{position: "relative", top: 2}} />
             </Tooltip>
           </Typography>
         )}

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -13,6 +13,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {truncateAddress, truncateAddressMiddle} from "../pages/utils";
 import {useGetNameFromAddress} from "../api/hooks/useGetANS";
+import VerifiedOutlined from "@mui/icons-material/VerifiedOutlined";
 
 const BUTTON_HEIGHT = 34;
 const TOOLTIP_TIME = 2000; // 2s
@@ -135,13 +136,24 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
           padding: "0.15rem 1rem 0.15rem 1rem",
         }}
       >
-        <Link
-          href={`https://www.aptosnames.com/name/${name}`}
-          target="_blank"
-          underline="none"
-        >
-          {`${name}.apt`}
-        </Link>
+        {name.endsWith(".apt") ? (
+          <Link
+            href={`https://www.aptosnames.com/name/${name}`}
+            target="_blank"
+            underline="none"
+          >
+            {name}
+          </Link>
+        ) : (
+          <>
+            <Typography>
+              {name}{" "}
+              <Tooltip title={"This is a verified address label."}>
+                <VerifiedOutlined fontSize="small" />
+              </Tooltip>
+            </Typography>
+          </>
+        )}
       </Stack>
     </Box>
   );


### PR DESCRIPTION
This provides the ability for verified names, separate of ANS.  ANS name lookups are skipped, and it provides a verification check icon to show that it's a verified name.

For now, I've only provided 0xA as a tester.

An example here: https://deploy-preview-835--aptos-explorer.netlify.app/account/0x000000000000000000000000000000000000000000000000000000000000000a?network=mainnet