### PR TITLE
Update num delegator tooltip

### DIFF
--- a/src/pages/DelegatoryValidator/DetailCard.tsx
+++ b/src/pages/DelegatoryValidator/DetailCard.tsx
@@ -80,7 +80,7 @@ function ValidatorDetailCardContent({
           title="Number of Delegators"
           value={delegatorBalance}
           tooltip={
-            <StyledLearnMoreTooltip text="Number of owner accounts who have delegated stake to this stake pool" />
+            <StyledLearnMoreTooltip text="Number of owner accounts who have delegated stake to this stake pool + reward account(s)" />
           }
         />
         <ContentRowSpaceBetween

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -149,7 +149,7 @@ function ValidatorHeaderCell({
         <GeneralTableHeaderCell
           header="Delegators"
           tooltip={
-            <StyledLearnMoreTooltip text="Number of owner accounts who have delegated stake to this stake pool" />
+            <StyledLearnMoreTooltip text="Number of owner accounts who have delegated stake to this stake pool + reward account(s)" />
           }
           isTableTooltip={false}
         />


### PR DESCRIPTION
Indexer query returns all delegator balances (table items) associated with pool (not doing event parsing) so will include reward accounts