### PR TITLE
Updates monospace font

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
   parserOptions: {ecmaVersion: "latest", sourceType: "module"},
   ignorePatterns: ["pnpm-lock.yaml"],
   // files: ['*.ts', '*.tsx'],
-  // plugins: ['react-refresh'],
+  plugins: ["html"],
   rules: {
     // 'react-refresh/only-export-components': 'warn',
     // TODO: Remove these exceptions once we have better guards

--- a/index.html
+++ b/index.html
@@ -1,20 +1,26 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network." />
+    <meta
+      name="description"
+      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network."
+    />
     <meta property="og:title" content="Aptos Explorer" />
-    <meta property="og:description" content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network." />
+    <meta
+      property="og:description"
+      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network."
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
     <title>Aptos Explorer</title>
-    <!-- 
+    <!--
       This url refers to a css file in adobe fonts/typekit that includes the fonts configured in the aptos web project. The project id is "ifl8enc" which is used in the url.
 
       Fonts used at the time of writing are: (this is configurable in the adobe typekit project and subject to change).
@@ -24,30 +30,45 @@
 
       TODO: purchase font license(s) and integrate directly via @font-face
     -->
+    <link rel="stylesheet" href="https://use.typekit.net/ifl8enc.css" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Inter:wght@100..900&display=swap"
       rel="stylesheet"
-      href="https://use.typekit.net/ifl8enc.css"
     />
 
     <!-- Geo Blocking script from geotargetly.com -->
     <script>
-      (function(g,e,o,t,a,r,ge,tl,y){
-        t=g.getElementsByTagName(o)[0];y=g.createElement(e);y.async=true;
-        y.src='https://g9904216750.co/gb?id=-NkqVZbqVT7_Wp1sgHo5&refurl='+g.referrer+'&winurl='+encodeURIComponent(window.location);
-        t.parentNode.insertBefore(y,t);
-      })(document,'script','head');
+      (function (g, e, o, t, a, r, ge, tl, y) {
+        t = g.getElementsByTagName(o)[0];
+        y = g.createElement(e);
+        y.async = true;
+        y.src =
+          "https://g9904216750.co/gb?id=-NkqVZbqVT7_Wp1sgHo5&refurl=" +
+          g.referrer +
+          "&winurl=" +
+          encodeURIComponent(window.location);
+        t.parentNode.insertBefore(y, t);
+      })(document, "script", "head");
     </script>
 
     <!-- Hotjar Tracking Code for https://explorer.aptoslabs.com/ -->
     <script>
-      (function(h,o,t,j,a,r){
-          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-          h._hjSettings={hjid:3271013,hjsv:6};
-          a=o.getElementsByTagName('head')[0];
-          r=o.createElement('script');r.async=1;
-          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-          a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      (function (h, o, t, j, a, r) {
+        h.hj =
+          h.hj ||
+          function () {
+            (h.hj.q = h.hj.q || []).push(arguments);
+          };
+        h._hjSettings = {hjid: 3271013, hjsv: 6};
+        a = o.getElementsByTagName("head")[0];
+        r = o.createElement("script");
+        r.async = 1;
+        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+        a.appendChild(r);
+      })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
     </script>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "aptos-node-checker-client": "0.0.5",
     "chart.js": "^4.4.1",
     "date-fns": "^3.2.0",
+    "eslint-plugin-html": "^8.1.2",
     "graphql": "^16.8.1",
     "js-sha3": "^0.9.3",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ dependencies:
   date-fns:
     specifier: ^3.2.0
     version: 3.2.0
+  eslint-plugin-html:
+    specifier: ^8.1.2
+    version: 8.1.2
   graphql:
     specifier: ^16.8.1
     version: 16.8.1
@@ -5685,6 +5688,45 @@ packages:
       csstype: 3.1.3
     dev: false
 
+  /dom-serializer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
+      }
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution:
+      {
+        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
+      }
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution:
+      {
+        integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
+      }
+    engines: {node: ">= 4"}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution:
+      {
+        integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==,
+      }
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dot-case@3.0.4:
     resolution:
       {
@@ -5754,7 +5796,6 @@ packages:
         integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
       }
     engines: {node: ">=0.12"}
-    dev: true
 
   /environment@1.1.0:
     resolution:
@@ -5843,6 +5884,16 @@ packages:
         integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
       }
     engines: {node: ">=10"}
+
+  /eslint-plugin-html@8.1.2:
+    resolution:
+      {
+        integrity: sha512-pbRchDV2SmqbCi/Ev/q3aAikzG9BcFe0IjjqjtMn8eTLq71ZUggyJB6CDmuwGAXmYZHrXI12XTfCqvgcnPRqGw==,
+      }
+    engines: {node: ">=16.0.0"}
+    dependencies:
+      htmlparser2: 9.1.0
+    dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.56.0):
     resolution:
@@ -6588,6 +6639,18 @@ packages:
       }
     dependencies:
       react-is: 16.13.1
+    dev: false
+
+  /htmlparser2@9.1.0:
+    resolution:
+      {
+        integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==,
+      }
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /http-cache-semantics@4.1.1:

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -74,7 +74,7 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   //
 
   typography: {
-    fontFamily: `lft-etica-mono,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace`,
+    fontFamily: `"DM Mono",lft-etica-mono,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace`,
     fontWeightLight: 200,
     fontWeightRegular: 400,
     fontWeightBold: 500,
@@ -103,7 +103,7 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
       fontWeight: "600",
     },
     stats: {
-      fontFamily: `lft-etica-mono,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace`,
+      fontFamily: `"DM Mono",lft-etica-mono,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace`,
       fontWeight: "400",
     },
     subtitle1: {


### PR DESCRIPTION
@ying-w noted that `,` and `.` were not distinct in the current monospace font. I pulled in `DM Mono` which is the standard monospace font the design system uses. In the process of modifying the `index.html` file our linter started to fail on the doctype tag. Instead of ignoring it, I opted to pull in `eslint-plugin-html` to parse it.

Note, we are currently using adobe for one font and google fonts for another. We should move fully to the design system's fonts at some point. 

New Font
![image](https://github.com/user-attachments/assets/4612d66a-6875-4b8e-86b0-e5fc84256909)

Old Font
![image](https://github.com/user-attachments/assets/6c22df89-793c-4e09-a673-1a9d232daa0b)
