### PR TITLE
[HashButton] add margin between img and label

### DIFF
--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -248,7 +248,14 @@ function HashButtonInner({
         variant="contained"
         endIcon={<ChevronRightRoundedIcon sx={{opacity: "0.75", m: 0}} />}
       >
-        {img ? <img src={img} height={20} width={20} /> : null}
+        {img ? (
+          <Box
+            component="span"
+            sx={{mr: 1, display: "flex", alignItems: "center"}}
+          >
+            <img src={img} height={20} width={20} />
+          </Box>
+        ) : null}
         {label ? label : truncateHash}
       </Button>
 


### PR DESCRIPTION
|before|after|
|---|---|
|<img width="1411" alt="image" src="https://github.com/user-attachments/assets/f54bb548-a821-4945-8eb3-ed91097a4181">|<img width="1427" alt="image" src="https://github.com/user-attachments/assets/935380c4-794a-495a-a7cb-25320f3f5f07">|