### PR TITLE
[user txns] Hide type on user transactions table

### DIFF
--- a/src/pages/Transactions/TransactionsTable.tsx
+++ b/src/pages/Transactions/TransactionsTable.tsx
@@ -243,6 +243,15 @@ const DEFAULT_COLUMNS: TransactionColumn[] = [
   "amountGas",
 ];
 
+export const USER_COLUMNS: TransactionColumn[] = [
+  "versionStatus",
+  "timestamp",
+  "sender",
+  "receiverOrCounterParty",
+  "function",
+  "amountGas",
+];
+
 type TransactionRowProps = {
   transaction: Types.Transaction;
   columns: TransactionColumn[];
@@ -365,7 +374,7 @@ type UserTransactionsTableProps = {
 
 export function UserTransactionsTable({
   versions,
-  columns = DEFAULT_COLUMNS,
+  columns = USER_COLUMNS,
   address,
 }: UserTransactionsTableProps) {
   return (


### PR DESCRIPTION
This symbol means nothing, because every transaction by definition is a user transaction.

This gives us a little more real estate.

Applies to the main page https://deploy-preview-847--aptos-explorer.netlify.app/?network=mainnet

And for users https://deploy-preview-847--aptos-explorer.netlify.app/account/0xc67545d6f3d36ed01efc9b28cbfd0c1ae326d5d262dd077a29539bcee0edce9e?network=mainnet