### PR TITLE
[transaction types] Update logos, and update tooltip to list all

### DIFF
--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -2,14 +2,13 @@ import {Box, Stack, Typography} from "@mui/material";
 import React from "react";
 import StartRoundedIcon from "@mui/icons-material/StartRounded";
 import OutlinedFlagIcon from "@mui/icons-material/OutlinedFlag";
-import VerifiedOutlined from "@mui/icons-material/VerifiedOutlined";
-import StopOutlined from "@mui/icons-material/StopOutlined";
 import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
 import MultipleStopRoundedIcon from "@mui/icons-material/MultipleStopRounded";
 import UpdateRoundedIcon from "@mui/icons-material/UpdateRounded";
 import QuestionMarkOutlined from "@mui/icons-material/QuestionMarkOutlined";
 import {grey} from "../themes/colors/aptosColorPalette";
 import TooltipTypography from "./TooltipTypography";
+import {CheckCircleOutlined, StopCircleOutlined} from "@mui/icons-material";
 
 export enum TransactionTypeName {
   BlockMetadata = "block_metadata_transaction",
@@ -58,9 +57,9 @@ function getTypeIcon(type: string, color?: Color) {
     case TransactionTypeName.StateCheckpoint:
       return <OutlinedFlagIcon fontSize="small" color={color} />;
     case TransactionTypeName.Validator:
-      return <VerifiedOutlined fontSize="small" color={color} />;
+      return <CheckCircleOutlined fontSize="small" color={color} />;
     case TransactionTypeName.BlockEpilogue:
-      return <StopOutlined fontSize="small" color={color} />;
+      return <StopCircleOutlined fontSize="small" color={color} />;
     default:
       return <QuestionMarkOutlined fontSize="small" color={color} />;
   }

--- a/src/pages/Transactions/Components/TransactionTypeTooltip.tsx
+++ b/src/pages/Transactions/Components/TransactionTypeTooltip.tsx
@@ -11,9 +11,9 @@ export default function TransactionTypeTooltip() {
   return (
     <TableTooltip title="Transaction Types">
       <Stack spacing={2}>
-        <TooltipTransactionType type={TransactionTypeName.User} />
-        <TooltipTransactionType type={TransactionTypeName.BlockMetadata} />
-        <TooltipTransactionType type={TransactionTypeName.StateCheckpoint} />
+        {Object.values(TransactionTypeName).map((type) => (
+          <TooltipTransactionType type={type} />
+        ))}
       </Stack>
     </TableTooltip>
   );


### PR DESCRIPTION
Before:
<img width="494" alt="Screenshot 2024-10-24 at 5 23 21 PM" src="https://github.com/user-attachments/assets/f576039b-3702-4ea0-8e2a-7187aae8ea08">

After:
<img width="488" alt="Screenshot 2024-10-24 at 5 23 38 PM" src="https://github.com/user-attachments/assets/0b7dd1ff-4224-491f-b3d6-78b5a565532f">

