### PR TITLE
[CoinsTable] allow filter by verified

### DIFF
--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -10,7 +10,7 @@ import {
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import HashButton, {HashType} from "../../../components/HashButton";
-import {grey} from "../../../themes/colors/aptosColorPalette";
+import {grey, primary} from "../../../themes/colors/aptosColorPalette";
 import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import {CoinDescription} from "../../../api/hooks/useGetCoinList";
@@ -90,20 +90,47 @@ function CoinVerifiedCell({data}: {data: CoinDescriptionPlusAmount}) {
   });
 }
 
+enum CoinVerificationFilterType {
+  VERIFIED,
+  RECOGNIZED,
+  ALL,
+}
+
 export type CoinDescriptionPlusAmount = {
   amount: number;
   tokenStandard: string;
 } & CoinDescription;
 
 export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
-  const [showVerifiedOnly, setShowVerifiedOnly] = React.useState(true);
+  const [verificationFilter, setVerificationFilter] = React.useState(
+    CoinVerificationFilterType.VERIFIED,
+  );
 
-  const filteredCoins = showVerifiedOnly
-    ? coins.filter((coin) => coin.isInPanoraTokenList)
-    : coins;
+  function toIndex(coin: CoinDescriptionPlusAmount): number {
+    return coin.panoraOrderIndex
+      ? coin.panoraOrderIndex
+      : coin.chainId !== 0
+        ? 0
+        : 1000000;
+  }
 
-  const heavyTextColor = grey[450];
-  const lightTextColor = grey[400];
+  let filteredCoins = coins;
+  switch (verificationFilter) {
+    case CoinVerificationFilterType.VERIFIED:
+      filteredCoins = coins.filter((coin) => coin.isInPanoraTokenList);
+      break;
+    case CoinVerificationFilterType.RECOGNIZED:
+      filteredCoins = coins.filter((coin) => coin.chainId !== 0);
+      break;
+    case CoinVerificationFilterType.ALL:
+      filteredCoins = coins;
+      break;
+  }
+  filteredCoins = filteredCoins.sort((a, b) => toIndex(a) - toIndex(b));
+
+  const selectedTextColor = primary[500];
+  const unselectedTextColor = grey[400];
+  const dividerTextColor = grey[200];
 
   // TODO: For FA, possibly add store as more info
   return (
@@ -117,11 +144,16 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
       >
         <Button
           variant="text"
-          onClick={() => setShowVerifiedOnly(true)}
+          onClick={() =>
+            setVerificationFilter(CoinVerificationFilterType.VERIFIED)
+          }
           sx={{
             fontSize: 12,
             fontWeight: 600,
-            color: showVerifiedOnly ? heavyTextColor : lightTextColor,
+            color:
+              CoinVerificationFilterType.VERIFIED === verificationFilter
+                ? selectedTextColor
+                : unselectedTextColor,
             padding: 0,
             "&:hover": {
               background: "transparent",
@@ -135,18 +167,51 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
           sx={{
             fontSize: 11,
             fontWeight: 600,
-            color: heavyTextColor,
+            color: dividerTextColor,
           }}
         >
           |
         </Typography>
         <Button
           variant="text"
-          onClick={() => setShowVerifiedOnly(false)}
+          onClick={() =>
+            setVerificationFilter(CoinVerificationFilterType.RECOGNIZED)
+          }
           sx={{
             fontSize: 12,
             fontWeight: 600,
-            color: !showVerifiedOnly ? heavyTextColor : lightTextColor,
+            color:
+              CoinVerificationFilterType.RECOGNIZED === verificationFilter
+                ? selectedTextColor
+                : unselectedTextColor,
+            padding: 0,
+            "&:hover": {
+              background: "transparent",
+            },
+          }}
+        >
+          Recognized
+        </Button>
+        <Typography
+          variant="subtitle1"
+          sx={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: dividerTextColor,
+          }}
+        >
+          |
+        </Typography>
+        <Button
+          variant="text"
+          onClick={() => setVerificationFilter(CoinVerificationFilterType.ALL)}
+          sx={{
+            fontSize: 12,
+            fontWeight: 600,
+            color:
+              CoinVerificationFilterType.ALL === verificationFilter
+                ? selectedTextColor
+                : unselectedTextColor,
             padding: 0,
             "&:hover": {
               background: "transparent",

--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -1,5 +1,12 @@
 import * as React from "react";
-import {Table, TableHead, TableRow} from "@mui/material";
+import {
+  Button,
+  Stack,
+  Table,
+  TableRow,
+  Typography,
+  TableHead,
+} from "@mui/material";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import HashButton, {HashType} from "../../../components/HashButton";
@@ -89,57 +96,116 @@ export type CoinDescriptionPlusAmount = {
 } & CoinDescription;
 
 export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
+  const [showVerifiedOnly, setShowVerifiedOnly] = React.useState(true);
+
+  const filteredCoins = showVerifiedOnly
+    ? coins.filter((coin) => coin.isInPanoraTokenList)
+    : coins;
+
+  const heavyTextColor = grey[450];
+  const lightTextColor = grey[400];
+
   // TODO: For FA, possibly add store as more info
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          <GeneralTableHeaderCell header="Name" />
-          <GeneralTableHeaderCell header="Asset Type" />
-          <GeneralTableHeaderCell header="Asset" />
-          <GeneralTableHeaderCell
-            header="Verified"
-            tooltip={
-              <LearnMoreTooltip
-                text="This uses the Panora token list to verify authenticity of known assets on-chain.  It does not guarantee anything else about the asset and is not financial advice."
-                link="https://github.com/PanoraExchange/Aptos-Tokens"
-              />
+    <>
+      <Stack
+        direction="row"
+        justifyContent="flex-end"
+        spacing={1}
+        marginY={0.5}
+        height={16}
+      >
+        <Button
+          variant="text"
+          onClick={() => setShowVerifiedOnly(true)}
+          sx={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: showVerifiedOnly ? heavyTextColor : lightTextColor,
+            padding: 0,
+            "&:hover": {
+              background: "transparent",
+            },
+          }}
+        >
+          Verified
+        </Button>
+        <Typography
+          variant="subtitle1"
+          sx={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: heavyTextColor,
+          }}
+        >
+          |
+        </Typography>
+        <Button
+          variant="text"
+          onClick={() => setShowVerifiedOnly(false)}
+          sx={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: !showVerifiedOnly ? heavyTextColor : lightTextColor,
+            padding: 0,
+            "&:hover": {
+              background: "transparent",
+            },
+          }}
+        >
+          All
+        </Button>
+      </Stack>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <GeneralTableHeaderCell header="Name" />
+            <GeneralTableHeaderCell header="Asset Type" />
+            <GeneralTableHeaderCell header="Asset" />
+            <GeneralTableHeaderCell
+              header="Verified"
+              tooltip={
+                <LearnMoreTooltip
+                  text="This uses the Panora token list to verify authenticity of known assets on-chain. It does not guarantee anything else about the asset and is not financial advice."
+                  link="https://github.com/PanoraExchange/Aptos-Tokens"
+                />
+              }
+              isTableTooltip={true}
+            />
+            <GeneralTableHeaderCell header="Amount" />
+          </TableRow>
+        </TableHead>
+        <GeneralTableBody>
+          {filteredCoins.map((coinDesc, i) => {
+            let friendlyType = coinDesc.tokenStandard;
+            switch (friendlyType) {
+              case "v1":
+                friendlyType = "Coin";
+                break;
+              case "v2":
+                friendlyType = "Fungible Asset";
+                break;
             }
-            isTableTooltip={true}
-          />
-          <GeneralTableHeaderCell header="Amount" />
-        </TableRow>
-      </TableHead>
-      <GeneralTableBody>
-        {coins.map((coinDesc, i) => {
-          let friendlyType = coinDesc.tokenStandard;
-          switch (friendlyType) {
-            case "v1":
-              friendlyType = "Coin";
-              break;
-            case "v2":
-              friendlyType = "Fungible Asset";
-              break;
-          }
-          return (
-            <GeneralTableRow key={i}>
-              <CoinNameCell name={coinDesc.name} />
-              <CoinNameCell name={friendlyType} />
-              <CoinTypeCell data={coinDesc} />
-              <CoinVerifiedCell data={coinDesc} />
-              <AmountCell
-                amount={coinDesc.amount}
-                decimals={coinDesc.decimals}
-                symbol={getAssetSymbol(
-                  coinDesc.panoraSymbol,
-                  coinDesc.bridge,
-                  coinDesc.symbol,
-                )}
-              />
-            </GeneralTableRow>
-          );
-        })}
-      </GeneralTableBody>
-    </Table>
+            return (
+              <GeneralTableRow key={i}>
+                <CoinNameCell name={coinDesc.name} />
+                <CoinNameCell name={friendlyType} />
+                <CoinTypeCell data={coinDesc} />
+                <CoinVerifiedCell data={coinDesc} />
+                <AmountCell
+                  amount={coinDesc.amount}
+                  decimals={coinDesc.decimals}
+                  symbol={getAssetSymbol(
+                    coinDesc.panoraSymbol,
+                    coinDesc.bridge,
+                    coinDesc.symbol,
+                  )}
+                />
+              </GeneralTableRow>
+            );
+          })}
+        </GeneralTableBody>
+      </Table>
+    </>
   );
 }


### PR DESCRIPTION
## difference

|before|after|
|--|--|
|<img width="1424" alt="image" src="https://github.com/user-attachments/assets/9841d43a-bd4b-45f2-8bea-c36fe956962a">|<img width="1419" alt="image" src="https://github.com/user-attachments/assets/c044838f-b30d-4295-afcf-2fccefa5f77c">|

## background

currently, coins page is filled with spam coins, hard to see what what coins matter even with the verified logo.
 
## solution

add "verified | all" tabs and default to "verified" so that only verified coins are displayed by default. only show the rest unless we really want to and click "all"

## to reviewers

the UI is pretty much copied from CollapsibleCards.tsx, only modifying text "expand all | collapse all" to "verified | all"