### PR TITLE
Add hard coded coins

### DIFF
--- a/src/api/hooks/useGetCoinList.ts
+++ b/src/api/hooks/useGetCoinList.ts
@@ -1,5 +1,6 @@
 import {useQuery} from "@tanstack/react-query";
 import {ResponseError} from "../client";
+import {AccountAddress} from "@aptos-labs/ts-sdk";
 
 export type CoinDescription = {
   chainId: number;
@@ -18,6 +19,51 @@ export type CoinDescription = {
   panoraOrderIndex: number;
   coinGeckoId: string | null;
   coinMarketCapId: number | null;
+  native?: boolean;
+};
+
+// This provides a way to hardcode coins that are not in the token list, but still
+// have functionality used elsewhere
+export const HardCodedCoins: Record<string, CoinDescription> = {
+  "0x1::aptos_coin::AptosCoin": {
+    chainId: 1,
+    tokenAddress: "0x1::aptos_coin::AptosCoin",
+    faAddress: "0xa",
+    name: "Aptos Coin",
+    symbol: "APT",
+    decimals: 8,
+    panoraSymbol: "APT",
+    bridge: null,
+    logoUrl:
+      "https://raw.githubusercontent.com/PanoraExchange/Aptos-Tokens/main/logos/APT.svg",
+    websiteUrl: "https://aptosfoundation.org",
+    category: "Native",
+    isInPanoraTokenList: true,
+    isBanned: false,
+    panoraOrderIndex: 1,
+    coinGeckoId: "aptos",
+    coinMarketCapId: 21794,
+    native: true,
+  },
+  "0xd39fcd33aedfd436a1bbb576a48d5c7c0ac317c9a9bb7d53ae9ffb41e8cb9fd9": {
+    chainId: 1,
+    tokenAddress: null,
+    faAddress:
+      "0xd39fcd33aedfd436a1bbb576a48d5c7c0ac317c9a9bb7d53ae9ffb41e8cb9fd9",
+    name: "Find Out Points",
+    symbol: "FFO",
+    decimals: 8,
+    panoraSymbol: null,
+    bridge: null,
+    logoUrl: "",
+    websiteUrl: "https://www.letsfindout.ai/",
+    category: "Native",
+    isInPanoraTokenList: false,
+    isBanned: false,
+    panoraOrderIndex: 999999999,
+    coinGeckoId: null,
+    coinMarketCapId: null,
+  },
 };
 
 export function useGetCoinList(options?: {retry?: number | boolean}) {
@@ -36,12 +82,32 @@ export function useGetCoinList(options?: {retry?: number | boolean}) {
       const queryString = new URLSearchParams(query);
       const url = `${end_point}?${queryString}`;
 
-      const ret = await (
+      const ret: {data: CoinDescription[]} = await (
         await fetch(url, {
           method: "GET",
           headers: headers,
         })
       ).json();
+
+      // Merge hardcoded coins with the fetched coins only adding missing
+      // TODO: Probably provide a list for bad internet connections / rate limiting
+      const hardcodedKeys = Object.keys(HardCodedCoins).filter((key) => {
+        return !ret.data.find((coin) => {
+          return (
+            coin.tokenAddress === key ||
+            (coin.faAddress &&
+              AccountAddress.from(coin.faAddress).toStringLong() === key)
+          );
+        });
+      });
+
+      // Any that don't exist, add them (and at the beginning)
+      const newData: CoinDescription[] = [];
+      hardcodedKeys.forEach((key) => {
+        newData.push(HardCodedCoins[key]);
+      });
+      ret.data = newData.concat(ret.data);
+
       return ret;
     },
     retry: options?.retry ?? false,

--- a/src/components/Table/VerifiedCell.tsx
+++ b/src/components/Table/VerifiedCell.tsx
@@ -42,8 +42,6 @@ const nativeTokens: Record<string, string> = {
   "0xA": "APT",
 };
 const labsVerifiedTokens: Record<string, string> = {
-  "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b":
-    "Native USD₮",
   "0xd39fcd33aedfd436a1bbb576a48d5c7c0ac317c9a9bb7d53ae9ffb41e8cb9fd9":
     "Find Out Points",
 };

--- a/src/components/Table/VerifiedCell.tsx
+++ b/src/components/Table/VerifiedCell.tsx
@@ -20,13 +20,13 @@ type VerifiedCellProps = {
 };
 
 export enum VerifiedType {
-  NATIVE_TOKEN, // Native token e.g. APT
-  LABS_VERIFIED, // Specifically verified by labs
-  COMMUNITY_VERIFIED, // Verified by Panora
-  UNVERIFIED, // In panora list but not verified
-  COMMUNITY_BANNED, // Banned by Panora
-  LABS_BANNED, // Banned by labs
-  UNKNOWN, // Not in panora list, could be anything
+  NATIVE_TOKEN = "Native", // Native token e.g. APT
+  LABS_VERIFIED = "Verified", // Specifically verified by labs
+  COMMUNITY_VERIFIED = "Community Verified", // Verified by Panora
+  RECOGNIZED = "Recognized", // In panora list but not verified
+  UNVERIFIED = "Unverified", // Not in panora list, could be anything
+  LABS_BANNED = "Banned", // Banned by labs
+  COMMUNITY_BANNED = "Community Banned", // Banned by Panora
 }
 
 export function isBannedType(level: VerifiedType): boolean {
@@ -42,6 +42,8 @@ const nativeTokens: Record<string, string> = {
   "0xA": "APT",
 };
 const labsVerifiedTokens: Record<string, string> = {
+  "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b":
+    "Native USD₮",
   "0xd39fcd33aedfd436a1bbb576a48d5c7c0ac317c9a9bb7d53ae9ffb41e8cb9fd9":
     "Find Out Points",
 };
@@ -93,18 +95,19 @@ export function verifiedLevel(input: VerifiedCellProps): VerifiedLevelInfo {
     };
   } else if (input?.known) {
     return {
-      level: VerifiedType.UNVERIFIED,
+      level: VerifiedType.RECOGNIZED,
     };
   } else {
     return {
-      level: VerifiedType.UNKNOWN,
+      level: VerifiedType.UNVERIFIED,
     };
   }
 }
 
-export function VerifiedAsset({data}: {data: VerifiedCellProps}) {
-  const {level, reason} = verifiedLevel(data);
-
+export function getVerifiedMessageAndIcon(
+  level: VerifiedType,
+  reason?: string,
+) {
   let tooltipMessage = "";
   let icon = null;
   switch (level) {
@@ -113,7 +116,7 @@ export function VerifiedAsset({data}: {data: VerifiedCellProps}) {
       icon = <VerifiedUser fontSize="small" />;
       break;
     case VerifiedType.LABS_VERIFIED:
-      tooltipMessage = `This asset is verified.`;
+      tooltipMessage = `This asset is verified by the builders of the explorer.`;
       icon = <Verified fontSize="small" />;
       break;
     case VerifiedType.COMMUNITY_VERIFIED:
@@ -121,27 +124,35 @@ export function VerifiedAsset({data}: {data: VerifiedCellProps}) {
         "This asset is verified by the community on the Panora token list.";
       icon = <VerifiedOutlined fontSize="small" />;
       break;
-    case VerifiedType.UNVERIFIED:
+    case VerifiedType.RECOGNIZED:
       tooltipMessage =
-        "This asset is recognized, but not been verified by the community.";
+        "This asset is recognized, but many not have been verified by the community.";
       icon = <Warning fontSize="small" />;
       break;
-    case VerifiedType.UNKNOWN:
+    case VerifiedType.UNVERIFIED:
       tooltipMessage =
-        "This asset is not verified, it may or may not be recognized by the community.";
+        "This asset is not verified, it may or may not be recognized by the community.  Please use with caution.";
       icon = <WarningAmberOutlined fontSize="small" />;
       break;
     case VerifiedType.COMMUNITY_BANNED:
       tooltipMessage =
-        "This asset has been banned on the Panora token list, please use with caution.";
+        "This asset has been banned on the Panora token list, please avoid using this asset.";
       icon = <DangerousOutlined fontSize="small" />;
       break;
     case VerifiedType.LABS_BANNED:
-      tooltipMessage = `This asset has been marked as a scam or dangerous, please proceed with caution. (${reason})`;
+      tooltipMessage = `This asset has been marked as a scam or dangerous, please avoid using this asset.`;
+      if (reason) {
+        tooltipMessage += ` (${reason})`;
+      }
       icon = <Dangerous fontSize="small" />;
       break;
   }
+  return {tooltipMessage, icon};
+}
 
+export function VerifiedAsset({data}: {data: VerifiedCellProps}) {
+  const {level, reason} = verifiedLevel(data);
+  const {tooltipMessage, icon} = getVerifiedMessageAndIcon(level, reason);
   return (
     <Stack direction="row" spacing={1} alignItems="center">
       <StyledTooltip title={tooltipMessage}>{icon}</StyledTooltip>

--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -15,8 +15,8 @@ import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import {CoinDescription} from "../../../api/hooks/useGetCoinList";
 import {VerifiedCoinCell} from "../../../components/Table/VerifiedCell";
-import {LearnMoreTooltip} from "../../../components/IndividualPageContent/LearnMoreTooltip";
 import {getAssetSymbol} from "../../../utils";
+import {getLearnMoreTooltip} from "../../Transaction/helpers";
 
 function CoinNameCell({name}: {name: string}) {
   return (
@@ -229,12 +229,7 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
             <GeneralTableHeaderCell header="Asset" />
             <GeneralTableHeaderCell
               header="Verified"
-              tooltip={
-                <LearnMoreTooltip
-                  text="This uses the Panora token list to verify authenticity of known assets on-chain. It does not guarantee anything else about the asset and is not financial advice."
-                  link="https://github.com/PanoraExchange/Aptos-Tokens"
-                />
-              }
+              tooltip={getLearnMoreTooltip("coin_verification")}
               isTableTooltip={true}
             />
             <GeneralTableHeaderCell header="Amount" />

--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -17,6 +17,9 @@ import {CoinDescription} from "../../../api/hooks/useGetCoinList";
 import {VerifiedCoinCell} from "../../../components/Table/VerifiedCell";
 import {getAssetSymbol} from "../../../utils";
 import {getLearnMoreTooltip} from "../../Transaction/helpers";
+import {useGlobalState} from "../../../global-config/GlobalConfig";
+import {useEffect} from "react";
+import {Network} from "@aptos-labs/ts-sdk";
 
 function CoinNameCell({name}: {name: string}) {
   return (
@@ -94,6 +97,7 @@ enum CoinVerificationFilterType {
   VERIFIED,
   RECOGNIZED,
   ALL,
+  NONE, // Turns it off entirely
 }
 
 export type CoinDescriptionPlusAmount = {
@@ -102,9 +106,16 @@ export type CoinDescriptionPlusAmount = {
 } & CoinDescription;
 
 export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
+  const [state] = useGlobalState();
   const [verificationFilter, setVerificationFilter] = React.useState(
-    CoinVerificationFilterType.VERIFIED,
+    CoinVerificationFilterType.NONE,
   );
+
+  useEffect(() => {
+    if (state.network_name === Network.MAINNET) {
+      setVerificationFilter(CoinVerificationFilterType.VERIFIED);
+    }
+  }, [state, state.network_value]);
 
   function toIndex(coin: CoinDescriptionPlusAmount): number {
     return coin.panoraOrderIndex
@@ -123,6 +134,7 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
       filteredCoins = coins.filter((coin) => coin.chainId !== 0);
       break;
     case CoinVerificationFilterType.ALL:
+    case CoinVerificationFilterType.NONE:
       filteredCoins = coins;
       break;
   }
@@ -132,95 +144,99 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
   const unselectedTextColor = grey[400];
   const dividerTextColor = grey[200];
 
+  const filterSelector = (
+    <Stack
+      direction="row"
+      justifyContent="flex-end"
+      spacing={1}
+      marginY={0.5}
+      height={16}
+    >
+      <Button
+        variant="text"
+        onClick={() =>
+          setVerificationFilter(CoinVerificationFilterType.VERIFIED)
+        }
+        sx={{
+          fontSize: 12,
+          fontWeight: 600,
+          color:
+            CoinVerificationFilterType.VERIFIED === verificationFilter
+              ? selectedTextColor
+              : unselectedTextColor,
+          padding: 0,
+          "&:hover": {
+            background: "transparent",
+          },
+        }}
+      >
+        Verified
+      </Button>
+      <Typography
+        variant="subtitle1"
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: dividerTextColor,
+        }}
+      >
+        |
+      </Typography>
+      <Button
+        variant="text"
+        onClick={() =>
+          setVerificationFilter(CoinVerificationFilterType.RECOGNIZED)
+        }
+        sx={{
+          fontSize: 12,
+          fontWeight: 600,
+          color:
+            CoinVerificationFilterType.RECOGNIZED === verificationFilter
+              ? selectedTextColor
+              : unselectedTextColor,
+          padding: 0,
+          "&:hover": {
+            background: "transparent",
+          },
+        }}
+      >
+        Recognized
+      </Button>
+      <Typography
+        variant="subtitle1"
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: dividerTextColor,
+        }}
+      >
+        |
+      </Typography>
+      <Button
+        variant="text"
+        onClick={() => setVerificationFilter(CoinVerificationFilterType.ALL)}
+        sx={{
+          fontSize: 12,
+          fontWeight: 600,
+          color:
+            CoinVerificationFilterType.ALL === verificationFilter
+              ? selectedTextColor
+              : unselectedTextColor,
+          padding: 0,
+          "&:hover": {
+            background: "transparent",
+          },
+        }}
+      >
+        All
+      </Button>
+    </Stack>
+  );
+
   // TODO: For FA, possibly add store as more info
   return (
     <>
-      <Stack
-        direction="row"
-        justifyContent="flex-end"
-        spacing={1}
-        marginY={0.5}
-        height={16}
-      >
-        <Button
-          variant="text"
-          onClick={() =>
-            setVerificationFilter(CoinVerificationFilterType.VERIFIED)
-          }
-          sx={{
-            fontSize: 12,
-            fontWeight: 600,
-            color:
-              CoinVerificationFilterType.VERIFIED === verificationFilter
-                ? selectedTextColor
-                : unselectedTextColor,
-            padding: 0,
-            "&:hover": {
-              background: "transparent",
-            },
-          }}
-        >
-          Verified
-        </Button>
-        <Typography
-          variant="subtitle1"
-          sx={{
-            fontSize: 11,
-            fontWeight: 600,
-            color: dividerTextColor,
-          }}
-        >
-          |
-        </Typography>
-        <Button
-          variant="text"
-          onClick={() =>
-            setVerificationFilter(CoinVerificationFilterType.RECOGNIZED)
-          }
-          sx={{
-            fontSize: 12,
-            fontWeight: 600,
-            color:
-              CoinVerificationFilterType.RECOGNIZED === verificationFilter
-                ? selectedTextColor
-                : unselectedTextColor,
-            padding: 0,
-            "&:hover": {
-              background: "transparent",
-            },
-          }}
-        >
-          Recognized
-        </Button>
-        <Typography
-          variant="subtitle1"
-          sx={{
-            fontSize: 11,
-            fontWeight: 600,
-            color: dividerTextColor,
-          }}
-        >
-          |
-        </Typography>
-        <Button
-          variant="text"
-          onClick={() => setVerificationFilter(CoinVerificationFilterType.ALL)}
-          sx={{
-            fontSize: 12,
-            fontWeight: 600,
-            color:
-              CoinVerificationFilterType.ALL === verificationFilter
-                ? selectedTextColor
-                : unselectedTextColor,
-            padding: 0,
-            "&:hover": {
-              background: "transparent",
-            },
-          }}
-        >
-          All
-        </Button>
-      </Stack>
+      {verificationFilter !== CoinVerificationFilterType.NONE && filterSelector}
       <Table>
         <TableHead>
           <TableRow>

--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -13,8 +13,8 @@ import {
 import {Types} from "aptos";
 import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
-import {LearnMoreTooltip} from "../../../../components/IndividualPageContent/LearnMoreTooltip";
 import {VerifiedCoinCell} from "../../../../components/Table/VerifiedCell";
+import {getLearnMoreTooltip} from "../../helpers";
 
 type BalanceChangeCellProps = {
   balanceChange: BalanceChange;
@@ -153,12 +153,7 @@ function BalanceChangeHeaderCell({column}: BalanceChangeHeaderCellProps) {
       return (
         <GeneralTableHeaderCell
           header="Verified"
-          tooltip={
-            <LearnMoreTooltip
-              text="This uses the Panora token list to verify authenticity of known assets on-chain.  It does not guarantee anything else about the asset and is not financial advice."
-              link="https://github.com/PanoraExchange/Aptos-Tokens"
-            />
-          }
+          tooltip={getLearnMoreTooltip("coin_verification")}
           isTableTooltip={true}
         />
       );

--- a/src/pages/Transaction/helpers.tsx
+++ b/src/pages/Transaction/helpers.tsx
@@ -3,6 +3,13 @@ import {
   LearnMoreTooltip,
   LearnMoreTooltipPlaceholder,
 } from "../../components/IndividualPageContent/LearnMoreTooltip";
+import TableTooltip from "../../components/Table/TableTooltip";
+import {Box, Link, Stack} from "@mui/material";
+import {
+  getVerifiedMessageAndIcon,
+  VerifiedType,
+} from "../../components/Table/VerifiedCell";
+import TooltipTypography from "../../components/TooltipTypography";
 
 export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
   switch (txnField) {
@@ -137,6 +144,46 @@ export function getLearnMoreTooltip(txnField: string): JSX.Element | null {
           link="https://aptos.dev/en/network/glossary#move-virtual-machine-mvm"
           linkToText
         />
+      );
+    case "coin_verification":
+      return (
+        <TableTooltip title="Transaction Types">
+          <Stack spacing={2}>
+            <TooltipTypography variant="inherit">
+              The explorer uses the{" "}
+              <Link
+                href="https://github.com/PanoraExchange/Aptos-Tokens"
+                target="_blank"
+              >
+                Panora token list
+              </Link>{" "}
+              to verify authenticity of known assets on-chain. It does not
+              guarantee anything else about the asset and is not financial
+              advice. The following levels of verification are below:
+            </TooltipTypography>
+            {Object.values(VerifiedType).map((level) => {
+              const {tooltipMessage, icon} = getVerifiedMessageAndIcon(level);
+
+              return (
+                <Box sx={{display: "flex", alignItems: "flex-start", gap: 2}}>
+                  {icon}
+                  <Stack spacing={0.5}>
+                    <TooltipTypography variant="subtitle2" fontWeight={600}>
+                      {level}
+                    </TooltipTypography>
+                    <TooltipTypography variant="body2">
+                      {tooltipMessage}
+                    </TooltipTypography>
+                  </Stack>
+                </Box>
+              );
+            })}
+          </Stack>
+        </TableTooltip>
+        /*     <LearnMoreTooltip
+               text=""
+               link="https://github.com/PanoraExchange/Aptos-Tokens"
+             />;*/
       );
     default:
       return <LearnMoreTooltipPlaceholder />;

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -36,6 +36,7 @@ import {knownAddresses} from "../../../api/hooks/useGetANS";
 export type SearchResult = {
   label: string;
   to: string | null;
+  image?: string;
 };
 
 export const NotFoundResult: SearchResult = {
@@ -183,7 +184,7 @@ export default function HeaderSearch() {
   }
 
   function handleAddress(searchText: string): Promise<SearchResult | null>[] {
-    // TODO: add digital assets, collections, fungible asset detection, etc.
+    // TODO: add digital assets, collections, etc.
     const promises = [];
     const address = AccountAddress.from(searchText).toStringLong();
     // It's either an account OR an object: we query both at once to save time
@@ -198,6 +199,7 @@ export default function HeaderSearch() {
         return null;
         // Do nothing. It's expected that not all search input is a valid account
       });
+    // TODO: Add searching the coin list first
     const faPromise = getAccountResource(
       {address, resourceType: faMetadataResource},
       state.aptos_client,
@@ -296,13 +298,15 @@ export default function HeaderSearch() {
       .map((coin: CoinDescription) => {
         if (coin.tokenAddress) {
           return {
-            label: `Coin ${getAssetSymbol(coin.panoraSymbol, coin.bridge, coin.symbol)} - ${coin.tokenAddress}`,
+            label: `${getAssetSymbol(coin.panoraSymbol, coin.bridge, coin.symbol)}`,
             to: `/coin/${coin.tokenAddress}`,
+            image: coin.logoUrl,
           };
         } else {
           return {
-            label: `Fungible Asset ${getAssetSymbol(coin.panoraSymbol, coin.bridge, coin.symbol)} - ${coin.faAddress}`,
+            label: `${getAssetSymbol(coin.panoraSymbol, coin.bridge, coin.symbol)}`,
             to: `/fungible_asset/${coin.faAddress}`,
+            image: coin.logoUrl,
           };
         }
       });
@@ -506,7 +510,11 @@ export default function HeaderSearch() {
       renderOption={(props, option) => {
         return (
           <li {...props} key={props.id}>
-            <ResultLink to={option.to} text={option.label} />
+            <ResultLink
+              to={option.to}
+              text={option.label}
+              image={option.image}
+            />
           </li>
         );
       }}

--- a/src/pages/layout/Search/ResultLink.tsx
+++ b/src/pages/layout/Search/ResultLink.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-import {Typography} from "@mui/material";
+import {Box, Typography} from "@mui/material";
 import {Link} from "../../../routing";
 
 type ResultLinkProps = {
   to: string | null;
   text: string;
+  image?: string;
 };
 
-export default function ResultLink({to, text}: ResultLinkProps): JSX.Element {
+export default function ResultLink({
+  to,
+  text,
+  image,
+}: ResultLinkProps): JSX.Element {
   const style = {
     padding: 0.5,
     display: "block",
@@ -28,7 +33,17 @@ export default function ResultLink({to, text}: ResultLinkProps): JSX.Element {
 
   return (
     <Link to={to} color="inherit" underline="none" sx={style}>
-      {text}
+      <Box sx={{display: "flex", justifyContent: "left"}}>
+        {image ? (
+          <Box
+            component="span"
+            sx={{mr: 1, display: "flex", alignItems: "center"}}
+          >
+            <img src={image} height={20} width={20} />
+          </Box>
+        ) : null}
+        <Typography variant="inherit">{text}</Typography>
+      </Box>
     </Link>
   );
 }


### PR DESCRIPTION
This adds the ability for hardcoded coins that may not be in the Panora coin list for faster response time.  It also cleans up verification level tooltips, and makes sure all coins show on non-mainnet by default