### PR TITLE
[Search] label search does prefix match if len(searchText) >= 4

### DIFF
--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -270,17 +270,21 @@ export default function HeaderSearch() {
   async function handleLabelLookup(
     searchText: string,
   ): Promise<(SearchResult | null)[]> {
-    const searchResults = [];
+    const searchResults: SearchResult[] = [];
     const searchLowerCase = searchText.toLowerCase();
-    for (const address in knownAddresses) {
-      const knownName = knownAddresses[address];
-      if (knownName?.toLowerCase() === searchLowerCase) {
+    Object.entries(knownAddresses).forEach(([address, knownName]) => {
+      if (
+        (searchLowerCase.length >= 4 &&
+          knownName.toLowerCase().startsWith(searchLowerCase)) ||
+        (searchLowerCase.length < 4 &&
+          knownName.toLowerCase() === searchLowerCase)
+      ) {
         searchResults.push({
           label: `Account ${truncateAddress(address)} ${knownName}`,
           to: `/account/${address}`,
         });
       }
-    }
+    });
     return searchResults;
   }
 


### PR DESCRIPTION
"apt" remains as is
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/12dc946d-d2ef-4f9f-a1c9-6879c5f78ce1">
"thala" prefix search works
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/16924ac2-7d99-4893-8c43-8addf24014e3">
