### PR TITLE
[ChangesTab] add "Resource" row for write_resource change

### DIFF
--- a/src/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/src/pages/Transaction/Tabs/ChangesTab.tsx
@@ -65,6 +65,9 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
             />
           )}
           <ContentRow title="State Key Hash:" value={change.state_key_hash} />
+          {"data" in change && change.data && "type" in change.data && (
+            <ContentRow title="Resource:" value={change.data.type} />
+          )}
           {"data" in change && change.data && (
             <ContentRow
               title="Data:"


### PR DESCRIPTION
This is helpful for looking up by resource type, since resource type in Data row is not always fulltext and make ctrl+f search difficult.

Note that in "Before", ctrl+f "AccountPositions" doesnt work, but it works in "After"

|Before|After|
|--|--|
|<img width="1398" alt="image" src="https://github.com/user-attachments/assets/02cfdc10-7223-47de-abe9-3c7ecd1e0a51">|<img width="1392" alt="image" src="https://github.com/user-attachments/assets/f85b2360-c215-4838-8395-08d22d2d9871">|