### PR TITLE
[verification] Add colors to levels, and say the level in words

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -158,8 +158,7 @@ export const knownAddresses: Record<string, string> = {
     "Bybit 1",
   "0xfd9192f8ad8dc60c483a884f0fbc8940f5b8618f3cf2bbf91693982b373dfdea":
     "Bitfinex 1",
-  "0xdc7adffa09da5736ce1303f7441f4367fa423617c6822ad2fbc8522d9efd8fa4":
-    "Htx 1", // Huobi
+  "0xdc7adffa09da5736ce1303f7441f4367fa423617c6822ad2fbc8522d9efd8fa4": "Htx 1", // Huobi
   // Social
   "0x8d2d7bcde13b2513617df3f98cdd5d0e4b9f714c6308b9204fe18ad900d92609":
     "Chingari",
@@ -181,8 +180,7 @@ export const knownAddresses: Record<string, string> = {
   "0xf73e887a8754f540ee6e1a93bdc6dde2af69fc7ca5de32013e89dd44244473cb":
     "USDt contract",
   // Other
-  "0x7e783b349d3e89cf5931af376ebeadbfab855b3fa239b7ada8f5a92fbea6b387":
-    "Pyth", // oracle
+  "0x7e783b349d3e89cf5931af376ebeadbfab855b3fa239b7ada8f5a92fbea6b387": "Pyth", // oracle
   "0x07d7e436f0b2aafde60774efb26ccc432cf881b677aca7faaf2a01879bd19fb8":
     "Switchboard", // oracle
   "0x5a0ad9e31a2f452504429b6f7073cb325994c2c66204f5deb8e0561a9e950c3c": "Tevi",

--- a/src/components/Table/VerifiedCell.tsx
+++ b/src/components/Table/VerifiedCell.tsx
@@ -1,5 +1,5 @@
 import GeneralTableCell from "./GeneralTableCell";
-import {Stack} from "@mui/material";
+import {Box, Stack, useTheme} from "@mui/material";
 import StyledTooltip from "../StyledTooltip";
 import {
   Dangerous,
@@ -11,12 +11,18 @@ import {
 } from "@mui/icons-material";
 import VerifiedOutlined from "@mui/icons-material/VerifiedOutlined";
 import * as React from "react";
+import {
+  codeBlockColor,
+  codeBlockColorClickableOnHover,
+} from "../../themes/colors/aptosColorPalette";
+import {BUTTON_HEIGHT} from "../TitleHashButton";
 
 type VerifiedCellProps = {
   id: string; // FA address or Coin Type
   known: boolean;
   isBanned?: boolean;
   isInPanoraTokenList?: boolean;
+  banner?: boolean;
 };
 
 export enum VerifiedType {
@@ -112,49 +118,72 @@ export function getVerifiedMessageAndIcon(
   switch (level) {
     case VerifiedType.NATIVE_TOKEN:
       tooltipMessage = `This asset is verified as a native token of Aptos.`;
-      icon = <VerifiedUser fontSize="small" />;
+      icon = <VerifiedUser fontSize="small" color="info" />;
       break;
     case VerifiedType.LABS_VERIFIED:
       tooltipMessage = `This asset is verified by the builders of the explorer.`;
-      icon = <Verified fontSize="small" />;
+      icon = <Verified fontSize="small" color="info" />;
       break;
     case VerifiedType.COMMUNITY_VERIFIED:
       tooltipMessage =
         "This asset is verified by the community on the Panora token list.";
-      icon = <VerifiedOutlined fontSize="small" />;
+      icon = <VerifiedOutlined fontSize="small" color="info" />;
       break;
     case VerifiedType.RECOGNIZED:
       tooltipMessage =
         "This asset is recognized, but many not have been verified by the community.";
-      icon = <Warning fontSize="small" />;
+      icon = <Warning fontSize="small" color="secondary" />;
       break;
     case VerifiedType.UNVERIFIED:
       tooltipMessage =
         "This asset is not verified, it may or may not be recognized by the community.  Please use with caution.";
-      icon = <WarningAmberOutlined fontSize="small" />;
+      icon = <WarningAmberOutlined fontSize="small" color="warning" />;
       break;
     case VerifiedType.COMMUNITY_BANNED:
       tooltipMessage =
         "This asset has been banned on the Panora token list, please avoid using this asset.";
-      icon = <DangerousOutlined fontSize="small" />;
+      icon = <DangerousOutlined fontSize="small" color="error" />;
       break;
     case VerifiedType.LABS_BANNED:
       tooltipMessage = `This asset has been marked as a scam or dangerous, please avoid using this asset.`;
       if (reason) {
-        tooltipMessage += ` (${reason})`;
+        tooltipMessage += ` Reason: (${reason})`;
       }
-      icon = <Dangerous fontSize="small" />;
+      icon = <Dangerous fontSize="small" color="error" />;
       break;
   }
   return {tooltipMessage, icon};
 }
 
 export function VerifiedAsset({data}: {data: VerifiedCellProps}) {
+  const theme = useTheme();
   const {level, reason} = verifiedLevel(data);
   const {tooltipMessage, icon} = getVerifiedMessageAndIcon(level, reason);
+
+  const bannerTheme = {
+    height: BUTTON_HEIGHT,
+    backgroundColor: codeBlockColor,
+    "&:hover": {
+      backgroundColor: codeBlockColorClickableOnHover,
+    },
+    color: theme.palette.mode === "dark" ? "#83CCED" : "#0EA5E9",
+    padding: "0.15rem 0.35rem 0.15rem 0.5rem",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    borderRadius: 50,
+    textDecoration: "none",
+  };
+
   return (
-    <Stack direction="row" spacing={1} alignItems="center">
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      sx={data.banner ? bannerTheme : undefined}
+    >
       <StyledTooltip title={tooltipMessage}>{icon}</StyledTooltip>
+      {data.banner && <Box>{level}</Box>}
     </Stack>
   );
 }

--- a/src/components/TitleHashButton.tsx
+++ b/src/components/TitleHashButton.tsx
@@ -8,15 +8,19 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import {grey} from "../themes/colors/aptosColorPalette";
+import {
+  codeBlockColor,
+  codeBlockColorClickableOnHover,
+  grey,
+} from "../themes/colors/aptosColorPalette";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {truncateAddress, truncateAddressMiddle} from "../pages/utils";
 import {useGetNameFromAddress} from "../api/hooks/useGetANS";
 import VerifiedOutlined from "@mui/icons-material/VerifiedOutlined";
 
-const BUTTON_HEIGHT = 34;
-const TOOLTIP_TIME = 2000; // 2s
+export const BUTTON_HEIGHT = 34;
+export const TOOLTIP_TIME = 2000; // 2s
 
 export enum HashType {
   ACCOUNT = "account",
@@ -124,20 +128,32 @@ function Name({address, isValidator}: {address: string; isValidator: boolean}) {
   }
   const isAns = name.endsWith(".apt") || name.endsWith(".petra");
 
+  const ansStyle = {
+    height: BUTTON_HEIGHT,
+    backgroundColor: `${theme.palette.mode === "dark" ? grey[600] : grey[200]}`,
+    borderRadius: 1,
+    color: "inherit",
+    padding: "0.15rem 1rem 0.15rem 1rem",
+  };
+
+  const knownNameStyle = {
+    height: BUTTON_HEIGHT,
+    backgroundColor: codeBlockColor,
+    "&:hover": {
+      backgroundColor: codeBlockColorClickableOnHover,
+    },
+    color: theme.palette.mode === "dark" ? "#83CCED" : "#0EA5E9",
+    padding: "0.15rem 0.35rem 0.15rem 1rem",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    borderRadius: 50,
+    textDecoration: "none",
+  };
+
   return (
     <Box>
-      <Stack
-        justifyContent="center"
-        sx={{
-          height: BUTTON_HEIGHT,
-          backgroundColor: `${
-            theme.palette.mode === "dark" ? grey[600] : grey[200]
-          }`,
-          borderRadius: 1,
-          color: "inherit",
-          padding: "0.15rem 1rem 0.15rem 1rem",
-        }}
-      >
+      <Stack justifyContent="center" sx={isAns ? ansStyle : knownNameStyle}>
         {isAns ? (
           <Link
             href={`https://www.aptosnames.com/name/${name}`}

--- a/src/pages/Coin/Title.tsx
+++ b/src/pages/Coin/Title.tsx
@@ -36,7 +36,9 @@ export default function CoinTitle({struct, coinData, symbol}: CoinTitleProps) {
         {!isBannedType(level) && (
           <TitleHashButton hash={assetSymbol} type={HashType.SYMBOL} />
         )}
-        <VerifiedAsset data={{id: struct, known: !!coinData, ...coinData}} />
+        <VerifiedAsset
+          data={{id: struct, known: !!coinData, banner: true, ...coinData}}
+        />
       </Stack>
     </Stack>
   );

--- a/src/pages/FungibleAsset/Title.tsx
+++ b/src/pages/FungibleAsset/Title.tsx
@@ -38,7 +38,9 @@ export default function FATitle({address, metadata, coinData}: FATitleProps) {
         {!isBannedType(level) && (
           <TitleHashButton hash={assetSymbol} type={HashType.SYMBOL} />
         )}
-        <VerifiedAsset data={{id: address, known: !!coinData, ...coinData}} />
+        <VerifiedAsset
+          data={{id: address, known: !!coinData, banner: true, ...coinData}}
+        />
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
Now colors for verification levels:

<img width="1338" alt="Screenshot 2024-10-28 at 2 45 53 PM" src="https://github.com/user-attachments/assets/3dfb17a1-4908-43ef-8097-8c4edf05e76a"> ( See https://deploy-preview-877--aptos-explorer.netlify.app/account/0xc67545d6f3d36ed01efc9b28cbfd0c1ae326d5d262dd077a29539bcee0edce9e/coins?network=mainnet, you will have to click all on the right)

Balance change example:
https://deploy-preview-877--aptos-explorer.netlify.app/txn/1761043867/balanceChange?network=mainnet

<img width="1477" alt="Screenshot 2024-10-28 at 2 47 50 PM" src="https://github.com/user-attachments/assets/2733a1fd-9f7e-4968-b4dd-30decfa78b7c">

Banned coin example:
https://deploy-preview-877--aptos-explorer.netlify.app/coin/0xbbc4a9af0e7fa8885bda5db08028e7b882f2c2bba1e0fedbad1d8316f73f8b2f::ograffio::Ograffio?network=mainnet
<img width="1028" alt="Screenshot 2024-10-28 at 2 48 37 PM" src="https://github.com/user-attachments/assets/4df3c423-5097-4cd9-bd48-7601bd933c7b">

Verified coin example:
<img width="911" alt="Screenshot 2024-10-28 at 2 51 03 PM" src="https://github.com/user-attachments/assets/8b2c94a3-d0db-4c1a-abeb-8c09dc420b7b">


