### PR TITLE
[CoinTitle] fix style

### DIFF
--- a/src/pages/Coin/Title.tsx
+++ b/src/pages/Coin/Title.tsx
@@ -31,7 +31,15 @@ export default function CoinTitle({struct, coinData, symbol}: CoinTitleProps) {
   return (
     <Stack direction="column" spacing={2} marginX={1}>
       <Typography variant="h3">{title()}</Typography>
-      <Stack direction="row" spacing={1}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          "& > *": {
+            flexShrink: "0", // Prevent elements from shrinking
+          },
+        }}
+      >
         <TitleHashButton hash={struct} type={HashType.STRUCT} />
         {!isBannedType(level) && (
           <TitleHashButton hash={assetSymbol} type={HashType.SYMBOL} />


### PR DESCRIPTION
before
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/508b316c-24d1-45c0-a232-865412179a2f">
after
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/b67fdc91-8db1-4acf-bd1c-62774230326e">
