### PR TITLE
[analytics] Add fullnode count

### DIFF
--- a/src/api/hooks/useGetAnalyticsData.ts
+++ b/src/api/hooks/useGetAnalyticsData.ts
@@ -18,6 +18,7 @@ export type AnalyticsData = {
   max_tps_15_blocks_in_past_30_days: {
     max_tps_15_blocks_in_past_30_days: number;
   }[];
+  latest_node_count: NodeCountData[];
 };
 
 export type DailyAnalyticsData =
@@ -74,6 +75,11 @@ export type DailyUserTxnData = {
 export type MonthlyActiveUserData = {
   mau_signer_30: number;
   date: string;
+};
+
+export type NodeCountData = {
+  date: string;
+  approx_nodes: number;
 };
 
 export function useGetAnalyticsData() {

--- a/src/api/hooks/useGetFullnodeCount.ts
+++ b/src/api/hooks/useGetFullnodeCount.ts
@@ -1,0 +1,17 @@
+import {useEffect, useState} from "react";
+import {NodeCountData, useGetAnalyticsData} from "./useGetAnalyticsData";
+
+export function useGetFullnodeCount() {
+  const [latestNodeCount, setLatestNodeCount] = useState<number | null>(null);
+
+  const analyticsData = useGetAnalyticsData();
+
+  useEffect(() => {
+    if (analyticsData?.latest_node_count !== undefined) {
+      const data = analyticsData.latest_node_count as NodeCountData[];
+      setLatestNodeCount(data[data.length - 1].approx_nodes);
+    }
+  }, [analyticsData?.latest_node_count]);
+
+  return {latestNodeCount};
+}

--- a/src/pages/Analytics/NetworkInfo/ActiveFullnodes.tsx
+++ b/src/pages/Analytics/NetworkInfo/ActiveFullnodes.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import MetricCard from "./MetricCard";
+import {useGetFullnodeCount} from "../../../api/hooks/useGetFullnodeCount";
+
+export default function ActiveFullnodes() {
+  const {latestNodeCount} = useGetFullnodeCount();
+
+  return (
+    <MetricCard
+      data={latestNodeCount ? latestNodeCount.toLocaleString("en-US") : "-"}
+      label="Active Fullnodes"
+      tooltip="Number of approximate fullnodes. Updated once every 24 hours."
+    />
+  );
+}

--- a/src/pages/Analytics/NetworkInfo/NetworkInfo.tsx
+++ b/src/pages/Analytics/NetworkInfo/NetworkInfo.tsx
@@ -7,6 +7,7 @@ import ActiveValidators from "./ActiveValidators";
 import TotalTransactions from "./TotalTransactions";
 import {useGetInMainnet} from "../../../api/hooks/useGetInMainnet";
 import {Link} from "../../../routing";
+import ActiveFullnodes from "./ActiveFullnodes";
 
 type CardStyle = "default" | "outline";
 
@@ -68,6 +69,11 @@ export default function NetworkInfo({isOnHomePage}: NetworkInfoProps) {
         <Grid item xs={12} md={6} lg={3}>
           <LinkableContainer linkToAnalyticsPage={onHomePage}>
             <ActiveValidators />
+          </LinkableContainer>
+        </Grid>
+        <Grid item xs={12} md={6} lg={3}>
+          <LinkableContainer linkToAnalyticsPage={onHomePage}>
+            <ActiveFullnodes />
           </LinkableContainer>
         </Grid>
       </Grid>


### PR DESCRIPTION
### Description

Adds fullnode approx count to the page
<img width="1357" alt="Screenshot 2024-11-01 at 6 10 08 PM" src="https://github.com/user-attachments/assets/2b45f2b4-987f-4b93-b218-5483e7df6f00">

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

- [ ] Have you run `pnpm fmt`?
