### PR TITLE
[verification] Ensure emojicoin addresses only match emojis

### DIFF
--- a/src/components/Table/VerifiedCell.tsx
+++ b/src/components/Table/VerifiedCell.tsx
@@ -291,6 +291,9 @@ export function VerifiedCoinCell({data}: {data: VerifiedCellProps}) {
 export const TEXT_ENCODER = new TextEncoder();
 
 export function getEmojicoinMarketAddressAndTypeTags(args: {symbol: string}) {
+  if (!args.symbol.match(/^\p{Emoji}+$/u)) {
+    return null;
+  }
   const symbolBytes = TEXT_ENCODER.encode(args.symbol);
   const marketAddress = deriveEmojicoinPublisherAddress({
     symbol: symbolBytes,

--- a/src/pages/layout/Search/Index.tsx
+++ b/src/pages/layout/Search/Index.tsx
@@ -343,9 +343,13 @@ export default function HeaderSearch() {
   async function handleEmojiCoinLookup(
     searchText: string,
   ): Promise<(SearchResult | null)[]> {
-    const {marketAddress, coin, lp} = getEmojicoinMarketAddressAndTypeTags({
+    const emojicoinData = getEmojicoinMarketAddressAndTypeTags({
       symbol: searchText,
     });
+    if (!emojicoinData) {
+      return [];
+    }
+    const {marketAddress, coin, lp} = emojicoinData;
     return getAccount(
       {address: marketAddress.toString()},
       state.aptos_client,


### PR DESCRIPTION
### Description

Previously, it's possible though rare, to somehow make a coin that doesn't match emojis, this ensure it only does checks if it's actually emojis.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
