### PR TITLE
Update sanitization to properly accept vanity addresses

### DIFF
--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -58,7 +58,9 @@ export default function AccountPage({isObject = false}: AccountPageProps) {
   let addressError: ResponseError | null = null;
   if (maybeAddress) {
     try {
-      address = AccountAddress.from(maybeAddress).toStringLong();
+      address = AccountAddress.from(maybeAddress, {
+        maxMissingChars: 63,
+      }).toStringLong();
     } catch (e: any) {
       addressError = {
         type: ResponseErrorType.INVALID_INPUT,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,9 @@ export function getBytecodeSizeInKB(bytecodeHex: string): number {
  * Standardizes an address to the format "0x" followed by 64 lowercase hexadecimal digits.
  */
 export const standardizeAddress = (address: AccountAddressInput): string => {
-  return AccountAddress.from(address).toStringLong();
+  return AccountAddress.from(address, {
+    maxMissingChars: 63,
+  }).toStringLong();
 };
 
 export const tryStandardizeAddress = (


### PR DESCRIPTION
### Description

When calling `toStringLong`, make sure the address accepted also accepts vanity addresses so that it can sanitize them.

### Related Links

**Tests**
http://localhost:3000/account/0x4b9da755bccc9fa1d7aafc238118a420684db60cf8b2be0c93f6e4243660efe6?network=mainnet
http://localhost:3000/account/0x000000007c9f6724cfc3ead36713389148bbeb48a310dacd43a767b52ada4be7?network=mainnet

### Checklist
