### PR TITLE
[txns] Fix navigation in transactions with back

### DIFF
--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -81,14 +81,9 @@ export function GraphqlClientProvider({children}: GraphqlClientProviderProps) {
 
 export function useGetIsGraphqlClientSupported(): boolean {
   const [state] = useGlobalState();
-  const [isGraphqlClientSupported, setIsGraphqlClientSupported] =
-    useState<boolean>(getIsGraphqlClientSupportedFor(state.network_name));
-
-  useEffect(() => {
-    setIsGraphqlClientSupported(
-      getIsGraphqlClientSupportedFor(state.network_name),
-    );
-  }, [state.network_name]);
+  const isGraphqlClientSupported = getIsGraphqlClientSupportedFor(
+    state.network_name,
+  );
 
   return isGraphqlClientSupported;
 }

--- a/src/pages/Transactions/Index.tsx
+++ b/src/pages/Transactions/Index.tsx
@@ -1,25 +1,34 @@
-import {useEffect, useState} from "react";
 import {useSearchParams} from "react-router-dom";
 import {Box, Button, Stack, Typography} from "@mui/material";
 import PageHeader from "../layout/PageHeader";
 import AllTransactions from "./AllTransactions";
 import UserTransactions from "./UserTransactions";
 import {useGetIsGraphqlClientSupported} from "../../api/hooks/useGraphqlClient";
-import {useGlobalState} from "../../global-config/GlobalConfig";
 import {usePageMetadata} from "../../components/hooks/usePageMetadata";
+import {useEffect} from "react";
 
 export default function TransactionsPage() {
-  const [state] = useGlobalState();
-  const [userTxnOnly, setUserTxnOnly] = useState<boolean>(true);
   const [searchParams, setSearchParams] = useSearchParams();
   const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
+  const allTxnOnly = searchParams.get("type") === "all";
 
-  useEffect(() => {
-    setUserTxnOnly(isGraphqlClientSupported);
-  }, [isGraphqlClientSupported, state.network_name]);
+  usePageMetadata({title: "Transactions"});
 
+  // Initial search params setup with replace for support back navigation
   useEffect(() => {
-    if (userTxnOnly) {
+    if (isGraphqlClientSupported && !searchParams.get("type")) {
+      searchParams.set("type", "user");
+      return setSearchParams(searchParams, {replace: true});
+    }
+
+    if (!isGraphqlClientSupported && !searchParams.get("type")) {
+      searchParams.set("type", "all");
+      return setSearchParams(searchParams, {replace: true});
+    }
+  }, [isGraphqlClientSupported, searchParams, setSearchParams, allTxnOnly]);
+
+  const toggleUserTxnOnly = () => {
+    if (allTxnOnly) {
       searchParams.set("type", "user");
       searchParams.delete("start");
       setSearchParams(searchParams);
@@ -28,12 +37,6 @@ export default function TransactionsPage() {
       searchParams.delete("page");
       setSearchParams(searchParams);
     }
-  }, [userTxnOnly, searchParams, setSearchParams]);
-
-  usePageMetadata({title: "Transactions"});
-
-  const toggleUserTxnOnly = () => {
-    setUserTxnOnly(!userTxnOnly);
   };
 
   return (
@@ -41,15 +44,15 @@ export default function TransactionsPage() {
       <PageHeader />
       <Stack direction="row" justifyContent="space-between" alignItems="center">
         <Typography variant="h3" marginBottom={2}>
-          {userTxnOnly ? "User Transactions" : "All Transactions"}
+          {allTxnOnly ? "All Transactions" : "User Transactions"}
         </Typography>
         {isGraphqlClientSupported && (
           <Button onClick={toggleUserTxnOnly} variant="text">
-            {userTxnOnly ? `View All Transactions` : `View User Transactions`}
+            {allTxnOnly ? `View User Transactions` : `View All Transactions`}
           </Button>
         )}
       </Stack>
-      {userTxnOnly ? <UserTransactions /> : <AllTransactions />}
+      {allTxnOnly ? <AllTransactions /> : <UserTransactions />}
     </Box>
   );
 }

--- a/src/pages/Transactions/Index.tsx
+++ b/src/pages/Transactions/Index.tsx
@@ -16,16 +16,11 @@ export default function TransactionsPage() {
 
   // Initial search params setup with replace for support back navigation
   useEffect(() => {
-    if (isGraphqlClientSupported && !searchParams.get("type")) {
-      searchParams.set("type", "user");
-      return setSearchParams(searchParams, {replace: true});
+    if (!searchParams.get("type")) {
+      searchParams.set("type", isGraphqlClientSupported ? "user" : "all");
+      setSearchParams(searchParams, {replace: true});
     }
-
-    if (!isGraphqlClientSupported && !searchParams.get("type")) {
-      searchParams.set("type", "all");
-      return setSearchParams(searchParams, {replace: true});
-    }
-  }, [isGraphqlClientSupported, searchParams, setSearchParams, allTxnOnly]);
+  }, [isGraphqlClientSupported, searchParams, setSearchParams]);
 
   const toggleUserTxnOnly = () => {
     if (allTxnOnly) {


### PR DESCRIPTION
Hello!

Fix back navigation in transactions page

For the first navigation to transactions, a replacement is used so that you can exit with one click

Navigations between user and all transactions work as usual

**Before:**

https://github.com/user-attachments/assets/249dcf58-1e16-4a82-840b-f9003621f296

**After**


https://github.com/user-attachments/assets/bd34345c-d35e-4aa4-81da-a34e0cba64b7

**Thanks!**



