### PR TITLE
Fix code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/src/api/hooks/useGetANS.ts
+++ b/src/api/hooks/useGetANS.ts
@@ -104,7 +104,9 @@ async function genANSName(
     }
   } catch (error) {
     console.error(
-      `ERROR! Couldn't find ANS name for ${address} on ${networkName}`,
+      "ERROR! Couldn't find ANS name for %s on %s",
+      address,
+      networkName,
       error,
       typeof error,
     );


### PR DESCRIPTION
Fixes [https://github.com/aptos-labs/explorer/security/code-scanning/2](https://github.com/aptos-labs/explorer/security/code-scanning/2)

To fix the problem, we should avoid directly embedding user-provided values in the format string. Instead, we can use the `%s` specifier in the format string and pass the untrusted data as corresponding arguments. This approach ensures that the user-provided values are treated as strings and not as format specifiers.

- Modify the `console.error` call on line 107 of `src/api/hooks/useGetANS.ts` to use `%s` specifiers.
- Pass the `address` and `networkName` variables as additional arguments to the `console.error` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
