### PR TITLE
[account] Fix refreshes, and reduce excess API queries

### DIFF
--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -74,7 +74,9 @@ function getTabIcon(value: TabValue): JSX.Element {
 type TabPanelProps = {
   value: TabValue;
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: Types.AccountData | undefined;
+  objectData: Types.MoveResource | undefined;
+  resourceData: Types.MoveResource[] | undefined;
   isObject: boolean;
 };
 
@@ -82,6 +84,8 @@ function TabPanel({
   value,
   address,
   accountData,
+  objectData,
+  resourceData,
   isObject,
 }: TabPanelProps): JSX.Element {
   const TabComponent = TabComponents[value];
@@ -89,6 +93,8 @@ function TabPanel({
     <TabComponent
       address={address}
       accountData={accountData}
+      objectData={objectData}
+      resourceData={resourceData}
       isObject={isObject}
     />
   );
@@ -96,7 +102,9 @@ function TabPanel({
 
 type AccountTabsProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: Types.AccountData | undefined;
+  objectData: Types.MoveResource | undefined;
+  resourceData: Types.MoveResource[] | undefined;
   tabValues?: TabValue[];
   isObject?: boolean;
 };
@@ -105,6 +113,8 @@ type AccountTabsProps = {
 export default function AccountTabs({
   address,
   accountData,
+  objectData,
+  resourceData,
   isObject = false,
   tabValues = TAB_VALUES,
 }: AccountTabsProps): JSX.Element {
@@ -146,6 +156,8 @@ export default function AccountTabs({
           value={effectiveTab}
           address={address}
           accountData={accountData}
+          objectData={objectData}
+          resourceData={resourceData}
           isObject={isObject}
         />
       </Box>

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
-import {Types} from "aptos";
 import {CoinDescriptionPlusAmount, CoinsTable} from "../Components/CoinsTable";
 import {
   CoinDescription,
@@ -12,7 +11,6 @@ import {coinOrderIndex} from "../../utils";
 
 type TokenTabsProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
 };
 
 export default function CoinsTab({address}: TokenTabsProps) {

--- a/src/pages/Account/Tabs/InfoTab.tsx
+++ b/src/pages/Account/Tabs/InfoTab.tsx
@@ -10,45 +10,84 @@ import {tryStandardizeAddress} from "../../../utils";
 
 type InfoTabProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: Types.AccountData | undefined;
+  objectData: Types.MoveResource | undefined;
 };
 
-export default function InfoTab({address, accountData}: InfoTabProps) {
-  if (!accountData || Array.isArray(accountData)) {
+export default function InfoTab({
+  address,
+  accountData,
+  objectData,
+}: InfoTabProps) {
+  if (!accountData && !objectData) {
     return <EmptyTabContent />;
   }
 
-  const keyRotated =
-    tryStandardizeAddress(address) !==
-    tryStandardizeAddress(accountData.authentication_key);
+  let accountInfo = null;
+  if (accountData) {
+    const keyRotated =
+      tryStandardizeAddress(address) !==
+      tryStandardizeAddress(accountData.authentication_key);
+
+    accountInfo = (
+      <Box marginBottom={3}>
+        <ContentBox>
+          <ContentRow
+            title={"Sequence Number:"}
+            value={accountData.sequence_number}
+            tooltip={getLearnMoreTooltip("sequence_number")}
+          />
+          {keyRotated ? (
+            <ContentRow
+              title={"Authentication Key:"}
+              value={
+                <>
+                  {`${accountData.authentication_key} `}
+                  <span style={{marginLeft: 8, color: grey[450]}}>
+                    (rotated)
+                  </span>
+                </>
+              }
+              tooltip={getLearnMoreTooltip("authentication_key")}
+            />
+          ) : (
+            <ContentRow
+              title={"Authentication Key:"}
+              value={accountData.authentication_key}
+              tooltip={getLearnMoreTooltip("authentication_key")}
+            />
+          )}
+        </ContentBox>
+      </Box>
+    );
+  }
+
+  let objectInfo = null;
+  if (objectData) {
+    objectInfo = (
+      <Box marginBottom={3}>
+        <ContentBox>
+          <ContentRow
+            title={"Owner:"}
+            value={(objectData.data as any).owner}
+            tooltip={getLearnMoreTooltip("owner")}
+          />
+          <ContentRow
+            title={"Transferrable:"}
+            value={
+              (objectData.data as any).allow_ungated_transfer ? "Yes" : "No"
+            }
+            tooltip={getLearnMoreTooltip("allow_ungated_transfer")}
+          />
+        </ContentBox>
+      </Box>
+    );
+  }
 
   return (
-    <Box marginBottom={3}>
-      <ContentBox>
-        <ContentRow
-          title={"Sequence Number:"}
-          value={accountData.sequence_number}
-          tooltip={getLearnMoreTooltip("sequence_number")}
-        />
-        {keyRotated ? (
-          <ContentRow
-            title={"Authentication Key:"}
-            value={
-              <>
-                {`${accountData.authentication_key} `}
-                <span style={{marginLeft: 8, color: grey[450]}}>(rotated)</span>
-              </>
-            }
-            tooltip={getLearnMoreTooltip("authentication_key")}
-          />
-        ) : (
-          <ContentRow
-            title={"Authentication Key:"}
-            value={accountData.authentication_key}
-            tooltip={getLearnMoreTooltip("authentication_key")}
-          />
-        )}
-      </ContentBox>
-    </Box>
+    <>
+      {accountInfo}
+      {objectInfo}
+    </>
   );
 }

--- a/src/pages/Account/Tabs/ResourcesTab.tsx
+++ b/src/pages/Account/Tabs/ResourcesTab.tsx
@@ -1,7 +1,5 @@
 import {Types} from "aptos";
 import React from "react";
-import Error from "../Error";
-import {useGetAccountResources} from "../../../api/hooks/useGetAccountResources";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import CollapsibleCards from "../../../components/IndividualPageContent/CollapsibleCards";
@@ -9,11 +7,11 @@ import CollapsibleCard from "../../../components/IndividualPageContent/Collapsib
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 
 function ResourcesContent({
-  data,
+  resourceData,
 }: {
-  data: Types.MoveResource[] | undefined;
+  resourceData: Types.MoveResource[] | undefined;
 }): JSX.Element {
-  const resources: Types.MoveResource[] = data ?? [];
+  const resources: Types.MoveResource[] = resourceData ?? [];
 
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
     useExpandedList(resources.length);
@@ -44,20 +42,9 @@ function ResourcesContent({
 }
 
 type ResourcesTabProps = {
-  address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  resourceData: Types.MoveResource[] | undefined;
 };
 
-export default function ResourcesTab({address}: ResourcesTabProps) {
-  const {isLoading, data, error} = useGetAccountResources(address);
-
-  if (isLoading) {
-    return null;
-  }
-
-  if (error) {
-    return <Error address={address} error={error} />;
-  }
-
-  return <ResourcesContent data={data} />;
+export default function ResourcesTab({resourceData}: ResourcesTabProps) {
+  return <ResourcesContent resourceData={resourceData} />;
 }

--- a/src/pages/Account/Tabs/TransactionsTab.tsx
+++ b/src/pages/Account/Tabs/TransactionsTab.tsx
@@ -7,7 +7,8 @@ import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabC
 
 type TransactionsTabProps = {
   address: string;
-  accountData: Types.AccountData | Types.MoveResource[] | undefined;
+  accountData: Types.AccountData | undefined;
+  objectData: Types.MoveResource | undefined;
 };
 
 export default function TransactionsTab({
@@ -18,7 +19,7 @@ export default function TransactionsTab({
 
   // AccountTransactions: render transactions where the account is the sender
   // AccountAllTransactions: render all transactions where the account is involved
-  if (Array.isArray(accountData)) {
+  if (!accountData) {
     return isGraphqlClientSupported ? (
       <AccountAllTransactions address={address} />
     ) : (

--- a/src/pages/Account/Title.tsx
+++ b/src/pages/Account/Title.tsx
@@ -7,18 +7,28 @@ type AccountTitleProps = {
   address: string;
   isObject?: boolean;
   isDeleted?: boolean;
+  isToken?: boolean;
 };
 
 export default function AccountTitle({
   address,
+  isToken = false,
   isObject = false,
   isDeleted = false,
 }: AccountTitleProps) {
   let title = "Account";
-  if (isObject && isDeleted) {
-    title = "Deleted Object";
+  if (isToken) {
+    if (isDeleted) {
+      title = "Deleted Token Object";
+    } else {
+      title = `Token Object`;
+    }
   } else if (isObject) {
-    title = "Object";
+    if (isDeleted) {
+      title = "Deleted Object";
+    } else {
+      title = "Object";
+    }
   }
 
   usePageMetadata({title: `${title} ${address}`});


### PR DESCRIPTION


### Description

This removes repeated account resources queries.  It removes the constant refresh on deleted resources, adds object ownership info easily accessible as well, and should handle mixed account / object.

Resolves https://github.com/aptos-labs/explorer/issues/957


### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
