### PR TITLE
[HashButton] add AssetHashButton

### DIFF
--- a/src/components/HashButton.tsx
+++ b/src/components/HashButton.tsx
@@ -24,6 +24,7 @@ import {useGetNameFromAddress} from "../api/hooks/useGetANS";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import IdenticonImg from "./IdenticonImg";
 import {Link} from "../routing";
+import {useGetCoinList, CoinDescription} from "../api/hooks/useGetCoinList";
 
 export enum HashType {
   ACCOUNT = "account",
@@ -78,37 +79,6 @@ interface HashButtonProps extends BoxProps {
   size?: "small" | "large";
   isValidator?: boolean;
   img?: string;
-}
-
-export default function HashButton({
-  hash,
-  type,
-  size = "small",
-  isValidator = false,
-  img,
-  ...props
-}: HashButtonProps) {
-  if (type === HashType.ACCOUNT || type === HashType.OBJECT) {
-    return (
-      <AccountHashButtonInner
-        hash={hash}
-        type={type}
-        size={size}
-        isValidator={isValidator}
-        {...props}
-      />
-    );
-  } else {
-    return (
-      <HashButtonInner
-        hash={hash}
-        type={type}
-        size={size}
-        img={img}
-        {...props}
-      />
-    );
-  }
 }
 
 interface AccountHashButtonInnerProps extends BoxProps {
@@ -334,4 +304,166 @@ function HashButtonInner({
       </Popover>
     </Box>
   );
+}
+
+interface AssetHashButtonInnerProps extends BoxProps {
+  hash: string;
+  type: HashType;
+  size?: "small" | "large";
+  img?: string;
+}
+
+function AssetHashButtonInner({
+  hash,
+  type,
+  size = "small",
+  img,
+}: AssetHashButtonInnerProps) {
+  const {data: coinData} = useGetCoinList();
+  const [copyTooltipOpen, setCopyTooltipOpen] = useState(false);
+  const theme = useTheme();
+
+  const legitCoin: CoinDescription | undefined = coinData?.data?.find(
+    (coin: CoinDescription) => {
+      const unverified = !coin.panoraTags.some((tag) => tag === "Verified");
+      if (unverified) {
+        return false;
+      }
+      if (type === HashType.COIN) {
+        return coin.tokenAddress === hash;
+      } else {
+        return coin.faAddress === hash;
+      }
+    },
+  );
+
+  const displayName = legitCoin
+    ? size === "large"
+      ? `${legitCoin.name} (${legitCoin.panoraSymbol ?? legitCoin.symbol})`
+      : `${legitCoin.panoraSymbol ?? legitCoin.symbol}`
+    : size === "large"
+      ? truncateAddressMiddle(hash)
+      : truncateAddress(hash);
+
+  const copyAddress = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    await navigator.clipboard.writeText(hash);
+    setCopyTooltipOpen(true);
+    setTimeout(() => {
+      setCopyTooltipOpen(false);
+    }, 2000);
+  };
+
+  const imgIsEmoji = img && img.match(/^\p{Emoji}+$/u);
+  let icon = null;
+  if (img && imgIsEmoji) {
+    icon = (
+      <Box component="span" sx={{mr: 1, display: "flex", alignItems: "center"}}>
+        {img}
+      </Box>
+    );
+  } else if (img) {
+    icon = (
+      <Box component="span" sx={{mr: 1, display: "flex", alignItems: "center"}}>
+        <img src={img} height={20} width={20} />
+      </Box>
+    );
+  } else if (legitCoin?.logoUrl) {
+    icon = (
+      <Box component="span" sx={{mr: 1, display: "flex", alignItems: "center"}}>
+        <img src={legitCoin.logoUrl} height={20} width={20} />
+      </Box>
+    );
+  }
+
+  return (
+    <Stack direction="row" alignItems={"center"} spacing={1}>
+      {icon}
+      <Link
+        to={getHashLinkStr(hash, type)}
+        sx={{
+          backgroundColor: codeBlockColor,
+          "&:hover": {
+            backgroundColor: codeBlockColorClickableOnHover,
+          },
+          color: theme.palette.mode === "dark" ? "#83CCED" : "#0EA5E9",
+          padding: "0.15rem 0.35rem 0.15rem 1rem",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+          borderRadius: 50,
+          textDecoration: "none",
+        }}
+      >
+        <Tooltip title={displayName} enterDelay={500} enterNextDelay={500}>
+          <span>{displayName}</span>
+        </Tooltip>
+        <Tooltip title="Copied" open={copyTooltipOpen}>
+          <Button
+            sx={{
+              color: "inherit",
+              "&:hover": {
+                backgroundColor: `${
+                  theme.palette.mode === "dark" ? primary[700] : primary[100]
+                }`,
+                color: `${
+                  theme.palette.mode === "dark" ? primary[100] : primary[600]
+                }`,
+              },
+              padding: "0.25rem 0.5rem 0.25rem 0.5rem",
+              margin: "0 0 0 0.2rem",
+              minWidth: "unset",
+              borderRadius: 50,
+            }}
+            onClick={copyAddress}
+            endIcon={
+              <ContentCopyIcon sx={{opacity: "0.75", mr: 1}} fontSize="small" />
+            }
+            size="small"
+          />
+        </Tooltip>
+      </Link>
+    </Stack>
+  );
+}
+
+export default function HashButton({
+  hash,
+  type,
+  size = "small",
+  isValidator = false,
+  img,
+  ...props
+}: HashButtonProps) {
+  if (type === HashType.ACCOUNT || type === HashType.OBJECT) {
+    return (
+      <AccountHashButtonInner
+        hash={hash}
+        type={type}
+        size={size}
+        isValidator={isValidator}
+        {...props}
+      />
+    );
+  } else if (type === HashType.COIN || type === HashType.FUNGIBLE_ASSET) {
+    return (
+      <AssetHashButtonInner
+        hash={hash}
+        type={type}
+        size={size}
+        img={img}
+        {...props}
+      />
+    );
+  } else {
+    return (
+      <HashButtonInner
+        hash={hash}
+        type={type}
+        size={size}
+        img={img}
+        {...props}
+      />
+    );
+  }
 }

--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -65,6 +65,7 @@ function TokenInfoCell({balanceChange}: BalanceChangeCellProps) {
             ? HashType.COIN
             : HashType.FUNGIBLE_ASSET
         }
+        size="large"
         img={
           balanceChange.logoUrl
             ? balanceChange.logoUrl

--- a/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/src/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -416,6 +416,7 @@ const swapAction = (
             : HashType.FUNGIBLE_ASSET
         }
         img={assetInCoin?.logoUrl}
+        size="small"
       />
       for {action.amountOut / Math.pow(10, assetOutCoin?.decimals ?? 0)}
       <HashButton
@@ -426,6 +427,7 @@ const swapAction = (
             : HashType.FUNGIBLE_ASSET
         }
         img={assetOutCoin?.logoUrl}
+        size="small"
       />
       on <HashButton hash={action.dex} type={HashType.ACCOUNT} />
     </Box>


### PR DESCRIPTION
### Description

https://deploy-preview-987--aptos-explorer.netlify.app/txn/2199584346?network=mainnet

before
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/8dee65c1-3115-44d1-8e1c-99d1147227a7" />

after
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/45ba7f9a-47e0-4a8f-a467-2bdba77bd691" />

---

before
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/38ff56c7-f905-4b2d-9d03-85bfd3bd90d2" />

after
<img width="1426" alt="image" src="https://github.com/user-attachments/assets/1ca118b2-fc3f-4b18-ba05-5967c2ba5768" />

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
