### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/src/pages/layout/Footer.tsx
+++ b/src/pages/layout/Footer.tsx
@@ -25,7 +25,7 @@ const socialLinks = [
     url: "https://discord.com/invite/aptosnetwork",
     icon: DiscordLogo,
   },
-  {title: "Twitter", url: "https://twitter.com/aptoslabs/", icon: TwitterLogo},
+  {title: "Twitter", url: "https://x.com/aptoslabs/", icon: TwitterLogo},
   {title: "Medium", url: "https://aptoslabs.medium.com/", icon: MediumLogo},
   {
     title: "LinkedIn",


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com/youngbuddha108 to reflect the platform's rebranding.
