### PR TITLE
Fix transaction submission against local testnet

### DIFF
--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -40,8 +40,7 @@ const useSubmitTransaction = () => {
 
   async function submitTransaction(transaction: InputTransactionData) {
     if (
-      network?.name.toLocaleLowerCase() !==
-        (state.network_name === "local" ? "localhost" : state.network_name) &&
+      network?.name.toLocaleLowerCase() !== state.network_name &&
       // TODO: This is a hack to get around network being cached
       wallet?.name !== "Google (AptosConnect)"
     ) {


### PR DESCRIPTION
### Description

When users are using a wallet (Petra) set to localnet and set Explorer to localnet, they are having `Wallet and Explorer should use the same network to submit a transaction` error

The wallet adapter uses "local" as the network name, so no need to add the conversion to "localhost"

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
