### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/explorer/security/code-scanning/9](https://github.com/aptos-labs/explorer/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will set the `contents` permission to `read`, which is sufficient for the linting and testing steps in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
