### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/explorer/security/code-scanning/8](https://github.com/aptos-labs/explorer/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs linting and testing, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
