### PR TITLE
[coins] Add migration to FA buttons

### DIFF
--- a/src/pages/Account/Components/CoinsTable.tsx
+++ b/src/pages/Account/Components/CoinsTable.tsx
@@ -188,8 +188,10 @@ function CoinMigrationCell({
   switch (isSuccessful) {
     case true:
       icon = <CheckCircleIcon />;
+      break;
     case false:
       icon = <ErrorOutlinedIcon />;
+      break;
   }
   return (
     <>

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -8,12 +8,14 @@ import {
 import {findCoinData} from "../../Transaction/Tabs/BalanceChangeTab";
 import {useGetAccountCoins} from "../../../api/hooks/useGetAccountCoins";
 import {coinOrderIndex} from "../../utils";
+import {Types} from "aptos";
 
 type TokenTabsProps = {
   address: string;
+  resourceData: Types.MoveResource[] | undefined;
 };
 
-export default function CoinsTab({address}: TokenTabsProps) {
+export default function CoinsTab({address, resourceData}: TokenTabsProps) {
   const {data: coinData} = useGetCoinList();
 
   const {isLoading, error, data} = useGetAccountCoins(address);
@@ -103,5 +105,11 @@ export default function CoinsTab({address}: TokenTabsProps) {
       });
   }
 
-  return <CoinsTable coins={parse_coins()} />;
+  return (
+    <CoinsTable
+      address={address}
+      resourceData={resourceData}
+      coins={parse_coins()}
+    />
+  );
 }


### PR DESCRIPTION
### Description
Adds conditional buttons for migrating to FA

1. Only enables button if it's not migrated
2. Only enables button if it's your account (the connected one)
3. Doesn't enable if it's FA

### Related Links

<img width="1211" alt="Screenshot 2025-06-02 at 11 58 27 PM" src="https://github.com/user-attachments/assets/f078a00b-49aa-4531-8d09-a11e971b3b25" />

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
