### PR TITLE
Fix module navigation between packages and other tabs in AccountPage

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -50,11 +50,15 @@ export default function ExplorerRoutes() {
 
         <Route path="/account">
           <Route
+            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            element={<AccountPage />}
+          />
+          <Route
             path=":address/modules/:modulesTab/:selectedModuleName"
             element={<AccountPage />}
           />
           <Route
-            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            path=":address/modules/:modulesTab"
             element={<AccountPage />}
           />
           <Route path=":address/:tab" element={<AccountPage />} />
@@ -63,11 +67,15 @@ export default function ExplorerRoutes() {
 
         <Route path="/object">
           <Route
+            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            element={<AccountPage isObject={true} />}
+          />
+          <Route
             path=":address/modules/:modulesTab/:selectedModuleName"
             element={<AccountPage isObject={true} />}
           />
           <Route
-            path=":address/modules/:modulesTab/:selectedModuleName/:selectedFnName"
+            path=":address/modules/:modulesTab"
             element={<AccountPage isObject={true} />}
           />
           <Route

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -103,35 +103,45 @@ function ModulesTabs({
       logEvent(eventName);
     }
 
-    let moduleNameParam = "";
-    let fnNameParam = "";
-
-    if (value === "packages" && newValue !== "packages") {
-      // From packages to other tabs: convert package name to first module name
-      if (selectedModuleName) {
-        const selectedPackage = sortedPackages.find(
-          (pkg) => pkg.name === selectedModuleName,
-        );
-        if (selectedPackage && selectedPackage.modules.length > 0) {
-          moduleNameParam = selectedPackage.modules[0].name;
+    const {moduleNameParam, fnNameParam} = (() => {
+      if (value === "packages" && newValue !== "packages") {
+        // From packages to other tabs: convert package name to first module name
+        if (selectedModuleName) {
+          const selectedPackage = sortedPackages.find(
+            (pkg) => pkg.name === selectedModuleName,
+          );
+          if (selectedPackage && selectedPackage.modules.length > 0) {
+            return {
+              moduleNameParam: selectedPackage.modules[0].name,
+              fnNameParam: "",
+            };
+          }
         }
-      }
-    } else if (value !== "packages" && newValue === "packages") {
-      // From other tabs to packages: convert module name to package name
-      if (selectedModuleName) {
-        const packageForModule = sortedPackages.find((pkg) =>
-          pkg.modules.some((mod) => mod.name === selectedModuleName),
-        );
-        if (packageForModule) {
-          moduleNameParam = packageForModule.name;
+        return {moduleNameParam: "", fnNameParam: ""};
+      } else if (value !== "packages" && newValue === "packages") {
+        // From other tabs to packages: convert module name to package name
+        if (selectedModuleName) {
+          const packageForModule = sortedPackages.find((pkg) =>
+            pkg.modules.some((mod) => mod.name === selectedModuleName),
+          );
+          if (packageForModule) {
+            return {
+              moduleNameParam: packageForModule.name,
+              fnNameParam: "",
+            };
+          }
         }
+        return {moduleNameParam: "", fnNameParam: ""};
+      } else if (value !== "packages" && newValue !== "packages") {
+        // Between non-packages tabs: preserve module name and function name
+        return {
+          moduleNameParam: selectedModuleName || "",
+          fnNameParam: selectedFnName ? `/${selectedFnName}` : "",
+        };
       }
-    } else if (value !== "packages" && newValue !== "packages") {
-      // Between non-packages tabs: preserve module name and function name
-      moduleNameParam = selectedModuleName || "";
-      fnNameParam = selectedFnName ? `/${selectedFnName}` : "";
-    }
-    // If both are packages or no conversion needed, leave params empty
+      // If both are packages or no conversion needed, leave params empty
+      return {moduleNameParam: "", fnNameParam: ""};
+    })();
 
     navigate(
       `/${accountPagePath(isObject)}/${address}/modules/${newValue}${moduleNameParam ? `/${moduleNameParam}` : ""}${fnNameParam}`,

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -119,16 +119,11 @@ function ModulesTabs({
     } else if (value !== "packages" && newValue === "packages") {
       // From other tabs to packages: convert module name to package name
       if (selectedModuleName) {
-        const selectedModule = sortedPackages
-          .flatMap((pkg) => pkg.modules)
-          .find((module) => module.name === selectedModuleName);
-        if (selectedModule) {
-          const packageForModule = sortedPackages.find((pkg) =>
-            pkg.modules.some((mod) => mod.name === selectedModuleName),
-          );
-          if (packageForModule) {
-            moduleNameParam = packageForModule.name;
-          }
+        const packageForModule = sortedPackages.find((pkg) =>
+          pkg.modules.some((mod) => mod.name === selectedModuleName),
+        );
+        if (packageForModule) {
+          moduleNameParam = packageForModule.name;
         }
       }
     } else if (value !== "packages" && newValue !== "packages") {

--- a/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Tabs.tsx
@@ -11,6 +11,7 @@ import {useNavigate} from "../../../../routing";
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
 import {accountPagePath} from "../../Index";
 import Packages from "./Packages";
+import {useGetAccountPackages} from "../../../../api/hooks/useGetAccountResource";
 
 const TabComponents = Object.freeze({
   packages: Packages,
@@ -79,6 +80,7 @@ function ModulesTabs({
   const {selectedFnName, selectedModuleName, modulesTab} = useParams();
   const navigate = useNavigate();
   const logEvent = useLogEventWithBasic();
+  const sortedPackages = useGetAccountPackages(address);
   const value =
     modulesTab === undefined ? tabValues[0] : (modulesTab as TabValue);
 
@@ -101,9 +103,43 @@ function ModulesTabs({
       logEvent(eventName);
     }
 
+    let moduleNameParam = "";
+    let fnNameParam = "";
+
+    if (value === "packages" && newValue !== "packages") {
+      // From packages to other tabs: convert package name to first module name
+      if (selectedModuleName) {
+        const selectedPackage = sortedPackages.find(
+          (pkg) => pkg.name === selectedModuleName,
+        );
+        if (selectedPackage && selectedPackage.modules.length > 0) {
+          moduleNameParam = selectedPackage.modules[0].name;
+        }
+      }
+    } else if (value !== "packages" && newValue === "packages") {
+      // From other tabs to packages: convert module name to package name
+      if (selectedModuleName) {
+        const selectedModule = sortedPackages
+          .flatMap((pkg) => pkg.modules)
+          .find((module) => module.name === selectedModuleName);
+        if (selectedModule) {
+          const packageForModule = sortedPackages.find((pkg) =>
+            pkg.modules.some((mod) => mod.name === selectedModuleName),
+          );
+          if (packageForModule) {
+            moduleNameParam = packageForModule.name;
+          }
+        }
+      }
+    } else if (value !== "packages" && newValue !== "packages") {
+      // Between non-packages tabs: preserve module name and function name
+      moduleNameParam = selectedModuleName || "";
+      fnNameParam = selectedFnName ? `/${selectedFnName}` : "";
+    }
+    // If both are packages or no conversion needed, leave params empty
+
     navigate(
-      `/${accountPagePath(isObject)}/${address}/modules/${newValue}/${selectedModuleName}` +
-        (selectedFnName ? `/${selectedFnName}` : ``),
+      `/${accountPagePath(isObject)}/${address}/modules/${newValue}${moduleNameParam ? `/${moduleNameParam}` : ""}${fnNameParam}`,
       {replace: true},
     );
   };


### PR DESCRIPTION
# Problem
In the AccountPage's ModulesTab, navigation issues occur when users switch between the packages tab and other tabs (code/run/view):

https://explorer.aptoslabs.com/object/0x6febdb5695dab42c3edf6baaebf7b49b4ae32fbb1411a5c33917f442ebe77daa/modules/packages/RegulatedToken?network=mainnet

<img width="407" height="200" alt="image" src="https://github.com/user-attachments/assets/40bf8de0-f083-48e0-999f-133244589e30" />

From packages to other tabs: Package names are incorrectly passed as module names, causing other tabs to fail displaying content
From other tabs to packages: Module names are incorrectly passed as package names, causing the packages tab to fail displaying content
URL redirect issues: Frequent URL redirects cause page flickering, degrading user experience


## Solution
Implemented intelligent navigation conversion logic that performs appropriate parameter conversion based on tab types:

### Key Changes
1. Route Optimization (src/ExplorerRoutes.tsx)
   - Reordered route priorities to ensure function name routes are matched first
   - Prevented route conflicts and improved navigation accuracy
3. Smart Parameter Conversion (src/pages/Account/Tabs/ModulesTab/Tabs.tsx)
   - From packages to other tabs: Convert package name to the first module name in that package
   - From other tabs to packages: Convert module name to the corresponding package name
   - Between other tabs: Preserve module name and function name
   - Within packages tab: No conversion, let packages component handle it

### Technical Implementation
- Introduced useGetAccountPackages hook to get package and module information
- Implemented bidirectional conversion logic between package names and module names
- Eliminated unnecessary URL redirects to improve user experience

## Test Scenarios
✅ Switch from packages tab to code tab
✅ Switch from code tab to packages tab
✅ Switch between code/run/view tabs
✅ Preserve function name parameters across relevant tabs
✅ Eliminate page flickering and URL redirects

## Impact
Only affects navigation logic in AccountPage's ModulesTab
No impact on existing functionality, only improves user experience
Backward compatible, doesn't break existing URL structure
This PR resolves critical navigation issues in module tabs, providing a smoother user experience while maintaining code clarity and maintainability.