### PR TITLE
Use FA metadata icon as fallback, in balance changes tab

### DIFF
--- a/src/api/hooks/useGetFaMetadata.ts
+++ b/src/api/hooks/useGetFaMetadata.ts
@@ -1,4 +1,4 @@
-import {useViewFunction} from "./useViewFunction";
+import {useViewFunction, UseViewFunctionOptions} from "./useViewFunction";
 
 export type FaMetadata = {
   name: string;
@@ -8,7 +8,10 @@ export type FaMetadata = {
   project_uri: string;
 };
 
-export function useGetFaMetadata(address: string): {
+export function useGetFaMetadata(
+  address: string,
+  options: UseViewFunctionOptions = {},
+): {
   isLoading: boolean;
   data: FaMetadata | null;
 } {
@@ -16,6 +19,11 @@ export function useGetFaMetadata(address: string): {
     "0x1::fungible_asset::metadata",
     ["0x1::object::ObjectCore"],
     [address],
+    {
+      gcTime: 30 * 60 * 1000,
+      staleTime: 5 * 60 * 1000,
+      ...options,
+    },
   );
 
   if (data) {

--- a/src/api/hooks/useViewFunction.ts
+++ b/src/api/hooks/useViewFunction.ts
@@ -1,13 +1,19 @@
 import {Types} from "aptos";
-import {useQuery, UseQueryResult} from "@tanstack/react-query";
+import {useQuery, UseQueryOptions, UseQueryResult} from "@tanstack/react-query";
 import {ResponseError} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {view} from "../index";
+
+export type UseViewFunctionOptions = Pick<
+  UseQueryOptions<Types.MoveValue[], ResponseError>,
+  "enabled" | "gcTime" | "staleTime"
+>;
 
 export function useViewFunction(
   functionName: string,
   typeArgs: string[],
   args: string[],
+  options: UseViewFunctionOptions = {},
 ): UseQueryResult<Types.MoveValue[], ResponseError> {
   const [state] = useGlobalState();
 
@@ -25,5 +31,6 @@ export function useViewFunction(
     ],
     queryFn: () => view(request, state.aptos_client),
     refetchOnWindowFocus: false,
+    ...options,
   });
 }

--- a/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
+++ b/src/pages/Transaction/Tabs/Components/CoinBalanceChangeTable.tsx
@@ -19,6 +19,8 @@ import {VerifiedCoinCell} from "../../../../components/Table/VerifiedCell";
 import {getLearnMoreTooltip} from "../../helpers";
 import {ContentCopy} from "@mui/icons-material";
 import StyledTooltip from "../../../../components/StyledTooltip";
+import {useGetFaMetadata} from "../../../../api/hooks/useGetFaMetadata";
+import {isValidAccountAddress} from "../../../utils";
 
 type BalanceChangeCellProps = {
   balanceChange: BalanceChange;
@@ -60,6 +62,13 @@ function VerifiedCell({balanceChange}: BalanceChangeCellProps) {
 }
 
 function TokenInfoCell({balanceChange}: BalanceChangeCellProps) {
+  const assetId = balanceChange.asset.id;
+  const isFa = isValidAccountAddress(assetId);
+
+  const {data: metadata} = useGetFaMetadata(balanceChange.asset.id, {
+    enabled: balanceChange.logoUrl === undefined && isFa,
+  });
+
   return (
     <GeneralTableCell sx={{}}>
       <HashButton
@@ -70,11 +79,7 @@ function TokenInfoCell({balanceChange}: BalanceChangeCellProps) {
             : HashType.FUNGIBLE_ASSET
         }
         size="large"
-        img={
-          balanceChange.logoUrl
-            ? balanceChange.logoUrl
-            : balanceChange.asset.symbol
-        }
+        img={balanceChange.logoUrl || metadata?.icon_uri}
       />
     </GeneralTableCell>
   );


### PR DESCRIPTION
### Description

We want the Shelby token icon to appear in the balance changes section in the explorer.
Using the metadata icon URI when main logo is not available as fallback.

before:

<img width="486" height="136" alt="Screenshot 2025-10-10 at 3 31 59 PM" src="https://github.com/user-attachments/assets/80920f45-f8a8-489c-a289-f391e74847db" />

after:

<img width="497" height="142" alt="Screenshot 2025-10-10 at 3 31 51 PM" src="https://github.com/user-attachments/assets/c2007dc8-1cd3-49da-87df-06ac3de72fec" />

