### PR TITLE
feat(network-select): exclude hidden networks from dropdown

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -16,7 +16,11 @@ export const networks: Record<string, string> = {
   local: "http://127.0.0.1:8080/v1",
 };
 
-export const hiddenNetworks = ["decibel", "shelbynet"];
+export const hiddenNetworks: readonly NetworkName[] = [
+  "decibel",
+  "shelbynet",
+  "local",
+] as const;
 
 export type NetworkName = keyof typeof networks;
 

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -26,7 +26,6 @@ function NetworkAndChainIdCached({
   chainId: string | null;
 }) {
   const theme = useTheme();
-
   return (
     <Stack
       direction="row"
@@ -38,7 +37,7 @@ function NetworkAndChainIdCached({
     >
       <Typography>{networkName}</Typography>
       <Typography variant="body2" sx={{color: theme.palette.text.disabled}}>
-        {chainId}
+        {chainId ?? "…"}
       </Typography>
     </Stack>
   );
@@ -76,6 +75,11 @@ export default function NetworkSelect() {
     const network_name = event.target.value;
     selectNetwork(network_name as NetworkName);
   };
+
+  const visibleNetworkNames = React.useMemo(
+    () => Object.keys(networks).filter((n) => !hiddenNetworks.includes(n)),
+    [],
+  );
 
   function DropdownIcon(props: SvgIconProps) {
     return (
@@ -146,7 +150,8 @@ export default function NetworkSelect() {
               <Typography variant="body2">Chain ID</Typography>
             </Stack>
           </MenuItem>
-          {Object.keys(networks).map((networkName: string) => (
+
+          {visibleNetworkNames.map((networkName) => (
             <MenuItem
               key={networkName}
               value={networkName}


### PR DESCRIPTION
### Description

- Filter `hiddenNetworks` before mapping to <MenuItem> to avoid rendering empty rows
- Memoize `visibleNetworkNames` for stable ordering and rerenders
- Type `hiddenNetworks` as `readonly NetworkName[]` for type safety
- Always show network label with chainId placeholder (“…”) while loading
- Remove redundant guard inside `NetworkMenuItem`

### Ghost items (mobile)
<img width="499" height="534" alt="image" src="https://github.com/user-attachments/assets/c5985907-e546-469f-b80c-4465a1d7ba1c" />

### Before:
<img width="1794" height="1064" alt="image" src="https://github.com/user-attachments/assets/922d842f-6a06-44b9-aaae-964a7c8bbf9e" />

###After:
<img width="1674" height="1064" alt="image" src="https://github.com/user-attachments/assets/50dbe091-1cd4-4b81-8a9e-c333e8fd11c3" />
