### PR TITLE
Hide zero value events

### DIFF
--- a/app/pages/Transaction/Tabs/EventsTab.tsx
+++ b/app/pages/Transaction/Tabs/EventsTab.tsx
@@ -12,6 +12,19 @@ type EventsTabProps = {
   transaction: Types.Transaction;
 };
 
+// Check if this is an events v2 / module event by detecting zero values.
+// Module events have account_address as 0x0, creation_number as "0", and
+// sequence_number as "0" for backwards compatibility.
+function isModuleEvent(event: Types.Event): boolean {
+  const zeroAddress =
+    event.guid.account_address === "0x0" ||
+    event.guid.account_address ===
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const zeroCreationNumber = event.guid.creation_number === "0";
+  const zeroSequenceNumber = event.sequence_number === "0";
+  return zeroAddress && zeroCreationNumber && zeroSequenceNumber;
+}
+
 export default function EventsTab({transaction}: EventsTabProps) {
   const events: Types.Event[] =
     "events" in transaction ? transaction.events : [];
@@ -29,43 +42,55 @@ export default function EventsTab({transaction}: EventsTabProps) {
       expandAll={expandAll}
       collapseAll={collapseAll}
     >
-      {events.map((event, i) => (
-        <CollapsibleCard
-          key={i}
-          titleKey="Index:"
-          titleValue={i.toString()}
-          expanded={expandedList[i]}
-          toggleExpanded={() => toggleExpandedAt(i)}
-        >
-          <ContentRow
-            title="Account Address:"
-            value={
-              <HashButton
-                hash={event.guid.account_address}
-                type={HashType.ACCOUNT}
-              />
-            }
-          />
-          <ContentRow
-            title="Creation Number:"
-            value={event.guid.creation_number}
-          />
-          <ContentRow title="Sequence Number:" value={event.sequence_number} />
-          <ContentRow title="Type:" value={event.type} />
-          <ContentRow
-            title="Data:"
-            value={
-              <JsonViewCard
-                data={
-                  typeof event.data == "object"
-                    ? event.data
-                    : {__PLACEHOLDER__: event.data}
+      {events.map((event, i) => {
+        const hideZeroFields = isModuleEvent(event);
+        return (
+          <CollapsibleCard
+            key={i}
+            titleKey="Index:"
+            titleValue={i.toString()}
+            expanded={expandedList[i]}
+            toggleExpanded={() => toggleExpandedAt(i)}
+          >
+            {!hideZeroFields && (
+              <ContentRow
+                title="Account Address:"
+                value={
+                  <HashButton
+                    hash={event.guid.account_address}
+                    type={HashType.ACCOUNT}
+                  />
                 }
               />
-            }
-          />
-        </CollapsibleCard>
-      ))}
+            )}
+            {!hideZeroFields && (
+              <ContentRow
+                title="Creation Number:"
+                value={event.guid.creation_number}
+              />
+            )}
+            {!hideZeroFields && (
+              <ContentRow
+                title="Sequence Number:"
+                value={event.sequence_number}
+              />
+            )}
+            <ContentRow title="Type:" value={event.type} />
+            <ContentRow
+              title="Data:"
+              value={
+                <JsonViewCard
+                  data={
+                    typeof event.data == "object"
+                      ? event.data
+                      : {__PLACEHOLDER__: event.data}
+                  }
+                />
+              }
+            />
+          </CollapsibleCard>
+        );
+      })}
     </CollapsibleCards>
   );
 }


### PR DESCRIPTION
### Description

Hides the `account_address`, `creation_number`, and `sequence_number` fields in the Events tab for module events (events v2).

These fields are zero-valued for backwards compatibility but are not meaningful for module events. By hiding them, the UI now only displays relevant information (Index, Type, and Data) for these event types, improving clarity.

A new `isModuleEvent()` helper function was added to `EventsTab.tsx` to detect module events based on these zero-valued fields, and the UI conditionally renders the fields accordingly.

### Related Links

### Checklist

---
[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1767915796503899?thread_ts=1767915796.503899&cid=C040LV2NWQ4)

<a href="https://cursor.com/background-agent?bcId=bc-e07298c2-55db-4a27-b80e-0b8d8299074f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e07298c2-55db-4a27-b80e-0b8d8299074f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

