### PR TITLE
fix(ssr): bundle react-simple-maps and d3 packages to fix ESM/CJS error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,11 +50,8 @@ export default defineConfig({
     noExternal: [
       "react-helmet-async", // CJS/ESM hybrid
       "react-countdown", // CJS with ESM entry
-    ],
-    // Packages to externalize during SSR (not bundled, loaded at runtime)
-    // react-simple-maps is CJS and tries to require() ESM d3 packages
-    // Since it's lazy-loaded client-only, we can safely externalize it
-    external: [
+      // react-simple-maps and d3 packages need to be bundled to handle CJS require() of ESM
+      // Vite will transform the CJS require() calls to work in ESM context
       "react-simple-maps",
       "d3-geo",
       "d3-zoom",


### PR DESCRIPTION
- Move react-simple-maps and d3 packages from ssr.external to ssr.noExternal
- This allows Vite to bundle and transform CJS require() calls to work in ESM SSR context
- Fixes ERR_REQUIRE_ESM error when react-simple-maps tries to require() ESM d3-geo package
- Map component is already client-only, but bundling ensures compatibility during SSR build

### Description

<!-- Please describe your change and its motivation. -->

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
