### PR TITLE
fix(JsonViewCard): improve spacing and indentation for JSON viewer

### DIFF
--- a/app/components/IndividualPageContent/JsonViewCard.tsx
+++ b/app/components/IndividualPageContent/JsonViewCard.tsx
@@ -259,10 +259,13 @@ export default function JsonViewCard({
           displayDataTypes={false}
           displayObjectSize={false}
           enableClipboard={false}
+          indentWidth={24}
+          shortenTextAfterLength={80}
           style={
             {
               fontFamily: theme.typography.fontFamily,
               fontSize: theme.typography.fontSize,
+              lineHeight: 1.6,
               backgroundColor: "transparent",
               // Custom colors using CSS variables
               "--w-rjv-key-string": textColor,


### PR DESCRIPTION
### Description

Fix JSON view spacing and indentation regression introduced in d139d10 when migrating from `react-json-view` to `@uiw/react-json-view`.

Changes:
- Set `indentWidth` to 24px (was default 15px which was too compact)
- Add `shortenTextAfterLength=80` to collapse long strings (matching previous behavior)
- Add `lineHeight: 1.6` for better readability between rows

Before this fix, the JSON viewer appeared cramped with minimal spacing between nested objects.

### Related Links

Regression from: d139d10 (`[tanstack] Modernize with bundle analyzer and smaller deps`)

### Checklist

- [x] Tested locally with JSON data display

Before:

<img width="606" height="351" alt="image" src="https://github.com/user-attachments/assets/0297fab3-6ad1-49ed-9a8b-3424aa81f4ed" />

Now:

<img width="484" height="326" alt="image" src="https://github.com/user-attachments/assets/9a4e98f0-ee77-40da-8d93-acacb58a3d0c" />