### PR TITLE
Transaction mobile card details

### DIFF
--- a/app/pages/Transactions/TransactionsTable.tsx
+++ b/app/pages/Transactions/TransactionsTable.tsx
@@ -291,22 +291,8 @@ function TransactionDetailDialog({
     }
   };
 
-  // Get the function string
-  let functionStr = "";
-  if ("payload" in transaction) {
-    if (
-      transaction.payload.type === "multisig_payload" &&
-      "transaction_payload" in transaction.payload &&
-      transaction.payload.transaction_payload &&
-      "function" in transaction.payload.transaction_payload
-    ) {
-      functionStr = transaction.payload.transaction_payload.function;
-    } else if ("function" in transaction.payload) {
-      functionStr = transaction.payload.function;
-    } else if (transaction.payload.type === "script_payload") {
-      functionStr = "Script";
-    }
-  }
+  // Check if transaction has a payload (for showing Function section)
+  const hasPayload = "payload" in transaction;
 
   return (
     <Dialog
@@ -335,6 +321,7 @@ function TransactionDetailDialog({
           )}
         </Stack>
         <IconButton
+          aria-label="Close dialog"
           onClick={onClose}
           sx={{
             position: "absolute",
@@ -367,7 +354,7 @@ function TransactionDetailDialog({
           </Stack>
 
           {/* Function */}
-          {functionStr && (
+          {hasPayload && (
             <Box>
               <Typography variant="body2" color="text.secondary" sx={{mb: 0.5}}>
                 Function
@@ -397,6 +384,7 @@ function TransactionDetailDialog({
                   title={copiedField === "sender" ? "Copied!" : "Copy address"}
                 >
                   <IconButton
+                    aria-label="Copy sender address"
                     size="small"
                     onClick={() => handleCopy(sender, "sender")}
                   >
@@ -435,6 +423,7 @@ function TransactionDetailDialog({
                   }
                 >
                   <IconButton
+                    aria-label="Copy counterparty address"
                     size="small"
                     onClick={() =>
                       handleCopy(counterparty.address, "counterparty")

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -740,12 +740,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}


### PR DESCRIPTION
### Description

This PR introduces a mobile-friendly view for transaction lists, replacing the table layout with interactive 3-line cards on smaller screens. Tapping a card now opens a new detail dialog, providing comprehensive transaction information before offering an option to navigate to the full transaction page.

Key changes include:
- **Transaction Cards:** Transactions are displayed as 3-line cards on mobile:
    - Line 1: Version, status, type, timestamp.
    - Line 2: Full function name (word-wrapped).
    - Line 3: Truncated counterparty address, amount, and gas fee.
- **Transaction Detail Dialog:** A new modal dialog appears upon tapping a card, showing:
    - Version, type, timestamp, full function, sender, counterparty (receiver/contract), color-coded amount, and gas fee.
    - Includes copy buttons for addresses and a "View Full Details" button to navigate to the transaction page.
- **Responsive Layout:** `TransactionsTable.tsx` now dynamically renders either the table or the new mobile cards based on screen size (below `md` breakpoint).

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

- [x] TypeScript compilation passes (`pnpm lint`)
- [x] All tests pass (`pnpm test`)
- [x] Code formatted with Prettier (`pnpm fmt`)

---
<a href="https://cursor.com/background-agent?bcId=bc-0fa2ba6d-a4d4-4cce-8e98-c55bacbc7c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fa2ba6d-a4d4-4cce-8e98-c55bacbc7c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

