### PR TITLE
CORS for preview builds

### DIFF
--- a/app/api/hooks/useGraphqlClient.tsx
+++ b/app/api/hooks/useGraphqlClient.tsx
@@ -5,7 +5,7 @@ import {
   HttpLink,
   InMemoryCache,
 } from "@apollo/client";
-import {getApiKey, NetworkName} from "../../constants";
+import {getApiKey, getGraphqlURI, NetworkName} from "../../constants";
 import {useNetworkName} from "../../global-config";
 import {ApolloProvider} from "@apollo/client/react";
 
@@ -14,24 +14,8 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
   return typeof graphqlUri === "string" && graphqlUri.length > 0;
 }
 
-export function getGraphqlURI(networkName: NetworkName): string | undefined {
-  switch (networkName) {
-    case "mainnet":
-      return "https://api.mainnet.aptoslabs.com/v1/graphql";
-    case "testnet":
-      return "https://api.testnet.staging.aptoslabs.com/v1/graphql";
-    case "devnet":
-      return "https://api.devnet.staging.aptoslabs.com/v1/graphql";
-    case "decibel":
-      return "https://api.netna.aptoslabs.com/v1/graphql";
-    case "shelbynet":
-      return "https://api.shelbynet.staging.shelby.xyz/v1/graphql";
-    case "local":
-      return "http://127.0.0.1:8090/v1/graphql";
-    default:
-      return undefined;
-  }
-}
+// Re-export for consumers that were importing from here
+export {getGraphqlURI} from "../../constants";
 
 // Cache Apollo clients per network to preserve GraphQL cache across renders
 const apolloClientCache = new Map<NetworkName, ApolloClient>();

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -740,12 +740,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/netlify.toml
+++ b/netlify.toml
@@ -46,3 +46,78 @@
 
 [context.branch-deploy.environment]
   NODE_ENV = "production"
+
+# API Proxy for CORS on preview builds
+# These redirects proxy API requests through Netlify to avoid CORS issues
+# when the Aptos API servers don't recognize preview deployment origins
+
+[[redirects]]
+  from = "/api-proxy/mainnet/*"
+  to = "https://api.mainnet.aptoslabs.com/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/api-proxy/testnet/*"
+  to = "https://api.testnet.staging.aptoslabs.com/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/api-proxy/devnet/*"
+  to = "https://api.devnet.staging.aptoslabs.com/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/api-proxy/decibel/*"
+  to = "https://api.netna.aptoslabs.com/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/api-proxy/shelbynet/*"
+  to = "https://api.shelbynet.staging.shelby.xyz/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+# GraphQL proxy endpoints
+[[redirects]]
+  from = "/graphql-proxy/mainnet"
+  to = "https://api.mainnet.aptoslabs.com/v1/graphql"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/graphql-proxy/testnet"
+  to = "https://api.testnet.staging.aptoslabs.com/v1/graphql"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/graphql-proxy/devnet"
+  to = "https://api.devnet.staging.aptoslabs.com/v1/graphql"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/graphql-proxy/decibel"
+  to = "https://api.netna.aptoslabs.com/v1/graphql"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}
+
+[[redirects]]
+  from = "/graphql-proxy/shelbynet"
+  to = "https://api.shelbynet.staging.shelby.xyz/v1/graphql"
+  status = 200
+  force = true
+  headers = {X-From = "netlify-proxy"}


### PR DESCRIPTION
### Description

This PR resolves CORS errors encountered on Netlify preview builds when fetching data from Aptos API and GraphQL endpoints. The Aptos API servers do not include Netlify preview deployment origins in their CORS allowed origins, leading to blocked requests.

To address this, a Netlify proxy solution has been implemented:
*   **`netlify.toml`**: New redirect rules are added to proxy API and GraphQL requests (e.g., `/api-proxy/mainnet/*` and `/graphql-proxy/mainnet`) through Netlify. These redirects use `status = 200` to make the requests appear as same-origin to the browser, bypassing CORS.
*   **`app/lib/constants.ts`**: Logic is introduced to dynamically detect Netlify preview deployments. When detected, API and GraphQL URLs are resolved to use these new proxy paths instead of direct API URLs.
*   **`app/api/hooks/useGraphqlClient.tsx`**: The `getGraphqlURI` function is now imported from the central constants file to ensure consistency and proper use of the new proxy logic.

This ensures that preview builds can successfully communicate with the Aptos APIs without CORS issues, while production builds continue to use direct API connections.

### Related Links

### Checklist

---
<a href="https://cursor.com/background-agent?bcId=bc-7b48ef48-0e18-4875-a8d6-df106dccc04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b48ef48-0e18-4875-a8d6-df106dccc04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

