### PR TITLE
Run page type generics

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -740,3 +740,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}


### PR DESCRIPTION
### Description

This PR enhances the "Run Function" page by recovering and displaying meaningful generic type parameter names from Move source code, similar to how argument names are handled.

Previously, generic type parameters were displayed as `T0`, `T1`, etc. Now, if the source code is available, the actual names (e.g., `CoinType`, `Recipient`) will be shown in the function signature and as labels for the type argument input fields. If source code is not available, it gracefully falls back to the `T0`, `T1` naming convention.

This improves clarity and user experience when interacting with generic Move functions.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

---
<a href="https://cursor.com/background-agent?bcId=bc-9d6208f9-b1ae-42c9-ba52-da15d10bf186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d6208f9-b1ae-42c9-ba52-da15d10bf186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

