### PR TITLE
Explorer old URL compatibility

### DIFF
--- a/app/hooks/useOldUrlRedirect.ts
+++ b/app/hooks/useOldUrlRedirect.ts
@@ -1,0 +1,64 @@
+/**
+ * Hook to redirect old subdomain-based URLs to the new query parameter format.
+ *
+ * Old format (2022): https://explorer.devnet.aptos.dev/path
+ * New format: https://explorer.aptoslabs.com/path?network=devnet
+ *
+ * This provides backward compatibility for old bookmarks and links.
+ */
+import {useEffect} from "react";
+
+// Mapping of old subdomains to network names
+const OLD_DOMAIN_MAPPINGS: Record<string, string> = {
+  // Old format: explorer.{network}.aptos.dev
+  "explorer.devnet.aptos.dev": "devnet",
+  "explorer.testnet.aptos.dev": "testnet",
+  "explorer.mainnet.aptos.dev": "mainnet",
+  // Also handle legacy aptos.dev domains without "explorer" prefix
+  "devnet.aptos.dev": "devnet",
+  "testnet.aptos.dev": "testnet",
+  "mainnet.aptos.dev": "mainnet",
+};
+
+// The canonical domain to redirect to
+const CANONICAL_DOMAIN = "explorer.aptoslabs.com";
+
+/**
+ * Hook that redirects old subdomain-based URLs to the new query parameter format.
+ * Should be called once in the root layout component.
+ *
+ * This handles cases where users have old bookmarks like:
+ * - https://explorer.devnet.aptos.dev/account/0x1
+ * - https://explorer.testnet.aptos.dev/txn/12345
+ *
+ * And redirects them to:
+ * - https://explorer.aptoslabs.com/account/0x1?network=devnet
+ * - https://explorer.aptoslabs.com/txn/12345?network=testnet
+ */
+export function useOldUrlRedirect(): void {
+  useEffect(() => {
+    // Only run on client
+    if (typeof window === "undefined") return;
+
+    const hostname = window.location.hostname.toLowerCase();
+
+    // Check if we're on an old domain that needs redirecting
+    const networkName = OLD_DOMAIN_MAPPINGS[hostname];
+    if (!networkName) return;
+
+    // Build the new URL
+    const newUrl = new URL(window.location.href);
+    newUrl.hostname = CANONICAL_DOMAIN;
+    newUrl.protocol = "https:";
+    newUrl.port = "";
+
+    // Add or update the network parameter
+    // Don't override if there's already a network param (user explicitly set it)
+    if (!newUrl.searchParams.has("network")) {
+      newUrl.searchParams.set("network", networkName);
+    }
+
+    // Redirect to the new URL
+    window.location.replace(newUrl.toString());
+  }, []);
+}

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -46,6 +46,7 @@ import Footer from "../components/layout/Footer";
 import {Fallback} from "../components/layout/Fallback";
 import {ErrorBoundary, NotFoundError} from "../components/ErrorBoundary";
 import {useHashToPathRedirect} from "../hooks/useHashToPathRedirect";
+import {useOldUrlRedirect} from "../hooks/useOldUrlRedirect";
 import LocalnetUnavailableModal from "../components/LocalnetUnavailableModal";
 
 // Router context type
@@ -118,6 +119,10 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootComponent() {
   const {queryClient} = Route.useRouteContext();
+
+  // Redirect old subdomain-based URLs to the new query parameter format for backward compatibility
+  // e.g., explorer.devnet.aptos.dev → explorer.aptoslabs.com?network=devnet
+  useOldUrlRedirect();
 
   // Redirect hash-based tab URLs to path-based URLs for backward compatibility
   useHashToPathRedirect();

--- a/netlify.toml
+++ b/netlify.toml
@@ -46,3 +46,54 @@
 
 [context.branch-deploy.environment]
   NODE_ENV = "production"
+
+# Redirects for old subdomain-based URLs (2022 format) to new query parameter format
+# These ensure backward compatibility for old bookmarks and links
+# Old format: https://explorer.{network}.aptos.dev/path
+# New format: https://explorer.aptoslabs.com/path?network={network}
+
+# Redirect from explorer.devnet.aptos.dev to explorer.aptoslabs.com with network=devnet
+[[redirects]]
+  from = "https://explorer.devnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=devnet"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://devnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=devnet"
+  status = 301
+  force = true
+
+# Redirect from explorer.testnet.aptos.dev to explorer.aptoslabs.com with network=testnet
+[[redirects]]
+  from = "https://explorer.testnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=testnet"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://testnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=testnet"
+  status = 301
+  force = true
+
+# Redirect from explorer.mainnet.aptos.dev to explorer.aptoslabs.com with network=mainnet
+[[redirects]]
+  from = "https://explorer.mainnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=mainnet"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://mainnet.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=mainnet"
+  status = 301
+  force = true
+
+# Redirect from explorer.aptos.dev (without network subdomain) to mainnet
+[[redirects]]
+  from = "https://explorer.aptos.dev/*"
+  to = "https://explorer.aptoslabs.com/:splat?network=mainnet"
+  status = 301
+  force = true


### PR DESCRIPTION
### Description

Implements backward compatibility for old explorer URLs from 2022, which used subdomain-based network selection (e.g., `explorer.devnet.aptos.dev`). The current explorer uses query parameters (e.g., `?network=devnet`).

This change ensures that old bookmarks and links continue to function by redirecting them to the canonical domain with the correct network parameter.

The solution provides two layers of protection:
1.  **Netlify redirects**: Server-side 301 redirects for immediate, SEO-friendly handling of old domains.
2.  **React hook (`useOldUrlRedirect`)**: Client-side fallback for cases where server redirects might not apply, ensuring consistent behavior.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

---
[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1768250624900459?thread_ts=1768250624.900459&cid=C040LV2NWQ4)

<a href="https://cursor.com/background-agent?bcId=bc-db98162c-94c9-43cc-8387-24e9e0edca54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db98162c-94c9-43cc-8387-24e9e0edca54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

