### PR TITLE
Packages dropdown selection logic

### DIFF
--- a/app/pages/Account/Tabs/ModulesTab/Packages.tsx
+++ b/app/pages/Account/Tabs/ModulesTab/Packages.tsx
@@ -9,7 +9,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import {useEffect, useMemo} from "react";
+import {useEffect} from "react";
 import {
   PackageMetadata,
   useGetAccountPackages,
@@ -114,13 +114,6 @@ function PackagesSidebar({
   const theme = useTheme();
   const isWideScreen = useMediaQuery(theme.breakpoints.up("md"));
   const logEvent = useLogEventWithBasic();
-  const flattedModules = useMemo(
-    () =>
-      sortedPackages.flatMap((pkg) =>
-        pkg.modules.map((module) => ({...module, pkg: pkg.name})),
-      ),
-    [sortedPackages],
-  );
 
   return (
     <Box
@@ -148,23 +141,20 @@ function PackagesSidebar({
       ) : (
         <Autocomplete
           fullWidth
-          options={flattedModules}
-          groupBy={(option) => option.pkg}
+          options={sortedPackages}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => (
-            <TextField {...params} label="Select a module" />
+            <TextField {...params} label="Select a package" />
           )}
-          onChange={(_, module) => {
-            if (module) {
-              logEvent("modules_clicked", module.name);
-              navigateToPackage(module?.name);
+          onChange={(_, pkg) => {
+            if (pkg) {
+              logEvent("package_clicked", pkg.name);
+              navigateToPackage(pkg.name);
             }
           }}
           value={
             selectedPackageName
-              ? flattedModules.find(
-                  (module) => module.name === selectedPackageName,
-                )
+              ? sortedPackages.find((pkg) => pkg.name === selectedPackageName)
               : null
           }
         />


### PR DESCRIPTION
### Description

Fixes the mobile dropdown on the packages page to correctly select and navigate by packages instead of individual modules.

Previously, the dropdown:
- Displayed individual modules as options.
- Was labeled "Select a module".
- Navigated using module names.

This change updates the dropdown to:
- Use packages as selectable options.
- Be labeled "Select a package".
- Navigate correctly to the selected package.
- Removes the unused `useMemo` for `flattedModules`.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

---
<a href="https://cursor.com/background-agent?bcId=bc-b0973f36-1f4b-47ad-859d-16841b969bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0973f36-1f4b-47ad-859d-16841b969bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

