### PR TITLE
Coin trading activities performance

### DIFF
--- a/app/api/hooks/useGetCoinActivities.ts
+++ b/app/api/hooks/useGetCoinActivities.ts
@@ -6,7 +6,106 @@ export type FAActivity = {
   owner_address: string;
 };
 
+/**
+ * Optimized hook for fetching coin/fungible asset activities.
+ *
+ * Performance optimizations:
+ * 1. Uses cursor-based pagination (transaction_version < cursor) instead of offset
+ *    - Offset pagination requires scanning all previous rows
+ *    - Cursor pagination uses indexed lookups, much faster
+ * 2. Removed distinct_on which was causing slow sequential scans
+ *    - We fetch slightly more and deduplicate on client side
+ * 3. Removed aggregate count query - uses "Load More" pattern instead
+ *    - Count queries over large tables are expensive
+ */
 export function useGetCoinActivities(
+  asset: string,
+  limit: number = 25,
+  cursor?: number, // Changed from offset to cursor (transaction_version to paginate from)
+): {
+  isLoading: boolean;
+  error: CombinedGraphQLErrors | undefined;
+  data: FAActivity[] | undefined;
+  hasMore: boolean;
+} {
+  // Fetch extra to detect if there are more results
+  const fetchLimit = limit + 1;
+
+  const {loading, error, data} = useGraphqlQuery<{
+    fungible_asset_activities: FAActivity[];
+  }>(
+    // Exclude gas fees from the list
+    // Use cursor-based pagination for performance
+    gql`
+      query GetFungibleAssetActivities(
+        $asset: String
+        $limit: Int
+        $cursor: bigint
+      ) {
+        fungible_asset_activities(
+          where: {
+            asset_type: {_eq: $asset}
+            type: {_neq: "0x1::aptos_coin::GasFeeEvent"}
+            transaction_version: {_lt: $cursor}
+          }
+          limit: $limit
+          order_by: {transaction_version: desc}
+        ) {
+          transaction_version
+          owner_address
+        }
+      }
+    `,
+    {
+      variables: {
+        asset,
+        limit: fetchLimit,
+        // Use a very large number as initial cursor to get the most recent activities
+        cursor: cursor ?? 9999999999999,
+      },
+    },
+  );
+
+  // Deduplicate by transaction_version on client side
+  // This is efficient for small page sizes (25 items)
+  const deduplicatedData = data?.fungible_asset_activities
+    ? deduplicateByVersion(data.fungible_asset_activities)
+    : undefined;
+
+  // Check if we have more results
+  const hasMore = (deduplicatedData?.length ?? 0) > limit;
+
+  // Return only the requested limit
+  const limitedData = deduplicatedData?.slice(0, limit);
+
+  return {
+    isLoading: loading,
+    error: error ? (error as CombinedGraphQLErrors) : undefined,
+    data: limitedData,
+    hasMore,
+  };
+}
+
+/**
+ * Deduplicate activities by transaction_version, keeping first occurrence
+ * This replaces the slow distinct_on database operation
+ */
+function deduplicateByVersion(activities: FAActivity[]): FAActivity[] {
+  const seen = new Set<number>();
+  return activities.filter((activity) => {
+    if (seen.has(activity.transaction_version)) {
+      return false;
+    }
+    seen.add(activity.transaction_version);
+    return true;
+  });
+}
+
+/**
+ * Legacy hook for backwards compatibility with offset pagination
+ * @deprecated Use useGetCoinActivities with cursor-based pagination instead
+ */
+export function useGetCoinActivitiesLegacy(
   asset: string,
   limit: number = 25,
   offset?: number,
@@ -24,9 +123,8 @@ export function useGetCoinActivities(
       };
     };
   }>(
-    // Exclude gas fees from the list
     gql`
-      query GetFungibleAssetActivities(
+      query GetFungibleAssetActivitiesLegacy(
         $asset: String
         $limit: Int
         $offset: Int

--- a/app/pages/Coin/Tabs/TransactionsTab.tsx
+++ b/app/pages/Coin/Tabs/TransactionsTab.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useState, useCallback} from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
@@ -13,7 +13,7 @@ import {
   useGetCoinActivities,
 } from "../../../api/hooks/useGetCoinActivities";
 import {CoinData} from "../Components/CoinData";
-import {Box, CircularProgress, Pagination} from "@mui/material";
+import {Box, Button, CircularProgress} from "@mui/material";
 
 type TransactionsTabProps = {
   struct: string;
@@ -23,43 +23,80 @@ type TransactionsTabProps = {
 const LIMIT = 25;
 
 export default function TransactionsTab({struct, data}: TransactionsTabProps) {
-  const [page, setPage] = useState(1);
+  // Store accumulated activities for "Load More" pattern
+  const [allActivities, setAllActivities] = useState<FAActivity[]>([]);
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
   const [prevStruct, setPrevStruct] = useState(struct);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
-  // Reset page when struct changes (during render, per React best practices)
+  // Reset state when struct changes (during render, per React best practices)
   if (struct !== prevStruct) {
     setPrevStruct(struct);
-    setPage(1);
+    setAllActivities([]);
+    setCursor(undefined);
+    setIsLoadingMore(false);
   }
 
-  const offset = (page - 1) * LIMIT;
-  const activityData = useGetCoinActivities(struct, LIMIT, offset);
+  const activityData = useGetCoinActivities(struct, LIMIT, cursor);
 
-  if (activityData?.isLoading) {
+  // Merge new data with existing data when load completes
+  React.useEffect(() => {
+    if (activityData.data && !activityData.isLoading) {
+      if (cursor === undefined) {
+        // Initial load - replace all activities
+        setAllActivities(activityData.data);
+      } else if (isLoadingMore) {
+        // Load more - append new activities
+        setAllActivities((prev) => {
+          // Deduplicate by transaction_version
+          const existingVersions = new Set(
+            prev.map((a) => a.transaction_version),
+          );
+          const newActivities = activityData.data!.filter(
+            (a) => !existingVersions.has(a.transaction_version),
+          );
+          return [...prev, ...newActivities];
+        });
+        setIsLoadingMore(false);
+      }
+    }
+  }, [activityData.data, activityData.isLoading, cursor, isLoadingMore]);
+
+  const handleLoadMore = useCallback(() => {
+    if (allActivities.length > 0) {
+      const lastActivity = allActivities[allActivities.length - 1];
+      setIsLoadingMore(true);
+      setCursor(lastActivity.transaction_version);
+    }
+  }, [allActivities]);
+
+  // Show loading only on initial load
+  if (activityData.isLoading && allActivities.length === 0) {
     return (
       <Box sx={{display: "flex", justifyContent: "center", padding: 4}}>
         <CircularProgress />
       </Box>
     );
   }
-  if (!data || Array.isArray(data) || !activityData?.data) {
+
+  if (!data || Array.isArray(data) || allActivities.length === 0) {
     return <EmptyTabContent />;
   }
 
-  const pageCount = activityData.count
-    ? Math.ceil(activityData.count / LIMIT)
-    : 0;
-
-  const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
-    setPage(value);
-  };
-
   return (
     <Box>
-      <FAActivityTable data={data} activities={activityData.data} />
-      {pageCount > 1 && (
+      <FAActivityTable data={data} activities={allActivities} />
+      {activityData.hasMore && (
         <Box sx={{display: "flex", justifyContent: "center", padding: 2}}>
-          <Pagination count={pageCount} page={page} onChange={handleChange} />
+          <Button
+            variant="outlined"
+            onClick={handleLoadMore}
+            disabled={isLoadingMore || activityData.isLoading}
+          >
+            {isLoadingMore || activityData.isLoading
+              ? "Loading..."
+              : "Load More"}
+          </Button>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
### Description

Optimizes the performance of the coin and fungible asset transaction tabs by refactoring the data fetching and pagination strategy.

The previous implementation suffered from significant slowdowns due to:
1.  **Inefficient `distinct_on` with offset pagination**: PostgreSQL had to scan all rows, deduplicate, then skip to the offset.
2.  **Offset-based pagination**: Required scanning all rows before the offset for each page.
3.  **Expensive aggregate count query**: Performed a full table scan to get the total count for pagination.

This PR addresses these issues by:
-   **Migrating to cursor-based pagination**: `useGetCoinActivities` now uses `transaction_version < cursor` for efficient, indexed lookups.
-   **Removing `distinct_on`**: Client-side deduplication is now performed for the small page sizes, avoiding slow database operations.
-   **Replacing numbered pagination with "Load More"**: The UI now accumulates activities and uses the last fetched `transaction_version` as the cursor for subsequent requests, eliminating the need for an expensive count query.

These changes result in significantly faster initial loads and subsequent pagination, improving the user experience for viewing coin and fungible asset activities.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

---
<a href="https://cursor.com/background-agent?bcId=bc-40bcc01c-48e5-4594-898c-2f66d9c94c25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40bcc01c-48e5-4594-898c-2f66d9c94c25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

