### PR TITLE
Account search gracefulness

### DIFF
--- a/app/pages/Account/Components/AccountAllTransactions.tsx
+++ b/app/pages/Account/Components/AccountAllTransactions.tsx
@@ -136,7 +136,7 @@ export default function AccountAllTransactions({
         >
           <AlertTitle>Transaction History Limited</AlertTitle>
           This account has a large transaction history. Due to performance
-          constraints, only the most recent{" "}
+          constraints, only the latest{" "}
           <strong>{MAX_DISPLAYABLE_TRANSACTIONS.toLocaleString()}</strong>{" "}
           transactions are displayed. Older transactions are not shown but can
           still be accessed directly by their version number.
@@ -149,8 +149,9 @@ export default function AccountAllTransactions({
         sx={{my: isCountUnknown ? 0 : 2}}
       >
         <Typography variant="body1" fontWeight="medium">
-          {txnCount.toLocaleString()} transactions
-          {isCountUnknown && " (estimated)"}
+          {isCountUnknown
+            ? `Showing up to ${txnCount.toLocaleString()} transactions`
+            : `${txnCount.toLocaleString()} transactions`}
         </Typography>
         {txnCount > 0 && (
           <CSVExportButton address={address} totalTransactionCount={txnCount} />


### PR DESCRIPTION
### Description

This PR implements a more graceful handling of the 10,000 transaction display limit in the `AccountAllTransactions` component.

**Key changes include:**

*   **Informative Alert:** Added an `Alert` component that appears when an account has more than `MAX_DISPLAYABLE_TRANSACTIONS` (10,000) or when the transaction count query times out. This alert explains the limitation and guides users on accessing older transactions by version number.
*   **Constant for Limit:** Extracted the 10,000 transaction limit into a named constant `MAX_DISPLAYABLE_TRANSACTIONS` for improved maintainability.
*   **Improved Text & Formatting:** Updated transaction count display text (e.g., "Showing latest X transactions") and applied locale formatting to numbers for better readability across the component and on the CSV export button.

This change aims to provide users with clear context and set proper expectations when viewing accounts with extensive transaction histories.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

*   [x] Added an informative alert for transaction limits.
*   [x] Extracted magic number into a named constant.
*   [x] Improved text and number formatting for clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ed561db-0668-491a-99d5-4487789c75e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ed561db-0668-491a-99d5-4487789c75e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Closes https://github.com/aptos-labs/explorer/issues/792
