### PR TITLE
feat(modules): add copy button for full function identifier

### DIFF
--- a/app/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/app/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -1167,11 +1167,19 @@ function ContractForm({
   const fullFunctionId = `${module.address}::${module.name}::${fn.name}`;
 
   async function copyFullFunctionId() {
-    await navigator.clipboard.writeText(fullFunctionId);
-    setFnCopyTooltipOpen(true);
-    setTimeout(() => {
-      setFnCopyTooltipOpen(false);
-    }, TOOLTIP_TIME);
+    try {
+      if (!navigator?.clipboard?.writeText) {
+        console.error("Clipboard API is not available in this environment.");
+        return;
+      }
+      await navigator.clipboard.writeText(fullFunctionId);
+      setFnCopyTooltipOpen(true);
+      setTimeout(() => {
+        setFnCopyTooltipOpen(false);
+      }, TOOLTIP_TIME);
+    } catch (error) {
+      console.error("Failed to copy function id to clipboard:", error);
+    }
   }
 
   // Extract parameter names from source code if available
@@ -1218,7 +1226,11 @@ function ContractForm({
               disableHoverListener={fnCopyTooltipOpen}
               disableTouchListener={fnCopyTooltipOpen}
             >
-              <IconButton onClick={copyFullFunctionId} size="small">
+              <IconButton
+                onClick={copyFullFunctionId}
+                size="small"
+                aria-label="Copy full function identifier"
+              >
                 <ContentCopy fontSize="small" />
               </IconButton>
             </StyledTooltip>


### PR DESCRIPTION
### Description

Added a copy button next to function names in the Modules tab contract form (both Run and Read views). When clicked, it copies the full function identifier in the format `address::module_name::function_name` to the clipboard, with a "Copied!" tooltip confirmation.

This addresses a common pain point where developers building transactions need to manually assemble Move function identifiers from multiple UI locations. The copied value can be used directly in SDKs and CLI transaction payloads.

### Related Links

  - Fixes #1395 

### Checklist
 - [x] I have read the [contributing guidelines](../CONTRIBUTING.md)                                                                                       
 - [x] I have tested my changes locally 
