### PR TITLE
fix(holders): remove slow aggregate count query

### DIFF
--- a/app/api/hooks/useGetCoinHolders.ts
+++ b/app/api/hooks/useGetCoinHolders.ts
@@ -14,15 +14,10 @@ export function useGetCoinHolders(
   isLoading: boolean;
   error: CombinedGraphQLErrors | undefined;
   data: CoinHolder[] | undefined;
-  count: number | undefined;
+  hasMore: boolean;
 } {
   const {loading, error, data} = useGraphqlQuery<{
     current_fungible_asset_balances: CoinHolder[];
-    current_fungible_asset_balances_aggregate: {
-      aggregate: {
-        count: number;
-      };
-    };
   }>(
     gql`
       query GetFungibleAssetBalances(
@@ -39,13 +34,6 @@ export function useGetCoinHolders(
           owner_address
           amount
         }
-        current_fungible_asset_balances_aggregate(
-          where: {asset_type: {_eq: $coin_type}}
-        ) {
-          aggregate {
-            count
-          }
-        }
       }
     `,
     {variables: {coin_type, limit, offset: offset ?? 0}},
@@ -55,6 +43,6 @@ export function useGetCoinHolders(
     isLoading: loading,
     error: error ? (error as CombinedGraphQLErrors) : undefined,
     data: data?.current_fungible_asset_balances,
-    count: data?.current_fungible_asset_balances_aggregate?.aggregate?.count,
+    hasMore: (data?.current_fungible_asset_balances?.length ?? 0) === limit,
   };
 }

--- a/app/pages/Coin/Tabs/HoldersTab.tsx
+++ b/app/pages/Coin/Tabs/HoldersTab.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useReducer} from "react";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {CoinData} from "../Components/CoinData";
 import {
@@ -14,7 +14,7 @@ import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import HashButton, {HashType} from "../../../components/HashButton";
 import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
-import {Box, CircularProgress, Pagination} from "@mui/material";
+import {Box, Button, CircularProgress} from "@mui/material";
 
 type HoldersTabProps = {
   struct: string;
@@ -23,42 +23,98 @@ type HoldersTabProps = {
 
 const LIMIT = 25;
 
+// Wrapper component that remounts HoldersContent when struct changes
 export default function HoldersTab({struct, data}: HoldersTabProps) {
-  const [page, setPage] = useState(1);
-  const [prevStruct, setPrevStruct] = useState(struct);
+  return <HoldersContent key={struct} struct={struct} data={data} />;
+}
 
-  // Reset page when struct changes (during render, per React best practices)
-  if (struct !== prevStruct) {
-    setPrevStruct(struct);
-    setPage(1);
+type HoldersState = {
+  offset: number;
+  holders: CoinHolder[];
+  lastLoadedOffset: number;
+};
+
+type HoldersAction =
+  | {type: "LOAD_MORE"}
+  | {type: "DATA_LOADED"; payload: {offset: number; data: CoinHolder[]}};
+
+function holdersReducer(state: HoldersState, action: HoldersAction): HoldersState {
+  switch (action.type) {
+    case "LOAD_MORE":
+      return {...state, offset: state.offset + LIMIT};
+    case "DATA_LOADED":
+      if (action.payload.offset === state.lastLoadedOffset) {
+        return state; // Already processed this offset
+      }
+      if (action.payload.offset === 0) {
+        return {
+          ...state,
+          holders: action.payload.data,
+          lastLoadedOffset: 0,
+        };
+      }
+      return {
+        ...state,
+        holders: [...state.holders, ...action.payload.data],
+        lastLoadedOffset: action.payload.offset,
+      };
+    default:
+      return state;
+  }
+}
+
+function HoldersContent({struct, data}: HoldersTabProps) {
+  const [state, dispatch] = useReducer(holdersReducer, {
+    offset: 0,
+    holders: [],
+    lastLoadedOffset: -1,
+  });
+
+  const holderData = useGetCoinHolders(struct, LIMIT, state.offset);
+
+  // Process loaded data via reducer dispatch
+  if (
+    holderData.data &&
+    holderData.data.length > 0 &&
+    state.lastLoadedOffset !== state.offset
+  ) {
+    dispatch({
+      type: "DATA_LOADED",
+      payload: {offset: state.offset, data: holderData.data},
+    });
   }
 
-  const offset = (page - 1) * LIMIT;
-  const holderData = useGetCoinHolders(struct, LIMIT, offset);
-
-  if (holderData?.isLoading) {
+  // Show loading only on initial load
+  if (holderData.isLoading && state.holders.length === 0) {
     return (
       <Box sx={{display: "flex", justifyContent: "center", padding: 4}}>
         <CircularProgress />
       </Box>
     );
   }
-  if (!data || Array.isArray(data) || !holderData?.data) {
+  if (!data || Array.isArray(data) || state.holders.length === 0) {
     return <EmptyTabContent />;
   }
 
-  const pageCount = holderData.count ? Math.ceil(holderData.count / LIMIT) : 0;
-
-  const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
-    setPage(value);
+  const handleLoadMore = () => {
+    dispatch({type: "LOAD_MORE"});
   };
 
   return (
     <Box>
-      <HoldersTable data={data} holders={holderData.data} offset={offset} />
-      {pageCount > 1 && (
+      <HoldersTable data={data} holders={state.holders} offset={0} />
+      {holderData.hasMore && (
         <Box sx={{display: "flex", justifyContent: "center", padding: 2}}>
-          <Pagination count={pageCount} page={page} onChange={handleChange} />
+          <Button
+            variant="outlined"
+            onClick={handleLoadMore}
+            disabled={holderData.isLoading}
+            startIcon={
+              holderData.isLoading ? <CircularProgress size={16} /> : null
+            }
+          >
+            {holderData.isLoading ? "Loading..." : "Load more"}
+          </Button>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Summary
Removes the slow `current_fungible_asset_balances_aggregate` count query that times out for tokens with many holders (e.g., USDT). Replaces numbered pagination with "Load more" button.

## Changes
- Remove aggregate count from `useGetCoinHolders` GraphQL query
- Replace `count` return value with `hasMore: boolean`
- Convert both HoldersTab components to use "Load more" pagination
- Use reducer pattern for accumulating holders across pages

## Test plan
- [x] Visit `/fungible_asset/0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b/holders?network=mainnet`
- [x] Verify page loads quickly without timeout
- [x] Click "Load more" and verify additional holders append