### PR TITLE
Portfolio yield AI dropdown

### DIFF
--- a/app/pages/Account/BalanceCard.tsx
+++ b/app/pages/Account/BalanceCard.tsx
@@ -7,10 +7,10 @@ import {
   Select,
   MenuItem,
   SelectChangeEvent,
+  useTheme,
 } from "@mui/material";
 import {getFormattedBalanceStr} from "../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import {Card} from "../../components/Card";
-import {useTheme} from "@mui/material";
 import StyledTooltip from "../../components/StyledTooltip";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import {useGetAccountAPTBalance} from "../../api/hooks/useGetAccountAPTBalance";
@@ -101,13 +101,18 @@ export default function BalanceCard({address}: BalanceCardProps) {
         </Stack>
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Typography fontSize={12} color={theme.palette.text.secondary}>
+          <Typography
+            id="defi-positions-provider-label"
+            fontSize={12}
+            color={theme.palette.text.secondary}
+          >
             DeFi positions on
           </Typography>
           <FormControl size="small" sx={{minWidth: 100}}>
             <Select
               value={portfolioProvider}
               onChange={handleProviderChange}
+              inputProps={{"aria-labelledby": "defi-positions-provider-label"}}
               sx={{
                 fontSize: 12,
                 color: theme.palette.text.primary,
@@ -141,6 +146,7 @@ export default function BalanceCard({address}: BalanceCardProps) {
             fontSize={12}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open portfolio on ${selectedProvider.label} in new tab`}
           >
             <OpenInNew sx={{fontSize: 12}} />
           </Link>


### PR DESCRIPTION
### Description

This PR introduces a dropdown menu to the Balance Card, allowing users to select between "Yield AI" and "Lightscan" for viewing their DeFi positions.

Previously, the card only provided a static link to Lightscan. This change enhances user flexibility by offering multiple portfolio viewing options. The selected option dynamically updates the external link, which opens in a new tab.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

---
[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1770727855599869?thread_ts=1770727855.599869&cid=C040LV2NWQ4)

<p><a href="https://cursor.com/background-agent?bcId=bc-1e3d99ac-a752-5f97-8ce1-ba02e0104896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e3d99ac-a752-5f97-8ce1-ba02e0104896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

