### PR TITLE
Fix infinite useEffect loop in OutOfCommissionPoolsBanner

### DIFF
--- a/app/components/OutOfCommissionPoolsBanner.tsx
+++ b/app/components/OutOfCommissionPoolsBanner.tsx
@@ -13,26 +13,21 @@ import {addressFromWallet} from "../utils";
 export function OutOfCommissionPoolsBanner() {
   const {connected, account} = useWallet();
   const aptosClient = useAptosClient();
-  const [hasZeroCommission, setHasZeroCommission] = useState<boolean>(false);
   const [zeroCommissionPoolAddresses, setZeroCommissionPoolAddresses] =
     useState<string[]>([]);
-  const [isChecking, setIsChecking] = useState<boolean>(false);
 
   const {delegatorPools, loading} = useGetDelegatedStaking(
     addressFromWallet(account?.address),
   );
 
   useEffect(() => {
-    if (!connected || loading || !delegatorPools || !aptosClient) {
-      setHasZeroCommission(false);
-      setZeroCommissionPoolAddresses([]);
-      return;
-    }
-
-    if (isChecking) return;
+    let cancelled = false;
 
     const checkPools = async () => {
-      setIsChecking(true);
+      if (!connected || loading || !delegatorPools || !aptosClient) {
+        setZeroCommissionPoolAddresses([]);
+        return;
+      }
 
       try {
         const poolChecks = delegatorPools.map(async (pool) => {
@@ -66,21 +61,26 @@ export function OutOfCommissionPoolsBanner() {
 
         const results = await Promise.all(poolChecks);
 
+        if (cancelled) return;
+
         const zeroCommissionPools = results
           .filter((result) => result.hasZeroCommission)
           .map((result) => result.address);
 
         setZeroCommissionPoolAddresses(zeroCommissionPools);
-        setHasZeroCommission(zeroCommissionPools.length > 0);
       } catch (error) {
         console.error("Error checking pool commissions:", error);
-      } finally {
-        setIsChecking(false);
       }
     };
 
     checkPools();
-  }, [connected, loading, delegatorPools, aptosClient, isChecking]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connected, loading, delegatorPools, aptosClient]);
+
+  const hasZeroCommission = zeroCommissionPoolAddresses.length > 0;
 
   if (!connected || !hasZeroCommission) {
     return null;


### PR DESCRIPTION
### Description

- Remove isChecking state, it was included in useEffect deps, causing infinite re-renders
- Add cancelled flag to prevent stale async results from updating state
- Move all setState calls inside the `checkPools` function to satisfy the linter
- Derive `hasZeroCommission` from `zeroCommissionPoolAddresses` rather than storing it in the state, again to satisfy the linter

> [!NOTE]
I cannot run tests locally; the API returns a 429 error on the first request. The `pnpm test --run` was green. Please check it before the merge.

Closes #1425

### Related Links

- https://github.com/aptos-labs/explorer/issues/1425
- https://explorer.aptoslabs.com/validators/all?network=mainnet

### Checklist