### PR TITLE
Robots.txt LLM validation

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -72,5 +72,5 @@ Sitemap: https://explorer.aptoslabs.com/sitemap.xml
 
 # LLM-specific files for AI assistants
 # See https://llmstxt.org for the llms.txt standard
-LLMs: https://explorer.aptoslabs.com/llms.txt
-LLMs-full: https://explorer.aptoslabs.com/llms-full.txt
+# https://explorer.aptoslabs.com/llms.txt
+# https://explorer.aptoslabs.com/llms-full.txt


### PR DESCRIPTION
### Description

Comments out invalid `LLMs:` and `LLMs-full:` directives in `robots.txt`. These lines are not part of the `robots.txt` specification and cause validation errors with tools like Google's validator. The `llms.txt` standard relies on well-known paths for discovery, not `robots.txt` directives. The lines are retained as comments for documentation.

### Related Links

### Checklist

---
<p><a href="https://cursor.com/agents/bc-b3d91ec5-484a-429d-8029-f1379755cf60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3d91ec5-484a-429d-8029-f1379755cf60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

