### PR TITLE
Paired FA hash lookup

### DIFF
--- a/app/api/hooks/useGetCoinPairedFa.ts
+++ b/app/api/hooks/useGetCoinPairedFa.ts
@@ -1,22 +1,19 @@
-import {useViewFunction} from "./useViewFunction";
+import {pairedFaMetadataAddress} from "@aptos-labs/ts-sdk";
 
 export function useGetCoinPairedFa(coinType: string): {
   isLoading: boolean;
   data: string | null;
 } {
-  const {isLoading, data} = useViewFunction(
-    "0x1::coin::paired_metadata",
-    [coinType],
-    [],
-  );
-
-  if (data !== undefined) {
-    const mappedData = data as [{vec: [{inner: string}]}];
-    const val = mappedData[0]?.vec[0];
-    if (val !== undefined && val !== null) {
-      return {isLoading, data: val.inner};
-    }
+  if (!coinType) {
+    return {isLoading: false, data: null};
   }
 
-  return {isLoading, data: null};
+  try {
+    const address = pairedFaMetadataAddress(
+      coinType as `0x${string}::${string}::${string}`,
+    );
+    return {isLoading: false, data: address.toStringLong()};
+  } catch {
+    return {isLoading: false, data: null};
+  }
 }

--- a/app/pages/Coin/Index.tsx
+++ b/app/pages/Coin/Index.tsx
@@ -48,14 +48,10 @@ export default function CoinPage() {
 
   const {isLoading: isLoadingCoinSupply, data: supplyInfo} =
     useGetCoinSupplyLimit(struct);
-  const {isLoading: isLoadingPairedFa, data: pairedFa} =
-    useGetCoinPairedFa(struct);
+  const {data: pairedFa} = useGetCoinPairedFa(struct);
 
   const isLoading =
-    isLoadingCoinInfo ||
-    isLoadingCoinList ||
-    isLoadingCoinSupply ||
-    isLoadingPairedFa;
+    isLoadingCoinInfo || isLoadingCoinList || isLoadingCoinSupply;
   if (error === null) {
     error = infoError;
   }


### PR DESCRIPTION
### Description

This PR changes the coin's paired FA lookup to be based on a local hash computation rather than an on-chain view function call.

Previously, the `useGetCoinPairedFa` hook used `useViewFunction` to call `0x1::coin::paired_metadata`. This has been replaced with a synchronous local derivation using `pairedFaMetadataAddress()` from `@aptos-labs/ts-sdk`. This method deterministically computes the paired FA metadata address, with a special case for APT.

This change eliminates a network round-trip, making the paired FA address retrieval immediate, and removes the need for `isLoadingPairedFa`.

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

- [x] Code formatted and linted
- [x] All tests passed

---
<p><a href="https://cursor.com/agents/bc-791649f2-e9bd-4cce-8443-166d7fc3537a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-791649f2-e9bd-4cce-8443-166d7fc3537a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

