### PR TITLE
add PROPS as verified 

### DIFF
--- a/app/data/mainnet/assets.ts
+++ b/app/data/mainnet/assets.ts
@@ -1,4 +1,4 @@
-import type { CoinDescription } from "../../api/hooks/useGetCoinList";
+import type {CoinDescription} from "../../api/hooks/useGetCoinList";
 
 /**
  * Hardcoded coin/asset metadata for Mainnet


### PR DESCRIPTION
Summary
- Add PROPS coin type to mainnetVerifiedTokens to display "Verified" status on the FA page
- The FA page uses the paired coin type for verification lookup, so the coin type entry is required

Test plan
 Visit https://explorer.aptoslabs.com/fungible_asset/0x6dba1728c73363be1bdd4d504844c40fbb893e368ccbeff1d1bd83497dbc756d/info?network=mainnet
 Verify PROPS displays "Verified" instead of "Community Verified"
