### PR TITLE
Event type in collapsed view

### DIFF
--- a/app/pages/Transaction/Tabs/EventsTab.tsx
+++ b/app/pages/Transaction/Tabs/EventsTab.tsx
@@ -47,7 +47,7 @@ export default function EventsTab({transaction}: EventsTabProps) {
           <CollapsibleCard
             key={i}
             titleKey="Index:"
-            titleValue={i.toString()}
+            titleValue={`${i} — ${event.type}`}
             expanded={expandedList[i]}
             toggleExpanded={() => toggleExpandedAt(i)}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Displays the event type alongside the index in the collapsed Events view within `EventsTab.tsx`. This improves readability by changing the `CollapsibleCard` title from just the index (e.g., `0`) to include the event type (e.g., `0 — 0x1::fungible_asset::Deposit`). This is a single-line change leveraging the existing `event.type` field.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->
Resolves https://github.com/aptos-labs/explorer/issues/1402

### Checklist

---
<p><a href="https://cursor.com/agents/bc-0768b946-e4a1-4721-aaea-278e36a03fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0768b946-e4a1-4721-aaea-278e36a03fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->