### PR TITLE
feat(changes): show change type and address/handle in collapsed header

### DIFF
--- a/app/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/app/pages/Transaction/Tabs/ChangesTab.tsx
@@ -16,6 +16,21 @@ type ChangesTabProps = {
   transaction: Types.Transaction;
 };
 
+function getChangeTitleValue(
+  change: Types.WriteSetChange,
+  index: number,
+): string {
+  const parts = [index.toString(), change.type];
+
+  if ("address" in change) {
+    parts.push(change.address);
+  } else if ("handle" in change) {
+    parts.push(change.handle);
+  }
+
+  return parts.join(" — ");
+}
+
 export default function ChangesTab({transaction}: ChangesTabProps) {
   const changes: Types.WriteSetChange[] =
     "changes" in transaction ? transaction.changes : [];
@@ -37,7 +52,7 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
         <CollapsibleCard
           key={change.state_key_hash}
           titleKey="Index:"
-          titleValue={i.toString()}
+          titleValue={getChangeTitleValue(change, i)}
           expanded={expandedList[i]}
           toggleExpanded={() => toggleExpandedAt(i)}
         >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

On the changes tab, collapsed cards previously only showed the index number (e.g. `Index: 0`). This made it difficult to identify changes when using "Collapse All".

This update follows the same pattern used by the events tab, where collapsed cards show `Index: {i} — {event.type}`. The changes tab collapsed header now shows:

- **Index** — the change position
- **Change type** — e.g. `write_resource`, `delete_table_item`, `write_module`
- **Address** (for resource/module changes) or **Handle** (for table item changes)

Example collapsed titles:
- `0 — write_resource — 0x1`
- `3 — write_table_item — 0xabcd...`

### Related Links

Addresses the feature request for more info on the changes page when collapsed, matching the events tab pattern as requested.

Closes https://github.com/aptos-labs/explorer/issues/915

### Checklist

- [x] Code follows existing patterns (mirrors events tab approach)
- [x] `pnpm fmt` passes
- [x] `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00b6fe14-29f4-40b7-9dc1-23951b05e557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00b6fe14-29f4-40b7-9dc1-23951b05e557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

