### PR TITLE
fix(transactions): infer balance change for accounts with non-coin APT flow

### DIFF
--- a/app/pages/Transaction/utils.test.ts
+++ b/app/pages/Transaction/utils.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, it} from "vitest";
-import {getTransactionCounterparty} from "./utils";
+import type {Types} from "~/types/aptos";
+import {
+  getCoinBalanceChangeForAccount,
+  getTransactionAmount,
+  getTransactionCounterparty,
+} from "./utils";
 
 function makeUserTx(
   func: string,
@@ -29,6 +34,46 @@ function makeObjectCoreChange(address: string, owner: string) {
     },
   };
 }
+
+function makeUserTransaction(
+  overrides: Partial<Types.Transaction_UserTransaction> = {},
+): Types.Transaction_UserTransaction {
+  return {
+    type: "user_transaction",
+    version: "1",
+    hash: "0xabc",
+    state_change_hash: "0x",
+    event_root_hash: "0x",
+    state_checkpoint_hash: null,
+    gas_used: "100",
+    success: true,
+    vm_status: "Executed successfully",
+    accumulator_root_hash: "0x",
+    changes: [],
+    sender:
+      "0x0000000000000000000000000000000000000000000000000000000000000099",
+    sequence_number: "0",
+    max_gas_amount: "10000",
+    gas_unit_price: "100",
+    expiration_timestamp_secs: "999999999",
+    payload: {
+      type: "entry_function_payload",
+      function: "0x1::aptos_account::transfer",
+      type_arguments: [],
+      arguments: [],
+    },
+    events: [],
+    timestamp: "1000000",
+    ...overrides,
+  };
+}
+
+const DELEGATOR_ADDR =
+  "0x0000000000000000000000000000000000000000000000000000000000000099";
+const POOL_ADDR =
+  "0x06099edbe54f242bad50020dfd67646b1e46282999483e7064e70f02f7ea3c15";
+const RECEIVER_ADDR =
+  "0x0000000000000000000000000000000000000000000000000000000000000055";
 
 describe("getTransactionCounterparty", () => {
   it("returns undefined for non-user transactions", () => {
@@ -287,5 +332,332 @@ describe("getTransactionCounterparty", () => {
         role: "receiver",
       });
     });
+  });
+});
+
+describe("getCoinBalanceChangeForAccount", () => {
+  it("returns 0 for an account not involved in the transaction", () => {
+    const txn = makeUserTransaction();
+    expect(getCoinBalanceChangeForAccount(txn, POOL_ADDR)).toBe(BigInt(0));
+  });
+
+  it("returns correct balance for a standard coin transfer (sender)", () => {
+    const txn = makeUserTransaction({
+      changes: [
+        {
+          type: "write_resource",
+          address: DELEGATOR_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "0"},
+              deposit_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+        {
+          type: "write_resource",
+          address: RECEIVER_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "1000"},
+              deposit_events: {
+                guid: {id: {addr: RECEIVER_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: RECEIVER_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::WithdrawEvent",
+          guid: {account_address: DELEGATOR_ADDR, creation_number: "3"},
+          sequence_number: "0",
+          data: {amount: "1000"},
+        },
+        {
+          type: "0x1::coin::DepositEvent",
+          guid: {account_address: RECEIVER_ADDR, creation_number: "2"},
+          sequence_number: "0",
+          data: {amount: "1000"},
+        },
+      ],
+    });
+
+    expect(getCoinBalanceChangeForAccount(txn, DELEGATOR_ADDR)).toBe(
+      BigInt(-1000),
+    );
+    expect(getCoinBalanceChangeForAccount(txn, RECEIVER_ADDR)).toBe(
+      BigInt(1000),
+    );
+  });
+
+  it("returns inferred positive amount for delegation pool add_stake", () => {
+    const txn = makeUserTransaction({
+      payload: {
+        type: "entry_function_payload",
+        function: "0x1::delegation_pool::add_stake",
+        type_arguments: [],
+        arguments: [POOL_ADDR, "5000000"],
+      },
+      changes: [
+        {
+          type: "write_resource",
+          address: DELEGATOR_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "0"},
+              deposit_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+        {
+          type: "write_resource",
+          address: POOL_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::stake::StakePool",
+            data: {active: {value: "5000000"}},
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::WithdrawEvent",
+          guid: {account_address: DELEGATOR_ADDR, creation_number: "3"},
+          sequence_number: "0",
+          data: {amount: "5000000"},
+        },
+      ],
+    });
+
+    const poolChange = getCoinBalanceChangeForAccount(txn, POOL_ADDR);
+    expect(poolChange).toBe(BigInt(5000000));
+
+    const delegatorChange = getCoinBalanceChangeForAccount(txn, DELEGATOR_ADDR);
+    expect(delegatorChange).toBe(BigInt(-5000000));
+  });
+
+  it("returns inferred negative amount for delegation pool withdraw", () => {
+    const txn = makeUserTransaction({
+      payload: {
+        type: "entry_function_payload",
+        function: "0x1::delegation_pool::withdraw",
+        type_arguments: [],
+        arguments: [POOL_ADDR, "3000000"],
+      },
+      changes: [
+        {
+          type: "write_resource",
+          address: DELEGATOR_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "3000000"},
+              deposit_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+        {
+          type: "write_resource",
+          address: POOL_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::stake::StakePool",
+            data: {active: {value: "0"}},
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::DepositEvent",
+          guid: {account_address: DELEGATOR_ADDR, creation_number: "2"},
+          sequence_number: "0",
+          data: {amount: "3000000"},
+        },
+      ],
+    });
+
+    const poolChange = getCoinBalanceChangeForAccount(txn, POOL_ADDR);
+    expect(poolChange).toBe(BigInt(-3000000));
+
+    const delegatorChange = getCoinBalanceChangeForAccount(txn, DELEGATOR_ADDR);
+    expect(delegatorChange).toBe(BigInt(3000000));
+  });
+
+  it("handles address normalization (short address lookup)", () => {
+    const shortAddr = "0x1";
+    const fullAddr =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    const txn = makeUserTransaction({
+      changes: [
+        {
+          type: "write_resource",
+          address: fullAddr,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "500"},
+              deposit_events: {guid: {id: {addr: fullAddr, creation_num: "2"}}},
+              withdraw_events: {
+                guid: {id: {addr: fullAddr, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::DepositEvent",
+          guid: {account_address: fullAddr, creation_number: "2"},
+          sequence_number: "0",
+          data: {amount: "500"},
+        },
+      ],
+    });
+
+    expect(getCoinBalanceChangeForAccount(txn, shortAddr)).toBe(BigInt(500));
+    expect(getCoinBalanceChangeForAccount(txn, fullAddr)).toBe(BigInt(500));
+  });
+
+  it("returns 0 for account with write set changes but balanced coin flow", () => {
+    const otherAddr =
+      "0x0000000000000000000000000000000000000000000000000000000000000077";
+    const txn = makeUserTransaction({
+      changes: [
+        {
+          type: "write_resource",
+          address: DELEGATOR_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "0"},
+              deposit_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+        {
+          type: "write_resource",
+          address: otherAddr,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "1000"},
+              deposit_events: {
+                guid: {id: {addr: otherAddr, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: otherAddr, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+        {
+          type: "write_resource",
+          address: POOL_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::stake::StakePool",
+            data: {active: {value: "0"}},
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::WithdrawEvent",
+          guid: {account_address: DELEGATOR_ADDR, creation_number: "3"},
+          sequence_number: "0",
+          data: {amount: "1000"},
+        },
+        {
+          type: "0x1::coin::DepositEvent",
+          guid: {account_address: otherAddr, creation_number: "2"},
+          sequence_number: "0",
+          data: {amount: "1000"},
+        },
+      ],
+    });
+
+    expect(getCoinBalanceChangeForAccount(txn, POOL_ADDR)).toBe(BigInt(0));
+  });
+});
+
+describe("getTransactionAmount", () => {
+  it("returns the larger of deposits and withdrawals", () => {
+    const txn = makeUserTransaction({
+      changes: [
+        {
+          type: "write_resource",
+          address: DELEGATOR_ADDR,
+          state_key_hash: "0x",
+          data: {
+            type: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+            data: {
+              coin: {value: "0"},
+              deposit_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "2"}},
+              },
+              withdraw_events: {
+                guid: {id: {addr: DELEGATOR_ADDR, creation_num: "3"}},
+              },
+            },
+          },
+        } as unknown as Types.WriteSetChange,
+      ],
+      events: [
+        {
+          type: "0x1::coin::WithdrawEvent",
+          guid: {account_address: DELEGATOR_ADDR, creation_number: "3"},
+          sequence_number: "0",
+          data: {amount: "5000000"},
+        },
+      ],
+    });
+
+    expect(getTransactionAmount(txn)).toBe(BigInt(5000000));
+  });
+
+  it("returns undefined for non-user transactions", () => {
+    const txn = {
+      type: "block_metadata_transaction",
+      version: "1",
+      hash: "0x",
+      events: [],
+      changes: [],
+    } as unknown as Types.Transaction;
+
+    expect(getTransactionAmount(txn)).toBe(undefined);
   });
 });

--- a/app/pages/Transaction/utils.tsx
+++ b/app/pages/Transaction/utils.tsx
@@ -511,13 +511,44 @@ export function getCoinBalanceChangeForAccount(
   address: string,
 ): bigint {
   const accountToBalance = getAptBalanceChangeMap(transaction);
+  const standardizedAddress = tryStandardizeAddress(address);
+  const lookupAddress = standardizedAddress ?? address;
 
-  if (!Object.hasOwn(accountToBalance, address)) {
-    return BigInt(0);
+  if (Object.hasOwn(accountToBalance, lookupAddress)) {
+    return accountToBalance[lookupAddress].amount;
   }
 
-  const accountBalance = accountToBalance[address];
-  return accountBalance.amount;
+  // Account has no direct coin/FA balance changes.
+  // Check if it participated in the transaction via write set changes.
+  // If so, calculate the "unaccounted" coin flow: the net APT that moved
+  // through non-coin mechanisms (e.g., staking to a delegation pool).
+  if ("changes" in transaction) {
+    const involvedViaChanges = transaction.changes.some((change) => {
+      if ("address" in change) {
+        const changeAddr = tryStandardizeAddress(
+          (change as {address: string}).address,
+        );
+        return changeAddr === lookupAddress;
+      }
+      return false;
+    });
+
+    if (involvedViaChanges) {
+      const netCoinFlow = Object.values(accountToBalance).reduce(
+        (sum, entry) => sum + entry.amount,
+        BigInt(0),
+      );
+      // A negative net flow means more APT was withdrawn than deposited
+      // via coin events — the difference went to this account through
+      // other mechanisms (e.g., staked). A positive net flow means this
+      // account sent APT out (e.g., unstaking withdrawal to delegator).
+      if (netCoinFlow !== BigInt(0)) {
+        return -netCoinFlow;
+      }
+    }
+  }
+
+  return BigInt(0);
 }
 
 export function getTransactionAmount(

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -761,12 +761,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes incorrect 0 APT amounts displayed in the transaction list for delegation pool accounts (e.g., `add_stake` calls).

**Root cause**: `getCoinBalanceChangeForAccount` only looks at coin/FA events (`DepositEvent`, `WithdrawEvent`, `fungible_asset::Deposit/Withdraw`). For delegation pool operations, the pool address never appears in these events because APT moves through internal staking mechanisms (`StakePool`), not standard coin transfers.

**Fix**: Instead of matching on transaction function names (which is fragile and requires maintaining a list), this uses a general "unaccounted flow" approach:

1. When an account has **no coin/FA events** but **does have write set changes** in the transaction, it's a participant through non-coin mechanisms
2. Calculate the net imbalance from all other accounts' coin events (sum of all balance changes)
3. The negation of that imbalance is the implied flow to/from the viewed account

This correctly infers:
- **`add_stake`**: delegator withdraws APT (negative coin event) → pool has write set changes → inferred +amount for pool
- **`withdraw`**: delegator receives APT (positive coin event) → pool has write set changes → inferred -amount for pool
- **`unlock`/`reactivate_stake`**: no coin transfers → net flow is 0 → shows 0 (correct, since no APT actually moves)

Also fixes address normalization: standardizes the input address before looking it up in the balance map, preventing format mismatches (e.g., short `0x1` vs full 64-char hex).

### Related Links

- Fixes the issue described in this PR: delegation pool `add_stake` showing 0 balance change
- Potentially related to #439

### Checklist

- [x] General approach (no function name matching) per reviewer feedback
- [x] Address standardization fix
- [x] Comprehensive test coverage (8 new tests)
- [x] All 92 tests pass
- [x] Lint and format clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-456a079d-23d0-497a-a459-70c2e5e60522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-456a079d-23d0-497a-a459-70c2e5e60522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

