### PR TITLE
feat(transaction): parse all fungible asset transfer function variants

### DIFF
--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -19,7 +19,7 @@ import TimestampValue from "../../../components/IndividualPageContent/ContentVal
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import {LearnMoreTooltip} from "../../../components/IndividualPageContent/LearnMoreTooltip";
 import {TransactionStatus} from "../../../components/TransactionStatus";
-import {standardizeAddress} from "../../../utils";
+import {standardizeAddress, tryStandardizeAddress} from "../../../utils";
 import {parseExpirationTimestamp} from "../../utils";
 import {getLearnMoreTooltip} from "../helpers";
 import {getTransactionAmount, getTransactionCounterparty} from "../utils";
@@ -455,25 +455,73 @@ const parsers = [
   parseKofiLSDEvent,
 ];
 
-const FA_TRANSFER_FUNCTIONS: Record<
-  string,
-  {metadataIndex: number; recipientIndex: number; amountIndex: number}
-> = {
-  "0x1::aptos_account::transfer_fungible_assets": {
-    metadataIndex: 0,
-    recipientIndex: 1,
-    amountIndex: 2,
-  },
-  "0x1::primary_fungible_store::transfer": {
-    metadataIndex: 0,
-    recipientIndex: 1,
-    amountIndex: 2,
-  },
-};
+function extractObjectInner(arg: unknown): string {
+  if (typeof arg === "object" && arg !== null && "inner" in arg) {
+    return (arg as {inner: string}).inner;
+  }
+  return String(arg);
+}
+
+/**
+ * Resolve the owner of a FungibleStore from the transaction's write-set
+ * changes by finding the ObjectCore at the store address.
+ */
+function resolveStoreOwnerFromChanges(
+  transaction: Types.Transaction,
+  storeAddr: string,
+): string | undefined {
+  if (!("changes" in transaction)) return undefined;
+  const changes = (transaction as {changes: Types.WriteSetChange[]}).changes;
+
+  const normalised = tryStandardizeAddress(storeAddr);
+  if (!normalised) return undefined;
+
+  for (const change of changes) {
+    if (change.type !== "write_resource" && change.type !== "create_resource")
+      continue;
+    const c = change as {address: string; data: {type: string; data: unknown}};
+    if (
+      tryStandardizeAddress(c.address) === normalised &&
+      c.data.type === "0x1::object::ObjectCore"
+    ) {
+      return (c.data.data as {owner: string}).owner;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the metadata address for a FungibleStore from the transaction's
+ * write-set changes.
+ */
+function resolveStoreMetadataFromChanges(
+  transaction: Types.Transaction,
+  storeAddr: string,
+): string | undefined {
+  if (!("changes" in transaction)) return undefined;
+  const changes = (transaction as {changes: Types.WriteSetChange[]}).changes;
+
+  const normalised = tryStandardizeAddress(storeAddr);
+  if (!normalised) return undefined;
+
+  for (const change of changes) {
+    if (change.type !== "write_resource" && change.type !== "create_resource")
+      continue;
+    const c = change as {address: string; data: {type: string; data: unknown}};
+    if (
+      tryStandardizeAddress(c.address) === normalised &&
+      c.data.type === "0x1::fungible_asset::FungibleStore"
+    ) {
+      const storeData = c.data.data as {metadata: {inner: string}};
+      return storeData.metadata.inner;
+    }
+  }
+  return undefined;
+}
 
 function parseFungibleAssetTransferFromPayload(
   transaction: Types.Transaction,
-): FungibleAssetTransfer | undefined {
+): FungibleAssetTransfer | FungibleAssetTransfer[] | undefined {
   if (
     !("payload" in transaction) ||
     !("sender" in transaction) ||
@@ -492,45 +540,67 @@ function parseFungibleAssetTransferFromPayload(
     return undefined;
   }
 
-  const funcConfig =
-    FA_TRANSFER_FUNCTIONS[
-      payload.function as keyof typeof FA_TRANSFER_FUNCTIONS
-    ];
-  if (!funcConfig) {
-    return undefined;
-  }
+  const typedPayload = payload as Types.TransactionPayload_EntryFunctionPayload;
+  const args = typedPayload.arguments;
+  const sender = (transaction as {sender: string}).sender;
+  const fn = typedPayload.function;
 
-  const args = (payload as Types.TransactionPayload_EntryFunctionPayload)
-    .arguments;
+  // 0x1::aptos_account::transfer_fungible_assets(metadata, to, amount)
+  // 0x1::primary_fungible_store::transfer(metadata, recipient, amount)
   if (
-    args.length <=
-    Math.max(
-      funcConfig.amountIndex,
-      funcConfig.recipientIndex,
-      funcConfig.metadataIndex,
-    )
+    fn === "0x1::aptos_account::transfer_fungible_assets" ||
+    fn === "0x1::primary_fungible_store::transfer"
   ) {
-    return undefined;
+    if (args.length < 3) return undefined;
+    return {
+      actionType: "fungible asset transfer",
+      from: sender,
+      to: String(args[1]),
+      metadata: extractObjectInner(args[0]),
+      amount: String(args[2]),
+    };
   }
 
-  const metadataArg = args[funcConfig.metadataIndex];
-  const metadata =
-    typeof metadataArg === "object" &&
-    metadataArg !== null &&
-    "inner" in metadataArg
-      ? (metadataArg as {inner: string}).inner
-      : String(metadataArg);
+  // 0x1::fungible_asset::transfer(from_store, to_store, amount)
+  // 0x1::dispatchable_fungible_asset::transfer(from_store, to_store, amount)
+  if (
+    fn === "0x1::fungible_asset::transfer" ||
+    fn === "0x1::dispatchable_fungible_asset::transfer"
+  ) {
+    if (args.length < 3) return undefined;
+    const toStoreAddr = extractObjectInner(args[1]);
+    const to = resolveStoreOwnerFromChanges(transaction, toStoreAddr);
+    const metadata = resolveStoreMetadataFromChanges(transaction, toStoreAddr);
+    if (!to) return undefined;
+    return {
+      actionType: "fungible asset transfer",
+      from: sender,
+      to,
+      metadata: metadata ?? toStoreAddr,
+      amount: String(args[2]),
+    };
+  }
 
-  const to = String(args[funcConfig.recipientIndex]);
-  const amount = String(args[funcConfig.amountIndex]);
+  // 0x1::aptos_account::batch_transfer_fungible_assets(metadata, recipients[], amounts[])
+  if (fn === "0x1::aptos_account::batch_transfer_fungible_assets") {
+    if (args.length < 3) return undefined;
+    const metadata = extractObjectInner(args[0]);
+    const recipients = args[1];
+    const amounts = args[2];
+    if (!Array.isArray(recipients) || !Array.isArray(amounts)) return undefined;
+    if (recipients.length === 0 || recipients.length !== amounts.length)
+      return undefined;
 
-  return {
-    actionType: "fungible asset transfer",
-    from: (transaction as {sender: string}).sender,
-    to,
-    metadata,
-    amount,
-  };
+    return recipients.map((recipient, i) => ({
+      actionType: "fungible asset transfer" as const,
+      from: sender,
+      to: String(recipient),
+      metadata,
+      amount: String(amounts[i]),
+    }));
+  }
+
+  return undefined;
 }
 
 function TransactionActionsRow({
@@ -580,9 +650,13 @@ function TransactionActionsRow({
   }
 
   // Parse FA transfer actions from payload (these functions don't emit transfer events)
-  const faTransferAction = parseFungibleAssetTransferFromPayload(transaction);
-  if (faTransferAction) {
-    actions.push(faTransferAction);
+  const faTransferResult = parseFungibleAssetTransferFromPayload(transaction);
+  if (faTransferResult) {
+    if (Array.isArray(faTransferResult)) {
+      actions.push(...faTransferResult);
+    } else {
+      actions.push(faTransferResult);
+    }
   }
 
   const {data: coinData} = useGetCoinList();

--- a/app/pages/Transaction/utils.test.ts
+++ b/app/pages/Transaction/utils.test.ts
@@ -5,15 +5,8 @@ function makeUserTx(
   func: string,
   args: unknown[],
   typeArgs: string[] = [],
-): {
-  type: string;
-  payload: {
-    type: string;
-    function: string;
-    type_arguments: string[];
-    arguments: unknown[];
-  };
-} {
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     type: "user_transaction",
     payload: {
@@ -21,6 +14,18 @@ function makeUserTx(
       function: func,
       type_arguments: typeArgs,
       arguments: args,
+    },
+    ...extra,
+  };
+}
+
+function makeObjectCoreChange(address: string, owner: string) {
+  return {
+    type: "write_resource",
+    address,
+    data: {
+      type: "0x1::object::ObjectCore",
+      data: {owner},
     },
   };
 }
@@ -144,6 +149,98 @@ describe("getTransactionCounterparty", () => {
     });
   });
 
+  describe("store-to-store FA transfers (receiver resolved from changes)", () => {
+    const storeAddr =
+      "0x0000000000000000000000000000000000000000000000000000000000000abc";
+    const ownerAddr =
+      "0x0000000000000000000000000000000000000000000000000000000000001234";
+
+    it("parses 0x1::fungible_asset::transfer with ObjectCore change", () => {
+      const tx = makeUserTx(
+        "0x1::fungible_asset::transfer",
+        [{inner: "0xfrom_store"}, {inner: storeAddr}, "1000"],
+        [],
+        {changes: [makeObjectCoreChange(storeAddr, ownerAddr)]},
+      );
+      const result = getTransactionCounterparty(tx as never);
+      expect(result).toEqual({
+        address: ownerAddr,
+        role: "receiver",
+      });
+    });
+
+    it("parses 0x1::dispatchable_fungible_asset::transfer with ObjectCore change", () => {
+      const tx = makeUserTx(
+        "0x1::dispatchable_fungible_asset::transfer",
+        [{inner: "0xfrom_store"}, {inner: storeAddr}, "2000"],
+        [],
+        {changes: [makeObjectCoreChange(storeAddr, ownerAddr)]},
+      );
+      const result = getTransactionCounterparty(tx as never);
+      expect(result).toEqual({
+        address: ownerAddr,
+        role: "receiver",
+      });
+    });
+
+    it("falls through to smart contract when no changes available", () => {
+      const tx = makeUserTx("0x1::fungible_asset::transfer", [
+        {inner: "0xfrom_store"},
+        {inner: storeAddr},
+        "1000",
+      ]);
+      const result = getTransactionCounterparty(tx as never);
+      expect(result).toEqual({
+        address:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+        role: "smartContract",
+      });
+    });
+  });
+
+  describe("batch FA transfer", () => {
+    it("returns single receiver for batch with one recipient", () => {
+      const tx = makeUserTx(
+        "0x1::aptos_account::batch_transfer_fungible_assets",
+        [{inner: "0xmetadata"}, ["0xrecipient_a"], ["1000"]],
+      );
+      expect(getTransactionCounterparty(tx as never)).toEqual({
+        address: "0xrecipient_a",
+        role: "receiver",
+      });
+    });
+
+    it("falls through for batch with multiple recipients", () => {
+      const tx = makeUserTx(
+        "0x1::aptos_account::batch_transfer_fungible_assets",
+        [
+          {inner: "0xmetadata"},
+          ["0xrecipient_a", "0xrecipient_b"],
+          ["1000", "2000"],
+        ],
+      );
+      const result = getTransactionCounterparty(tx as never);
+      expect(result).toEqual({
+        address:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+        role: "smartContract",
+      });
+    });
+
+    it("falls through for batch with empty recipients", () => {
+      const tx = makeUserTx(
+        "0x1::aptos_account::batch_transfer_fungible_assets",
+        [{inner: "0xmetadata"}, [], []],
+      );
+      const result = getTransactionCounterparty(tx as never);
+      expect(result).toEqual({
+        address:
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+        role: "smartContract",
+      });
+    });
+  });
+
   describe("token v2 soulbound mint", () => {
     it("parses 0x4::aptos_token::mint_soul_bound with receiver at arguments[7]", () => {
       const args = Array(8).fill("0x0");
@@ -157,13 +254,14 @@ describe("getTransactionCounterparty", () => {
   });
 
   describe("smart contract interactions", () => {
-    it("returns smart contract address for unknown functions", () => {
+    it("returns standardized smart contract address for unknown functions", () => {
       const tx = makeUserTx("0xdeadbeef::my_module::do_something", [
         "arg1",
         "arg2",
       ]);
       expect(getTransactionCounterparty(tx as never)).toEqual({
-        address: "0xdeadbeef",
+        address:
+          "0x00000000000000000000000000000000000000000000000000000000deadbeef",
         role: "smartContract",
       });
     });

--- a/app/pages/Transaction/utils.tsx
+++ b/app/pages/Transaction/utils.tsx
@@ -32,6 +32,34 @@ export type TransactionCounterparty = {
 //    the transaction is a user transfer (account A send money to account B)
 // when the transaction counterparty is a "smartContract",
 //    the transaction is a user interaction (account A interact with smart contract account B)
+/**
+ * Given a FungibleStore address, find the owner from ObjectCore in the
+ * transaction's write-set changes.
+ */
+function resolveStoreOwner(
+  transaction: Types.Transaction,
+  storeAddr: string,
+): string | undefined {
+  if (!("changes" in transaction)) return undefined;
+  const normalised = tryStandardizeAddress(storeAddr);
+  if (!normalised) return undefined;
+
+  for (const change of (transaction as {changes: Types.WriteSetChange[]})
+    .changes) {
+    if (change.type !== "write_resource" && change.type !== "create_resource") {
+      continue;
+    }
+    const c = change as {address: string; data: {type: string; data: unknown}};
+    if (
+      tryStandardizeAddress(c.address) === normalised &&
+      c.data.type === "0x1::object::ObjectCore"
+    ) {
+      return (c.data.data as {owner: string}).owner;
+    }
+  }
+  return undefined;
+}
+
 export function getTransactionCounterparty(
   transaction: Types.Transaction,
 ): TransactionCounterparty | undefined {
@@ -60,25 +88,30 @@ export function getTransactionCounterparty(
     return undefined;
   }
 
-  // there are two scenarios that this transaction is a 1:1 APT coin transfer:
-  // 1. coins are transferred from account1 to account2:
-  //    payload function is "0x1::coin::transfer" or "0x1::aptos_account::transfer_coins" and the first item in type_arguments is "0x1::aptos_coin::AptosCoin"
-  // 2. coins are transferred from account1 to account2, and account2 is created upon transaction:
-  //    payload function is "0x1::aptos_account::transfer" or "0x1::aptos_account::transfer_coins"
-  // In both scenarios, the first item in arguments is the receiver's address, and the second item is the amount.
-  //
-  // When transferring objects (and Fungible Assets), the receiver is the second argument.
-
+  // Coin transfers: receiver is the first argument
   const isCoinTransfer =
     payload.function === "0x1::coin::transfer" ||
     payload.function === "0x1::aptos_account::transfer_coins" ||
     payload.function === "0x1::aptos_account::transfer" ||
     payload.function === "0x1::aptos_account::fungible_transfer_only"; // rare
+
+  // Object and FA transfers: receiver is the second argument
   const isObjectTransfer =
     payload.function === "0x1::object::transfer" ||
     payload.function === "0x1::object::transfer_call" ||
     payload.function === "0x1::aptos_account::transfer_fungible_assets" ||
     payload.function === "0x1::primary_fungible_store::transfer";
+
+  // Store-to-store FA transfers: arguments are (from_store, to_store, amount).
+  // The receiver is the owner of the destination store, resolved from changes.
+  const isStoreTransfer =
+    payload.function === "0x1::fungible_asset::transfer" ||
+    payload.function === "0x1::dispatchable_fungible_asset::transfer";
+
+  // Batch FA transfer: arguments are (metadata, recipients[], amounts[]).
+  // Only resolve to a single receiver when there is exactly one recipient.
+  const isBatchFATransfer =
+    payload.function === "0x1::aptos_account::batch_transfer_fungible_assets";
 
   const isTokenV2MintSoulbound =
     payload.function === "0x4::aptos_token::mint_soul_bound";
@@ -101,6 +134,34 @@ export function getTransactionCounterparty(
       address: standardized ?? String(arg),
       role: "receiver",
     };
+  }
+
+  if (isStoreTransfer && payload.arguments.length >= 3) {
+    const toStoreArg = payload.arguments[1];
+    const toStoreAddr =
+      typeof toStoreArg === "object" &&
+      toStoreArg !== null &&
+      "inner" in toStoreArg
+        ? (toStoreArg as {inner: string}).inner
+        : String(toStoreArg);
+    const owner = resolveStoreOwner(transaction, toStoreAddr);
+    if (owner) {
+      return {
+        address: tryStandardizeAddress(owner) ?? owner,
+        role: "receiver",
+      };
+    }
+  }
+
+  if (isBatchFATransfer && payload.arguments.length >= 2) {
+    const recipients = payload.arguments[1];
+    if (Array.isArray(recipients) && recipients.length === 1) {
+      const addr = String(recipients[0]);
+      return {
+        address: tryStandardizeAddress(addr) ?? addr,
+        role: "receiver",
+      };
+    }
   }
 
   if (isTokenV2MintSoulbound && payload.arguments.length >= 8) {

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -761,3 +761,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Addresses the feature request to parse `transfer_fungible_assets` and related fungible asset transfer functions so the receiver is displayed and the transfer action is shown in the transaction overview.

**Changes:**

1. **Receiver parsing (`getTransactionCounterparty`)** — Added support for all FA transfer function variants:
   - `0x1::fungible_asset::transfer` — store-to-store transfer; receiver resolved by looking up the destination store's `ObjectCore` owner from the transaction's write-set changes
   - `0x1::dispatchable_fungible_asset::transfer` — same as above (dispatch variant)
   - `0x1::aptos_account::batch_transfer_fungible_assets` — single-recipient batch shows the receiver; multi-recipient batches fall through to smart contract display

2. **Fungible asset transfer action parsing** — Added a new `FungibleAssetTransfer` action type to the `TransactionActionsRow` component. Since FA transfer functions don't emit transfer events, we extract sender, receiver, asset metadata, and amount directly from the entry function payload arguments. Handles:
   - `0x1::aptos_account::transfer_fungible_assets`
   - `0x1::primary_fungible_store::transfer`
   - `0x1::fungible_asset::transfer` (resolves store owner + metadata from changes)
   - `0x1::dispatchable_fungible_asset::transfer` (same)
   - `0x1::aptos_account::batch_transfer_fungible_assets` (generates one action per recipient)

3. **Comprehensive unit tests** — 20 test cases for `getTransactionCounterparty` covering all transfer types, store-to-store transfers, batch transfers, multisig payloads, and edge cases.

**Verified with transaction [2946262614](https://explorer.aptoslabs.com/txn/2946262614?network=mainnet):**
- Receiver at `arguments[1]` = `0xb5fcaf97...` is correctly parsed
- Asset metadata at `arguments[0]` = `{inner: "0x357b0b74..."}` is correctly extracted
- Amount `15021000000` is displayed with proper decimal formatting

### Related Links

- Closes #1157
- Related (closed, not merged): #1170, #1184

### Checklist

- [x] `pnpm fmt` passes
- [x] `pnpm lint` passes (TypeScript + Biome)
- [x] `pnpm test --run` passes (126 tests, 7 files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aaa3210-b060-4987-9498-30471f2ed6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aaa3210-b060-4987-9498-30471f2ed6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

