### PR TITLE
feat(modules): add Simulate button for transaction simulation

### DIFF
--- a/app/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/app/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -1,10 +1,4 @@
-import {
-  type Aptos,
-  Ed25519PublicKey,
-  Hex,
-  parseTypeTag,
-  Secp256k1PublicKey,
-} from "@aptos-labs/ts-sdk";
+import {type Aptos, Hex, parseTypeTag} from "@aptos-labs/ts-sdk";
 import {
   type InputTransactionData,
   useWallet,
@@ -67,38 +61,6 @@ import ErrorPage from "../../Error";
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
 import {accountPagePath} from "../../Index";
 import {useModulesPathParams} from "./Tabs";
-
-/**
- * Create a PublicKey from a hex string, detecting the key type by byte length.
- * Ed25519 keys are 32 bytes; Secp256k1 compressed keys are 33 bytes.
- */
-function createPublicKeyFromHex(
-  publicKeyHex: string,
-): Ed25519PublicKey | Secp256k1PublicKey {
-  const hexStr = publicKeyHex.startsWith("0x")
-    ? publicKeyHex.slice(2)
-    : publicKeyHex;
-  const byteLength = hexStr.length / 2;
-
-  if (byteLength === 32) {
-    return new Ed25519PublicKey(publicKeyHex);
-  }
-  if (byteLength === 33 || byteLength === 65) {
-    return new Secp256k1PublicKey(publicKeyHex);
-  }
-
-  try {
-    return new Ed25519PublicKey(publicKeyHex);
-  } catch {
-    try {
-      return new Secp256k1PublicKey(publicKeyHex);
-    } catch {
-      throw new Error(
-        "Unsupported public key type. Simulation supports Ed25519 and Secp256k1 wallets.",
-      );
-    }
-  }
-}
 
 /**
  * Check if a string looks like an ANS name (ends with .apt)
@@ -741,13 +703,8 @@ function RunContractForm({
         },
       });
 
-      const publicKeyHex = Array.isArray(account.publicKey)
-        ? account.publicKey[0]
-        : account.publicKey;
-      const publicKey = createPublicKeyFromHex(publicKeyHex);
-
       const result = await sdkV2Client.transaction.simulate.simple({
-        signerPublicKey: publicKey,
+        signerPublicKey: account.publicKey,
         transaction,
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a **"Simulate"** button alongside the existing "Execute" button in the **Run** tab of the Modules page. This allows users to preview the full simulation result of a transaction before actually submitting it on-chain.

**How it works:**
- User fills in the entry function form (same as before for Execute)
- Clicks "Simulate" instead of "Execute"
- The transaction is built using the Aptos SDK and simulated via `aptos.transaction.simulate.simple()`
- The full simulation response is displayed as prettified JSON

**What the simulation result shows:**
- Success/failure status with VM status message
- Key metrics at a glance: gas used, events count, changes count
- Collapsible full JSON response including events, state changes, payload, etc.
- Copy-to-clipboard button for the full response

This gives users a clear preview of transaction behavior (events emitted, state changes, gas costs) without relying on wallet-specific simulation UIs, similar to the experience on [run.thala.dev](https://run.thala.dev).

**Implementation details:**
- Uses a `useRef` to distinguish Simulate vs Execute actions while sharing the same form validation
- Builds transaction with `sdkV2Client.transaction.build.simple()` and simulates with `sdkV2Client.transaction.simulate.simple()`
- Simulation and execution results are mutually exclusive (simulating clears execution results and vice versa)
- New `SimulationResultDisplay` component for structured result rendering

### Related Links

- Closes the feature request in this PR's original issue
- Referenced discussion about adding simulation to give users full transaction preview

### Checklist
- [x] Code formatted with `pnpm fmt`
- [x] Linting passes with `pnpm lint` (0 warnings)
- [x] TypeScript compiles cleanly
- [x] No new dependencies added
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d88031-8096-4dd7-9638-8f9de198afd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d88031-8096-4dd7-9638-8f9de198afd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

