### PR TITLE
feat(api-keys): suppress API keys on Netlify preview and branch-deploy builds

### DIFF
--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -40,10 +40,22 @@ const clientApiKeys: ApiKeys = {
 };
 
 /**
+ * True when the build was produced by a Netlify preview deployment (deploy-preview
+ * or branch-deploy context). API keys are intentionally suppressed for these
+ * contexts because the keys are not scoped to preview deployment URLs.
+ * Local development and production builds are unaffected.
+ */
+const isNetlifyPreview =
+  import.meta.env.VITE_NETLIFY_CONTEXT === "deploy-preview" ||
+  import.meta.env.VITE_NETLIFY_CONTEXT === "branch-deploy";
+
+/**
  * Get the client-side API key for a network.
  * This key is safe to expose in the browser (client API key).
+ * Returns undefined on Netlify preview builds.
  */
 export function getApiKey(network_name: NetworkName): string | undefined {
+  if (isNetlifyPreview) return undefined;
   return clientApiKeys[network_name];
 }
 
@@ -51,8 +63,19 @@ export function getApiKey(network_name: NetworkName): string | undefined {
  * Get the server-side API key for a network.
  * Reads from APTOS_<NETWORK>_API_KEY (no VITE_ prefix, never sent to browser).
  * Falls back to the client key if no server key is configured.
+ * Returns undefined on Netlify preview builds (checked via the CONTEXT runtime var).
  */
 export function getServerApiKey(network_name: NetworkName): string | undefined {
+  // Netlify sets CONTEXT at SSR function runtime; suppress keys for preview contexts.
+  const netlifyContext =
+    typeof process !== "undefined" ? process.env.CONTEXT : undefined;
+  if (
+    netlifyContext === "deploy-preview" ||
+    netlifyContext === "branch-deploy"
+  ) {
+    return undefined;
+  }
+
   if (typeof process !== "undefined" && process.env) {
     const envKey = `APTOS_${network_name.toUpperCase()}_API_KEY`;
     const serverKey = process.env[envKey];

--- a/app/types/declarations.d.ts
+++ b/app/types/declarations.d.ts
@@ -56,6 +56,12 @@ interface ImportMetaEnv {
   readonly VITE_APTOS_LOCAL_API_KEY?: string;
   // Server API keys are read from process.env (APTOS_<NETWORK>_API_KEY)
   // and are NOT included in ImportMetaEnv to prevent accidental client exposure.
+  // Netlify build context baked in at build time (production | deploy-preview | branch-deploy).
+  // Undefined for local development. Used to suppress API keys on preview builds.
+  readonly VITE_NETLIFY_CONTEXT?:
+    | "production"
+    | "deploy-preview"
+    | "branch-deploy";
   // Cache busting version for validator stats (bump to force fresh data)
   readonly VITE_VALIDATOR_STATS_CACHE_VERSION?: string;
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -92,14 +92,21 @@
     Content-Type = "text/plain; charset=utf-8"
 
 # Environment variable configuration
+# VITE_NETLIFY_CONTEXT is baked into the client bundle at build time so that
+# client-side code can identify the deploy context without relying on runtime
+# environment variables. API keys are suppressed for preview and branch-deploy
+# contexts because the keys are not scoped to those deployment URLs.
 [context.production.environment]
   NODE_ENV = "production"
+  VITE_NETLIFY_CONTEXT = "production"
 
 [context.deploy-preview.environment]
   NODE_ENV = "production"
+  VITE_NETLIFY_CONTEXT = "deploy-preview"
 
 [context.branch-deploy.environment]
   NODE_ENV = "production"
+  VITE_NETLIFY_CONTEXT = "branch-deploy"
 
 # Redirects for old subdomain-based URLs (2022 format) to new query parameter format
 # These ensure backward compatibility for old bookmarks and links


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Removes the dependency on API keys for Netlify preview builds (`deploy-preview` and `branch-deploy` contexts). The keys are not scoped to preview deployment URLs, so unauthenticated requests are the correct behaviour there. Local development and production deployments continue to use API keys as before.

**Changes:**

- **`netlify.toml`** — adds `VITE_NETLIFY_CONTEXT` to each build context (`production`, `deploy-preview`, `branch-deploy`). This value is baked into the client bundle at Vite build time so that client-side code can identify the deploy context without runtime environment access.

- **`app/lib/constants.ts`**
  - `getApiKey()` now returns `undefined` when `VITE_NETLIFY_CONTEXT` is a preview context, so client-side API requests go unauthenticated on preview deployments.
  - `getServerApiKey()` now checks Netlify's built-in `CONTEXT` runtime variable and returns `undefined` for `deploy-preview` and `branch-deploy`, preventing SSR functions from forwarding production keys on preview URLs.

- **`app/types/declarations.d.ts`** — declares `VITE_NETLIFY_CONTEXT` in `ImportMetaEnv` with a union type of the three valid values.

**Behaviour matrix:**

| Context | `VITE_NETLIFY_CONTEXT` | API keys used? |
|---|---|---|
| Local dev | `undefined` | Yes (if configured) |
| Production | `"production"` | Yes |
| Deploy preview | `"deploy-preview"` | **No** |
| Branch deploy | `"branch-deploy"` | **No** |

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist

- [x] Follows existing code patterns
- [x] TypeScript strict mode compliance (`pnpm lint` passes)
- [x] Biome formatting applied (`pnpm fmt` passes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffa391d6-8392-4858-ae19-0d9af0030462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffa391d6-8392-4858-ae19-0d9af0030462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

