### PR TITLE
docs(agents): add Cursor Cloud specific instructions for environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,8 +334,8 @@ Role-specific rules are available in tool-native formats:
 
 ### Environment
 
-- **Node.js 24+** is required (`engines` field in `package.json`). The VM ships with Node 22 via nvm; run `nvm install 24 && nvm alias default 24` before anything else.
-- **pnpm 10.32.1** is the pinned package manager. Enable it with `corepack enable && corepack prepare pnpm@10.32.1 --activate`.
+The VM update script installs **Node.js 24+** (via nvm), activates **pnpm 10.32.1** (via corepack), and runs `pnpm install`. After startup, **Biome**, **TypeScript**, and **Vitest** are available immediately — no manual setup required.
+
 - No Docker, databases, or external backend services are required. The explorer is a pure frontend/SSR app that reads from public Aptos API endpoints.
 - All environment variables are optional; sensible defaults are hardcoded. See `.env.example` for available overrides.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Configure the Cursor Cloud agent environment so that **Node 24+**, **pnpm 10.32.1**, and all npm dependencies (including Biome, TypeScript, and Vitest) are ready on VM startup without any manual setup.

**Changes:**
- Updated `AGENTS.md` `## Cursor Cloud specific instructions` to clarify that Node/pnpm/install are automated on startup, and Biome, TypeScript, and Vitest are available immediately.

**Update script** (runs automatically on VM startup):
```
. ~/.nvm/nvm.sh && nvm install 24 && nvm alias default 24
corepack enable && corepack prepare pnpm@10.32.1 --activate
pnpm install
```

No code changes — documentation and environment configuration only.

### Related Links

N/A — environment setup task.

### Checklist

- [x] `pnpm fmt` passes
- [x] `pnpm lint` passes (tsc + biome)
- [x] `pnpm test --run` passes (84/84 tests)
- [x] Dev server starts on port 3030 with live data
- [x] Biome 2.4.6, TypeScript 5.9.3, Vitest 4.1.0 all available after `pnpm install`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed744187-6aac-4c6e-b4fd-3dae79a2100b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed744187-6aac-4c6e-b4fd-3dae79a2100b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

