### PR TITLE
feat(aip141): add configurable warningCutoffVersion to suppress 10x fees warning

### DIFF
--- a/app/utils/aip140.test.ts
+++ b/app/utils/aip140.test.ts
@@ -5,6 +5,7 @@ describe("aip141", () => {
   afterEach(() => {
     AIP141_CONFIG.enabled = true;
     AIP141_CONFIG.gasReductionVersion = 116277493n;
+    AIP141_CONFIG.warningCutoffVersion = 2113286341n;
     AIP141_CONFIG.aip141GasScheduleVersion = 46;
   });
 
@@ -52,6 +53,24 @@ describe("aip141", () => {
     it("still applies 10x check when no version is provided", () => {
       expect(wouldExceedGasLimit("300000", "2000000")).toBe(true);
     });
+
+    it("skips transactions at or after the warning cutoff version", () => {
+      expect(wouldExceedGasLimit("300000", "2000000", "2113286341")).toBe(
+        false,
+      );
+      expect(wouldExceedGasLimit("300000", "2000000", "3000000000")).toBe(
+        false,
+      );
+    });
+
+    it("still flags transactions just before the warning cutoff", () => {
+      expect(wouldExceedGasLimit("300000", "2000000", "2113286340")).toBe(true);
+    });
+
+    it("disables cutoff when warningCutoffVersion is 0n", () => {
+      AIP141_CONFIG.warningCutoffVersion = 0n;
+      expect(wouldExceedGasLimit("300000", "2000000", "9999999999")).toBe(true);
+    });
   });
 
   describe("isAip141Executed", () => {
@@ -84,6 +103,10 @@ describe("aip141", () => {
 
     it("has gasReductionVersion set to AIP-17 version", () => {
       expect(AIP141_CONFIG.gasReductionVersion).toBe(116277493n);
+    });
+
+    it("has warningCutoffVersion set", () => {
+      expect(AIP141_CONFIG.warningCutoffVersion).toBe(2113286341n);
     });
 
     it("has aip141GasScheduleVersion set to 46", () => {

--- a/app/utils/aip140.ts
+++ b/app/utils/aip140.ts
@@ -10,15 +10,19 @@
  * schedule version reaches `aip141GasScheduleVersion`, AIP-141 is live
  * and the UI switches to "executed / current impact" messaging.
  *
- * There are three eras to consider:
+ * There are four eras to consider:
  *  1. Before the 100x gas reduction — transactions used the old (high) gas
  *     schedule. AIP-141's net effect on these is actually a ~10x *decrease*
  *     (100x down then 10x up), so they should NOT be flagged.
  *  2. After the 100x gas reduction but before AIP-141 — transactions use
  *     the reduced schedule. The 10x multiplier projects what gas would look
  *     like once AIP-141 is live.
- *  3. After AIP-141 enablement — gas is already raised. The 10x multiplier
- *     checks whether a further 10x increase would exceed the limit.
+ *  3. After AIP-141 enablement but before the warning cutoff — gas is
+ *     already raised. The 10x multiplier checks whether a further 10x
+ *     increase would exceed the limit.
+ *  4. At or after `warningCutoffVersion` — the 10x warning is suppressed
+ *     because the new gas schedule is already in effect and users have
+ *     adapted. Set to 0n to disable the cutoff (warn for all versions).
  */
 
 export const AIP141_CONFIG = {
@@ -34,6 +38,12 @@ export const AIP141_CONFIG = {
    * net-reduce their gas).
    */
   gasReductionVersion: 116277493n,
+  /**
+   * Ledger version at or after which the 10x fee warning is suppressed.
+   * Transactions at or after this version will never be flagged. Set to
+   * 0n to disable the cutoff and warn for all eligible versions.
+   */
+  warningCutoffVersion: 2113286341n,
   /**
    * The gas schedule `feature_version` at which AIP-141 takes effect.
    * The next gas schedule version bump enables AIP-141. When the on-chain
@@ -60,7 +70,9 @@ export function isAip141Executed(currentGasScheduleVersion: number): boolean {
  * AIP-141 multiplier — would exceed its max gas amount.
  *
  * Pass the transaction `version` so that pre-gas-reduction transactions
- * (which would actually *benefit* from AIP-141) are excluded.
+ * (which would actually *benefit* from AIP-141) are excluded, and
+ * post-cutoff transactions (where the new schedule is already the norm)
+ * are also excluded.
  */
 export function wouldExceedGasLimit(
   gasUsed: string,
@@ -69,12 +81,20 @@ export function wouldExceedGasLimit(
 ): boolean {
   if (!AIP141_CONFIG.enabled) return false;
   try {
-    if (
-      version &&
-      AIP141_CONFIG.gasReductionVersion > 0n &&
-      BigInt(version) < AIP141_CONFIG.gasReductionVersion
-    ) {
-      return false;
+    if (version) {
+      const v = BigInt(version);
+      if (
+        AIP141_CONFIG.gasReductionVersion > 0n &&
+        v < AIP141_CONFIG.gasReductionVersion
+      ) {
+        return false;
+      }
+      if (
+        AIP141_CONFIG.warningCutoffVersion > 0n &&
+        v >= AIP141_CONFIG.warningCutoffVersion
+      ) {
+        return false;
+      }
     }
 
     const projected = BigInt(gasUsed) * AIP141_CONFIG.gasMultiplier;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a configurable `warningCutoffVersion` to `AIP141_CONFIG` that suppresses the 10x gas fee warning for transactions at or after a specified ledger version. The default cutoff is set to version `2113286341`.

This allows the 10x fees warning to be scoped to a specific historical range of transactions, rather than applying indefinitely. Transactions before the gas reduction version (`116277493`) were already excluded; now transactions at or after the cutoff are also excluded.

The cutoff can be disabled by setting `warningCutoffVersion` to `0n`, which restores the previous behavior of warning for all eligible versions.

**Changes:**
- Added `warningCutoffVersion` field to `AIP141_CONFIG` in `app/utils/aip140.ts`
- Updated `wouldExceedGasLimit()` to return `false` for transactions at or after the cutoff version
- Updated doc comments to describe the four eras of gas schedule handling
- Added comprehensive unit tests for the new cutoff behavior

### Related Links

Related to AIP-141 gas impact analysis feature.

### Checklist

- [x] `pnpm fmt` passes
- [x] `pnpm lint` passes (only pre-existing warnings)
- [x] `pnpm test --run` passes (130 tests, including new cutoff tests)
- [x] Manually verified in dev server that recent transactions show no warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d00e9bd2-aeb3-4849-bed3-edd060db739b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d00e9bd2-aeb3-4849-bed3-edd060db739b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

