### PR TITLE
feat(labels): add Decibel label for mainnet address

### DIFF
--- a/app/data/mainnet/knownAddresses.ts
+++ b/app/data/mainnet/knownAddresses.ts
@@ -347,6 +347,8 @@ export const mainnetKnownAddresses: Record<string, string> = {
     "UFC Strike",
   "0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2":
     "WLFI USD",
+  "0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06":
+    "Decibel",
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff":
     "Burn Address",
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Add the "Decibel" label for mainnet address `0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06` to the known addresses registry.

### Related Links

N/A

### Checklist

- [x] Label added to `app/data/mainnet/knownAddresses.ts`
- [x] `pnpm fmt` passed
- [x] `pnpm lint` passed (pre-existing warnings only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f02e0c97-c205-4c2f-b3dd-584a685fac20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f02e0c97-c205-4c2f-b3dd-584a685fac20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

