### PR TITLE
feat(changes-tab): enrich table item changes with decoded data from indexer

### DIFF
--- a/app/api/hooks/useGetTableItemData.ts
+++ b/app/api/hooks/useGetTableItemData.ts
@@ -1,0 +1,93 @@
+import {useQuery} from "@tanstack/react-query";
+import {useNetworkValue, useSdkV2Client} from "../../global-config";
+import {useGetIsGraphqlClientSupported} from "./useGraphqlClient";
+
+const TABLE_ITEMS_DATA_QUERY = `
+  query TableItemsData($transaction_version: bigint!) {
+    table_items(
+      where: { transaction_version: { _eq: $transaction_version } }
+    ) {
+      decoded_key
+      decoded_value
+      key
+      table_handle
+      transaction_version
+      write_set_change_index
+    }
+  }
+`;
+
+const TABLE_ITEMS_METADATA_QUERY = `
+  query TableItemsMetadata($handles: [String!]!) {
+    table_metadatas(
+      where: { handle: { _in: $handles } }
+    ) {
+      handle
+      key_type
+      value_type
+    }
+  }
+`;
+
+export type IndexerTableItem = {
+  decoded_key: string;
+  decoded_value: string | null;
+  key: string;
+  table_handle: string;
+  transaction_version: number;
+  write_set_change_index: number;
+};
+
+export type IndexerTableMetadata = {
+  handle: string;
+  key_type: string;
+  value_type: string;
+};
+
+type TableItemsDataResponse = {
+  table_items: IndexerTableItem[];
+};
+
+type TableItemsMetadataResponse = {
+  table_metadatas: IndexerTableMetadata[];
+};
+
+export function useGetTableItemsData(transactionVersion: string | undefined) {
+  const client = useSdkV2Client();
+  const networkValue = useNetworkValue();
+  const isGraphqlSupported = useGetIsGraphqlClientSupported();
+
+  return useQuery({
+    queryKey: ["tableItemsData", transactionVersion, networkValue],
+    queryFn: () =>
+      client.queryIndexer<TableItemsDataResponse>({
+        query: {
+          query: TABLE_ITEMS_DATA_QUERY,
+          variables: {transaction_version: transactionVersion},
+        },
+      }),
+    enabled: isGraphqlSupported && !!transactionVersion,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 24 * 60 * 60 * 1000,
+  });
+}
+
+export function useGetTableItemsMetadata(handles: string[]) {
+  const client = useSdkV2Client();
+  const networkValue = useNetworkValue();
+  const isGraphqlSupported = useGetIsGraphqlClientSupported();
+
+  return useQuery({
+    queryKey: ["tableItemsMetadata", handles.sort().join(","), networkValue],
+    queryFn: () =>
+      client.queryIndexer<TableItemsMetadataResponse>({
+        query: {
+          query: TABLE_ITEMS_METADATA_QUERY,
+          variables: {handles},
+        },
+      }),
+    enabled: isGraphqlSupported && handles.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 24 * 60 * 60 * 1000,
+  });
+}

--- a/app/pages/Transaction/Tabs/ChangesTab.tsx
+++ b/app/pages/Transaction/Tabs/ChangesTab.tsx
@@ -6,6 +6,10 @@ import type {
   WriteSetChange_DeleteTableItem,
   WriteSetChange_WriteTableItem,
 } from "~/types/aptos";
+import {
+  useGetTableItemsData,
+  useGetTableItemsMetadata,
+} from "../../../api/hooks/useGetTableItemData";
 import HashButton, {HashType} from "../../../components/HashButton";
 import useExpandedList from "../../../components/hooks/useExpandedList";
 import CollapsibleCard from "../../../components/IndividualPageContent/CollapsibleCard";
@@ -165,9 +169,11 @@ function DecodedValueDisplay({value}: {value: unknown}) {
 function TableItemDetails({
   change,
   enclosingAccounts,
+  isEnriching = false,
 }: {
   change: TableItemChange;
   enclosingAccounts: EnclosingAccount[];
+  isEnriching?: boolean;
 }) {
   const theme = useTheme();
   const hasDecodedData = !!change.data;
@@ -203,6 +209,20 @@ function TableItemDetails({
                 </Stack>
               ))}
             </Stack>
+          }
+        />
+      )}
+
+      {isEnriching && !hasDecodedData && (
+        <ContentRow
+          title="Decoded Data:"
+          value={
+            <Typography
+              variant="body2"
+              sx={{color: mutedColor, fontStyle: "italic", fontSize: "0.85rem"}}
+            >
+              Loading decoded data from indexer…
+            </Typography>
           }
         />
       )}
@@ -290,15 +310,84 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
   const changes: Types.WriteSetChange[] =
     "changes" in transaction ? transaction.changes : [];
 
+  const transactionVersion =
+    "version" in transaction ? (transaction.version as string) : undefined;
+
+  const tableHandles = useMemo(() => {
+    const handles = new Set<string>();
+    for (const change of changes) {
+      if (isTableItemChange(change) && change.data == null) {
+        handles.add(change.handle);
+      }
+    }
+    return [...handles];
+  }, [changes]);
+
+  const hasUnenrichedTableItems = tableHandles.length > 0;
+
+  const {data: tableItemsResponse, isLoading: isLoadingItems} =
+    useGetTableItemsData(
+      hasUnenrichedTableItems ? transactionVersion : undefined,
+    );
+  const {data: tableMetadataResponse, isLoading: isLoadingMetadata} =
+    useGetTableItemsMetadata(hasUnenrichedTableItems ? tableHandles : []);
+
+  const enrichedChanges = useMemo(() => {
+    if (!tableItemsResponse || !tableMetadataResponse) return changes;
+
+    const tableItems = tableItemsResponse.table_items ?? [];
+    const tableMetadatas = tableMetadataResponse.table_metadatas ?? [];
+
+    if (tableItems.length === 0 && tableMetadatas.length === 0) return changes;
+
+    const metadataByHandle = new Map(tableMetadatas.map((m) => [m.handle, m]));
+    const tableItemByIndex = new Map(
+      tableItems.map((item) => [Number(item.write_set_change_index), item]),
+    );
+
+    return changes.map((change, i) => {
+      if (!isTableItemChange(change) || change.data != null) return change;
+
+      const indexerItem = tableItemByIndex.get(i);
+      const metadata = metadataByHandle.get(change.handle);
+      if (!indexerItem || !metadata) return change;
+
+      if (isWriteTableItem(change)) {
+        return {
+          ...change,
+          data: {
+            key: indexerItem.decoded_key,
+            key_type: metadata.key_type,
+            value: indexerItem.decoded_value,
+            value_type: metadata.value_type,
+          },
+        };
+      }
+
+      return {
+        ...change,
+        data: {
+          key: indexerItem.decoded_key,
+          key_type: metadata.key_type,
+          value: indexerItem.decoded_value,
+          value_type: metadata.value_type,
+        },
+      };
+    });
+  }, [changes, tableItemsResponse, tableMetadataResponse]);
+
+  const isEnriching =
+    hasUnenrichedTableItems && (isLoadingItems || isLoadingMetadata);
+
   const {expandedList, toggleExpandedAt, expandAll, collapseAll} =
-    useExpandedList(changes.length);
+    useExpandedList(enrichedChanges.length);
 
   const handleToAccounts = useMemo(
-    () => buildHandleToAccountsIndex(changes),
-    [changes],
+    () => buildHandleToAccountsIndex(enrichedChanges),
+    [enrichedChanges],
   );
 
-  if (changes.length === 0) {
+  if (enrichedChanges.length === 0) {
     return <EmptyTabContent />;
   }
 
@@ -308,7 +397,7 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
       expandAll={expandAll}
       collapseAll={collapseAll}
     >
-      {changes.map((change, i) => (
+      {enrichedChanges.map((change, i) => (
         <CollapsibleCard
           key={change.state_key_hash}
           titleKey="Index:"
@@ -356,6 +445,7 @@ export default function ChangesTab({transaction}: ChangesTabProps) {
             <TableItemDetails
               change={change}
               enclosingAccounts={handleToAccounts.get(change.handle) ?? []}
+              isEnriching={isEnriching && change.data == null}
             />
           )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Implements the table item data enrichment logic from [aptos-labs/aptos-ts-sdk#847](https://github.com/aptos-labs/aptos-ts-sdk/pull/847) directly in the explorer. When viewing a transaction's Changes tab, `write_table_item` and `delete_table_item` entries that arrive with `null` data from the fullnode API are now automatically enriched with decoded key/value types and values fetched from the indexer.

**How it works:**
1. Identifies table item changes with missing `data` fields
2. Queries the indexer's `table_items` table for decoded key/value data (matched by `transaction_version` and `write_set_change_index`)
3. Queries the indexer's `table_metadatas` table for type metadata (`key_type`, `value_type`) by table handle
4. Merges the decoded data into the changes array for display

The existing UI already supported displaying decoded data when available — this change provides the data source. Each enriched table item now shows:
- **Key Type** and **Key (Decoded)** — human-readable key with its Move type
- **Value Type** and **Value (Decoded)** — decoded value (supports both primitives and complex nested structs rendered as JSON)
- **Key (Raw)** and **Value (Raw)** — original hex-encoded data for reference

A loading indicator is shown while the indexer data is being fetched. Both queries are cached aggressively (infinite stale time) since transaction data is immutable.

### Related Links

- Based on: https://github.com/aptos-labs/aptos-ts-sdk/pull/847
- Resolves: https://github.com/aptos-labs/aptos-ts-sdk/issues/635 (explorer-side implementation)

### Checklist

- [x] Code formatted with `pnpm fmt`
- [x] Lint passes with `pnpm lint`
- [x] Tests pass with `pnpm test --run`
- [x] Manually tested with mainnet transaction version 563060087
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f5536f-31f1-4101-9930-ecb5448c82f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f5536f-31f1-4101-9930-ecb5448c82f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

