### PR TITLE
fix(blocks): humanize block age display

### DIFF
--- a/app/pages/Blocks/Table.tsx
+++ b/app/pages/Blocks/Table.tsx
@@ -25,11 +25,29 @@ import {
 import {assertNever} from "../../utils";
 import {getTimeDiffInSeconds, parseTimestamp} from "../utils";
 
-function getAgeInSeconds(block: Types.Block): string {
+function formatAge(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  } else if (seconds < 3600) {
+    const mins = Math.floor(seconds / 60);
+    return `${mins}min ago`;
+  } else if (seconds < 86400) {
+    const hrs = Math.floor(seconds / 3600);
+    return `${hrs}h ago`;
+  } else {
+    const days = Math.floor(seconds / 86400);
+    return `${days}d ago`;
+  }
+}
+
+function getBlockAge(block: Types.Block): string {
   const blockTimestamp = parseTimestamp(block.block_timestamp);
   const nowTimestamp = new Date();
-  const durationInSec = getTimeDiffInSeconds(blockTimestamp, nowTimestamp);
-  return durationInSec.toFixed(0);
+  const durationInSec = Math.max(
+    0,
+    Math.floor(getTimeDiffInSeconds(blockTimestamp, nowTimestamp)),
+  );
+  return formatAge(durationInSec);
 }
 
 type BlockCellProps = {
@@ -49,7 +67,7 @@ function BlockHeightCell({block}: BlockCellProps) {
 function BlockAgeCell({block}: BlockCellProps) {
   return (
     <GeneralTableCell sx={{textAlign: "left"}}>
-      {`${getAgeInSeconds(block)}s ago`}
+      {getBlockAge(block)}
     </GeneralTableCell>
   );
 }
@@ -187,7 +205,7 @@ const BlockCard = React.memo(function BlockCard({block}: BlockCardProps) {
           Block {block.block_height}
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {`${getAgeInSeconds(block)}s ago`}
+          {getBlockAge(block)}
         </Typography>
       </Stack>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies [`explorer-fix-block-age-display.patch`](https://github.com/aptos-labs/aptos-core/blob/ca7cea2f6ac68724e56680665d5f5ad22d7968cf/explorer-fix-block-age-display.patch) from `aptos-core`.

### Changes

- **Blocks table & mobile card**: Show age as `Xs ago`, `Ymin ago`, `Zh ago`, or `Wd ago` instead of always seconds.
- **Math**: Use `Math.floor` on the diff in seconds and `Math.max(0, …)` so clock skew does not show negative ages.

### Testing

- `pnpm fmt` / `pnpm lint` (pre-existing warnings in unrelated route files)
- `pnpm test --run` — all passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-118da268-2ba5-4fa4-9618-16b7bd2aac41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-118da268-2ba5-4fa4-9618-16b7bd2aac41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

