### PR TITLE
fix: Correct ThalaSwapCL event address and add support for liquidity event

### DIFF
--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -1803,7 +1803,7 @@ function parseThalaCLEvent(
 
     return {
       actionType: "swap",
-      dex: "0x075b4890de3e312d9425408c43d9a9752b64ab3562a30e89a55bdc568c645920",
+      dex,
       amountIn,
       amountOut,
       assetIn,


### PR DESCRIPTION
### Description

Event Name will omit the leading 0 in address, so it is not being parsed as expected.
