### PR TITLE
feat(transaction): badges for Object, String, and Option argument types

### DIFF
--- a/app/pages/Transaction/Tabs/Components/MoveFunctionParamTypeBadge.tsx
+++ b/app/pages/Transaction/Tabs/Components/MoveFunctionParamTypeBadge.tsx
@@ -3,13 +3,18 @@ import {getParamTypeDisplay} from "./moveParamTypeDisplay";
 
 type MoveFunctionParamTypeBadgeProps = {
   typeStr: string;
-  /** When false, match legacy Typography styling (function args table). */
-  variant?: "table" | "card";
+  /**
+   * Layout and plain (non-chip) type color:
+   * - `functionArgTable`: function-args table — monospace plain types use primary (legacy).
+   * - `typeArgTable`: type-args value column — plain types use default table text color.
+   * - `card`: stacked mobile card — slightly smaller chip; plain types use primary.
+   */
+  variant?: "functionArgTable" | "typeArgTable" | "card";
 };
 
 export default function MoveFunctionParamTypeBadge({
   typeStr,
-  variant = "table",
+  variant = "functionArgTable",
 }: MoveFunctionParamTypeBadgeProps) {
   const theme = useTheme();
   const display = getParamTypeDisplay(typeStr);
@@ -30,13 +35,15 @@ export default function MoveFunctionParamTypeBadge({
   } as const;
 
   if (display.kind === "plain") {
+    const plainColor =
+      variant === "typeArgTable" ? undefined : theme.palette.primary.main;
     return (
       <Typography
         component="span"
         variant="caption"
         sx={{
           fontFamily: "monospace",
-          color: theme.palette.primary.main,
+          ...(plainColor !== undefined ? {color: plainColor} : {}),
         }}
       >
         {display.text}
@@ -56,10 +63,10 @@ export default function MoveFunctionParamTypeBadge({
 
   return (
     <Tooltip title={display.tooltip} placement="top" enterDelay={300}>
-      {variant === "table" ? (
-        <span style={{display: "inline-flex", maxWidth: "100%"}}>{chip}</span>
-      ) : (
+      {variant === "card" ? (
         chip
+      ) : (
+        <span style={{display: "inline-flex", maxWidth: "100%"}}>{chip}</span>
       )}
     </Tooltip>
   );

--- a/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
+++ b/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
@@ -293,7 +293,10 @@ export default function TransactionArguments({
                               borderBottom: `1px solid ${theme.palette.divider}`,
                             }}
                           >
-                            <MoveFunctionParamTypeBadge typeStr={typeArg} />
+                            <MoveFunctionParamTypeBadge
+                              typeStr={typeArg}
+                              variant="typeArgTable"
+                            />
                           </TableCell>
                         </TableRow>
                       ))}

--- a/app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.test.ts
+++ b/app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.test.ts
@@ -74,6 +74,13 @@ describe("getParamTypeDisplay", () => {
       text: "unknown",
     });
   });
+
+  it("normalizes whitespace for unknown placeholder", () => {
+    expect(getParamTypeDisplay("  unknown  ")).toEqual({
+      kind: "plain",
+      text: "unknown",
+    });
+  });
 });
 
 describe("shortenTypeTagForBadge", () => {

--- a/app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.ts
+++ b/app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.ts
@@ -68,7 +68,7 @@ export type ParamTypeDisplay =
 export function getParamTypeDisplay(typeStr: string): ParamTypeDisplay {
   const trimmed = typeStr.trim();
   if (!trimmed || trimmed === "unknown") {
-    return {kind: "plain", text: typeStr};
+    return {kind: "plain", text: trimmed};
   }
 
   try {
@@ -113,6 +113,6 @@ export function getParamTypeDisplay(typeStr: string): ParamTypeDisplay {
 
     return {kind: "plain", text: trimmed};
   } catch {
-    return {kind: "plain", text: typeStr};
+    return {kind: "plain", text: trimmed};
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

On the transaction page, function argument **Type** cells and type-argument **Value** cells now use compact MUI chips for common stdlib types:

- `0x1::object::Object` (including generic instantiations) shows **Object**; the tooltip shows the full type string.
- `0x1::string::String` shows **String** with the full type on hover.
- `0x1::option::Option<…>` shows **Option** with a shortened inner type (e.g. nested `String` / `Object`, truncated long addresses); the tooltip shows the complete type.
- `vector<…>` shows **vector** with a shortened element type the same way; tooltip shows the full type. **`&vector<…>`** keeps a leading **`&`** on the label.

Reference types (e.g. `&0x1::object::Object<…>`) keep a leading `&` on the badge label. Other Move types are unchanged (monospace text as before).

Implementation uses `parseTypeTag` from `@aptos-labs/ts-sdk` with Vitest coverage in `moveParamTypeDisplay.test.ts`.

### Related Links

n/a

### Checklist

- [x] `pnpm fmt` / `pnpm lint` / `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbcd9316-c09e-4b6d-ae26-445dc821f9ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbcd9316-c09e-4b6d-ae26-445dc821f9ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

