### PR TITLE
feat(modules): add per-field copy buttons for struct responses

### DIFF
--- a/app/pages/Account/Tabs/ModulesTab/Contract.test.ts
+++ b/app/pages/Account/Tabs/ModulesTab/Contract.test.ts
@@ -1,23 +1,5 @@
 import {describe, expect, it} from "vitest";
-
-/**
- * These helpers are defined in Contract.tsx. We re-implement them here for
- * testing since the module has heavy React/MUI dependencies that make direct
- * imports impractical without a full render test setup.
- *
- * The canonical implementations live in Contract.tsx – keep these in sync.
- */
-
-function getFieldCopyValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean")
-    return String(value);
-  return JSON.stringify(value, null, 2);
-}
-
-function isStructResult(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import {getFieldCopyValue, isStructResult} from "./contractResultUtils";
 
 describe("getFieldCopyValue", () => {
   it("returns raw string without JSON escaping for string values", () => {
@@ -50,8 +32,16 @@ describe("getFieldCopyValue", () => {
     expect(getFieldCopyValue(arr)).toBe(JSON.stringify(arr, null, 2));
   });
 
-  it("returns JSON for null", () => {
-    expect(getFieldCopyValue(null)).toBe("null");
+  it("returns empty string for null", () => {
+    expect(getFieldCopyValue(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(getFieldCopyValue(undefined)).toBe("");
+  });
+
+  it("returns string representation for bigint", () => {
+    expect(getFieldCopyValue(BigInt(123))).toBe("123");
   });
 
   it("preserves quotes inside strings without adding backslashes", () => {
@@ -61,6 +51,14 @@ describe("getFieldCopyValue", () => {
     expect(result).not.toContain("\\");
     expect(result).toContain('"USDC"');
     expect(result).toContain('"APT"');
+  });
+
+  it("handles non-serialisable values gracefully", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const result = getFieldCopyValue(circular);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
   });
 });
 

--- a/app/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/app/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -60,6 +60,7 @@ import SidebarItem from "../../Components/SidebarItem";
 import ErrorPage from "../../Error";
 import {useLogEventWithBasic} from "../../hooks/useLogEventWithBasic";
 import {accountPagePath} from "../../Index";
+import {getFieldCopyValue, isStructResult} from "./contractResultUtils";
 import {useModulesPathParams} from "./Tabs";
 
 /**
@@ -962,17 +963,6 @@ function RunContractForm({
 
 const TOOLTIP_TIME = 2000;
 
-function getFieldCopyValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean")
-    return String(value);
-  return JSON.stringify(value, null, 2);
-}
-
-function isStructResult(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function FieldCopyButton({value}: {value: unknown}) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
@@ -1005,6 +995,7 @@ function FieldCopyButton({value}: {value: unknown}) {
           opacity: 0,
           transition: "opacity 0.15s",
           p: 0.25,
+          "&:focus-visible": {opacity: 1},
         }}
       >
         <ContentCopy sx={{fontSize: 14}} />
@@ -1029,7 +1020,10 @@ function StructFieldRow({fieldKey, value}: {fieldKey: string; value: unknown}) {
         px: 1,
         borderRadius: 0.5,
         "&:hover": {bgcolor: "action.hover"},
-        "&:hover .field-copy-btn": {opacity: 1},
+        "&:hover .field-copy-btn, &:focus-within .field-copy-btn": {opacity: 1},
+        "@media (pointer: coarse)": {
+          "& .field-copy-btn": {opacity: 0.7},
+        },
       }}
     >
       <Typography

--- a/app/pages/Account/Tabs/ModulesTab/contractResultUtils.ts
+++ b/app/pages/Account/Tabs/ModulesTab/contractResultUtils.ts
@@ -1,0 +1,41 @@
+/**
+ * Returns a clipboard-ready string for a struct field value.
+ *
+ * Strings are returned raw (no JSON escaping), primitives are stringified,
+ * and objects/arrays are pretty-printed as JSON. Handles edge cases like
+ * undefined, null, bigint, symbols, and non-serialisable values gracefully.
+ */
+export function getFieldCopyValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+
+  try {
+    const json = JSON.stringify(value, null, 2);
+    return json !== undefined ? json : String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Type guard: returns true when value is a plain object (struct), false for
+ * arrays, primitives, and null.
+ */
+export function isStructResult(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Add a "Copy Field" button next to each field in struct view function responses. When a response contains objects (structs), each field is displayed as an individual row with a hover-visible copy icon. Clicking it copies the **raw unescaped string value** to the clipboard — without JSON escape sequences (e.g., backslashes before quotes).

This solves the pain point where fields like:
```json
"name": "ICHI vault #\"USDC\"-\"APT\"-\"X20\"-\"@0x6e24...\""
```
can now be copied as:
```
ICHI vault #"USDC"-"APT"-"X20"-"@0x6e24..."
```
ready to paste directly as input for other function calls.

**Changes:**
- `contractResultUtils.ts` — Extracted `getFieldCopyValue` and `isStructResult` helpers into a dedicated module. `getFieldCopyValue` handles null, undefined, bigint, symbols, and circular references gracefully with try/catch fallback.
- `Contract.tsx` — Added `FieldCopyButton`, `StructFieldRow`, and `StructResultDisplay` components for per-field copy UX. Copy buttons appear on hover, focus-within (keyboard navigation), and are always visible on touch (coarse pointer) devices. Updated "Copy all" tooltip to show on hover.
- `Contract.test.ts` — 21 unit tests importing the production helpers, covering the exact scenario from the feature request plus edge cases (null, undefined, bigint, circular references).

**For simple (non-struct) results**, the display behavior is unchanged — values render in a monospace pre block with the existing copy-all button.

### Related Links

Feature request from PR discussion

### Checklist

- [x] TypeScript type-checking passes (`tsc --noEmit`)
- [x] Biome lint and formatting pass (`pnpm fmt && pnpm lint`)
- [x] All 218 tests pass (`pnpm test --run`)
- [x] Unit tests added for new helper functions
- [x] Accessibility: focus-visible/focus-within and coarse pointer support
- [x] No routes/tabs added or removed (no llms.txt/sitemap changes needed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b6fba6-cf3c-41a5-ac7d-4f4eea1816aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b6fba6-cf3c-41a5-ac7d-4f4eea1816aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

