### PR TITLE
feat(txn-events): human-readable FeeStatement table on Events tab

### DIFF
--- a/app/pages/Transaction/Tabs/Components/FeeStatementEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/FeeStatementEventView.tsx
@@ -37,7 +37,12 @@ function isFeeStatementShape(data: unknown): data is Record<string, unknown> {
     return false;
   }
   const record = data as Record<string, unknown>;
-  return KNOWN_FIELD_ORDER.some((k) => k in record && isUIntString(record[k]));
+  if (!isUIntString(record.total_charge_gas_units)) {
+    return false;
+  }
+  return KNOWN_FIELD_ORDER.every(
+    (key) => !(key in record) || isUIntString(record[key]),
+  );
 }
 
 function gasUnitsToOctas(gasUnits: string, gasUnitPrice: string): string {

--- a/app/pages/Transaction/Tabs/EventsTab.tsx
+++ b/app/pages/Transaction/Tabs/EventsTab.tsx
@@ -56,10 +56,12 @@ export default function EventsTab({transaction}: EventsTabProps) {
           !Array.isArray(event.data)
             ? (event.data as Record<string, unknown>)
             : null;
-        const feeStatementTable =
+        const feeStatementData =
           event.type === FEE_STATEMENT_EVENT_TYPE &&
           eventDataObject !== null &&
-          shouldRenderFeeStatementTable(eventDataObject);
+          shouldRenderFeeStatementTable(eventDataObject)
+            ? eventDataObject
+            : null;
 
         return (
           <CollapsibleCard
@@ -97,9 +99,9 @@ export default function EventsTab({transaction}: EventsTabProps) {
             <ContentRow
               title="Data:"
               value={
-                feeStatementTable && eventDataObject ? (
+                feeStatementData ? (
                   <FeeStatementEventView
-                    data={eventDataObject}
+                    data={feeStatementData}
                     gasUnitPrice={gasUnitPrice}
                   />
                 ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

On the transaction **Events** tab, `0x1::transaction_fee::FeeStatement` module events were shown as raw JSON. This change renders them as a small outlined table with plain-language row labels, gas units (using existing `GasValue` formatting), APT and octas for storage lines, and optional APT equivalents for gas rows when `gas_unit_price` is present on the transaction. Short captions explain storage refund vs. `gas_used` and what total gas charged represents. Any unexpected extra fields on the event payload are still shown as additional rows. If the data does not look like a fee statement, the UI falls back to `JsonViewCard` as before.

**Follow-up (review):** Fee statement detection now requires a valid `total_charge_gas_units` and rejects malformed values on any other known field that is present. Events tab uses a single `feeStatementData | null` binding so the render branch stays simple and type-safe.

### Related Links

Example transaction (mainnet): https://explorer.aptoslabs.com/txn/4643509767/events?network=mainnet

### Checklist

- [x] `pnpm fmt` / `pnpm lint`
- [x] `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940b8562-45b2-4150-b3c1-122e29f4b69f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940b8562-45b2-4150-b3c1-122e29f4b69f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

