### PR TITLE
feat(transaction): show Move argument names in transaction summary

### DIFF
--- a/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
+++ b/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
@@ -168,14 +168,23 @@ export default function TransactionArguments({
       return {functionArgNames: null, typeArgNames: typeNames};
     }
 
-    const hasSigner =
-      moveFunction.params.length !==
-      moveFunction.params.filter((p) => p !== "signer" && p !== "&signer")
-        .length;
-    const adjusted =
-      rawParamNames && (hasSigner ? rawParamNames.slice(1) : rawParamNames);
-    const fnArgNames =
-      adjusted && adjusted.length === filteredParams.length ? adjusted : null;
+    // Map source names to serialized args by ABI position: drop every signer
+    // slot (not only a single leading signer).
+    let fnArgNames: string[] | null = null;
+    if (rawParamNames && rawParamNames.length === moveFunction.params.length) {
+      const nonSignerIndices = moveFunction.params.reduce<number[]>(
+        (indices, param, index) => {
+          if (param !== "signer" && param !== "&signer") {
+            indices.push(index);
+          }
+          return indices;
+        },
+        [],
+      );
+      if (nonSignerIndices.length === filteredParams.length) {
+        fnArgNames = nonSignerIndices.map((idx) => rawParamNames[idx]);
+      }
+    }
 
     return {functionArgNames: fnArgNames, typeArgNames: typeNames};
   }, [payload, moduleSource, functionName, moveFunction, filteredParams]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The transaction overview **Arguments** section (`TransactionArguments`) now shows **type and value parameter names** when on-chain package source is available, using the same `extractFunctionParamNames` / `extractFunctionTypeParamNames` + `transformCode` path as the account **Run** tab. Names are aligned with serialized arguments by mapping **non-signer ABI parameter indices** to source names (so multiple or non-leading `signer` / `&signer` params stay aligned). Module bytecode and `PackageRegistry` are fetched at the transaction's **ledger version**.

When source is missing, ABI/param counts do not match, or parsing does not line up, the UI falls back to `T0` / `#0` style labels.

### Related Links

N/A

### Checklist

- [x] `pnpm fmt` / `pnpm lint` / `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d3d7619-95c2-4e80-9c28-7bb2bc79fb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d3d7619-95c2-4e80-9c28-7bb2bc79fb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

