### PR TITLE
docs(agents): routing, navigation, and AI quality bar in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The app is a **TanStack Start** (SSR-capable) SPA built with **Vite**, **TanStac
 
 ### From filename to URL
 
-- **Dot segments** become path segments: e.g. `account.$address.$tab.tsx` → `/account/:address/:tab`.
+- **Dot segments** become path segments: e.g. `account.$address.$tab.tsx` → `/account/$address/$tab`.
 - **Index**: `app/routes/index.tsx` is the home route.
 - **Layout routes** use a path prefix and render an `<Outlet />` for child routes. Some parent routes use `beforeLoad` to **redirect** legacy or shorthand URLs to the canonical path (for example, `?tab=` query params → `/$tab` in the path, or default tab when the path is “incomplete”).
 - **Root layout**: `app/routes/__root.tsx` registers global `head` metadata, error and not-found UI, and wraps the app with providers (React Query, MUI theme, wallet, GraphQL client, settings). It renders `Header`, `Footer`, and `<Outlet />` for page content. **Backward-compatibility redirects** for old hostnames and hash-based tab URLs run here via `useOldUrlRedirect` and `useHashToPathRedirect`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands `AGENTS.md` so automated contributors have a single place to learn how URLs, tabs, loaders, and network preservation work, and what quality bar to meet before shipping changes.

## Changes

- **Routing and navigation**: TanStack Router file-based routes, `tsr` codegen and `app/routeTree.gen.ts`, path vs layout routes, root layout and backward-compat redirects, `?network=` and why to use `Link` / `useNavigate` from `app/routing.tsx`, thin route files vs `app/pages/`, loaders and React Query, pending UI, and LLM/SEO alignment when routes change.
- **Quality expectations for AI-generated changes**: Read-before-write, scope discipline, fmt/lint/test and route generation, UX for loading/errors, a11y and security basics, test mocking, documentation drift, and **when to update `CHANGELOG.md` [Unreleased]**.
- **Commit / review**: “Before committing” and Reviewer checklist now call out **CHANGELOG** for user-visible or release-note-worthy PRs.
- **Coder callout**: Blockquote next to the LLM route checklist reinforcing **CHANGELOG** updates.

`CLAUDE.md` (symlink) stays in sync automatically.

## Verification

- `pnpm fmt && pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51d6ac2-7ecc-467e-9e90-e8b38fdfcb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51d6ac2-7ecc-467e-9e90-e8b38fdfcb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

