### PR TITLE
fix(ui): code modal backdrop + download current code as file

### DIFF
--- a/app/pages/Account/Components/CodeSnippet.tsx
+++ b/app/pages/Account/Components/CodeSnippet.tsx
@@ -339,7 +339,7 @@ export function Code({
   }
 
   function downloadCode() {
-    if (!displayedCode || typeof document === "undefined") {
+    if (!displayedCode) {
       return;
     }
     downloadTextFile(

--- a/app/pages/Account/Components/MovePackageManifest.tsx
+++ b/app/pages/Account/Components/MovePackageManifest.tsx
@@ -152,7 +152,7 @@ export function MovePackageManifest({manifest}: {manifest: string}) {
   }
 
   function downloadManifest() {
-    if (!sourceCode || typeof document === "undefined") {
+    if (!sourceCode) {
       return;
     }
     downloadTextFile(sourceCode, "Move.toml", "text/plain;charset=utf-8");

--- a/app/pages/Transaction/Tabs/Components/ScriptBytecodeDecompiler.tsx
+++ b/app/pages/Transaction/Tabs/Components/ScriptBytecodeDecompiler.tsx
@@ -228,7 +228,7 @@ export default function ScriptBytecodeDecompiler({
   }
 
   function downloadScriptCode() {
-    if (!displayedCode || typeof document === "undefined") {
+    if (!displayedCode) {
       return;
     }
     const filename =

--- a/app/utils/utils.test.ts
+++ b/app/utils/utils.test.ts
@@ -1,5 +1,6 @@
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import {
+  downloadTextFile,
   ensureBigInt,
   ensureBoolean,
   ensureMillisecondTimestamp,
@@ -14,6 +15,7 @@ import {
   isValidStruct,
   isValidUrl,
   octaToApt,
+  sanitizeDownloadFilename,
   standardizeAddress,
   timestampDisplay,
   toIpfsDisplayUrl,
@@ -21,7 +23,6 @@ import {
   truncateAddress,
   truncateAddressMiddle,
   tryStandardizeAddress,
-  sanitizeDownloadFilename,
 } from "./utils";
 
 describe("Address utilities", () => {
@@ -389,6 +390,87 @@ describe("sanitizeDownloadFilename", () => {
 
   it("falls back when empty after trim", () => {
     expect(sanitizeDownloadFilename("   ")).toBe("download");
+  });
+
+  it("strips trailing dots for cross-platform filenames", () => {
+    expect(sanitizeDownloadFilename("mod.")).toBe("mod");
+    expect(sanitizeDownloadFilename("a...")).toBe("a");
+    expect(sanitizeDownloadFilename("...")).toBe("download");
+  });
+});
+
+describe("downloadTextFile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("no-ops without document (SSR / Node)", () => {
+    const createUrl = vi.spyOn(URL, "createObjectURL");
+    const revokeUrl = vi.spyOn(URL, "revokeObjectURL");
+    vi.stubGlobal("document", undefined);
+
+    downloadTextFile("body", "file.txt");
+
+    expect(createUrl).not.toHaveBeenCalled();
+    expect(revokeUrl).not.toHaveBeenCalled();
+  });
+
+  it("creates a blob URL, triggers download, and revokes the URL", async () => {
+    const objectUrl = "blob:mock-url";
+    vi.spyOn(URL, "createObjectURL").mockReturnValue(objectUrl);
+    const revokeUrl = vi.spyOn(URL, "revokeObjectURL");
+
+    const click = vi.fn();
+    const appendChild = vi.fn();
+    const removeChild = vi.fn();
+    const link = {
+      setAttribute: vi.fn(),
+      style: {visibility: ""},
+      click,
+    };
+
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => link),
+      body: {appendChild, removeChild},
+    });
+
+    downloadTextFile("hello", "out.txt", "text/plain");
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    const blobArg = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    expect(blobArg).toBeInstanceOf(Blob);
+    expect(await blobArg.text()).toBe("hello");
+
+    expect(link.setAttribute).toHaveBeenCalledWith("href", objectUrl);
+    expect(link.setAttribute).toHaveBeenCalledWith("download", "out.txt");
+    expect(appendChild).toHaveBeenCalledWith(link);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(removeChild).toHaveBeenCalledWith(link);
+    expect(revokeUrl).toHaveBeenCalledWith(objectUrl);
+  });
+
+  it("applies sanitizeDownloadFilename to the download attribute", () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
+    vi.spyOn(URL, "revokeObjectURL");
+
+    const link = {
+      setAttribute: vi.fn(),
+      style: {},
+      click: vi.fn(),
+    };
+
+    vi.stubGlobal("document", {
+      createElement: () => link,
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+    });
+
+    downloadTextFile("x", "bad:name?.txt");
+
+    expect(link.setAttribute).toHaveBeenCalledWith("download", "bad_name_.txt");
   });
 });
 

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -948,17 +948,18 @@ const DOWNLOAD_FILENAME_FORBIDDEN = new Set('<>:"/\\|?*');
 
 /** Strips characters that are invalid or risky in common download filenames. */
 export function sanitizeDownloadFilename(name: string): string {
-  let out = "";
+  const chars: string[] = [];
   for (const ch of name) {
     const code = ch.codePointAt(0) ?? 0;
     if (code < 32 || DOWNLOAD_FILENAME_FORBIDDEN.has(ch)) {
-      out += "_";
+      chars.push("_");
     } else {
-      out += ch;
+      chars.push(ch);
     }
   }
-  const cleaned = out.trim();
-  return cleaned.length > 0 ? cleaned : "download";
+  const cleaned = chars.join("").trim();
+  const withoutTrailingDots = cleaned.replace(/\.+$/, "");
+  return withoutTrailingDots.length > 0 ? withoutTrailingDots : "download";
 }
 
 export function downloadTextFile(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Modal backdrop**: Fullscreen code modals use a high-opacity dimmed backdrop with blur; modal content uses the same solid code-block background as the inline view.
- **Download**: A **download** control (next to copy / expand) saves the **current** code as a file, with filenames that reflect the active view.

## Download behavior

| Surface | Filename(s) |
| --------|------------- |
| Modules → Code (published) | `{module}.move` |
| Modules → Code (decompiled) | `{module}-decompiled.move` |
| Modules → Code (disassembly) | `{module}-disassembly.txt` |
| Package manifest | `Move.toml` |
| Transaction script bytecode | `script-decompiled.move` or `script-disassembly.txt` |

Module names are sanitized for unsafe path characters.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6043c8d2-31cc-4dad-88a3-4b33a6032f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6043c8d2-31cc-4dad-88a3-4b33a6032f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

