### PR TITLE
feat(modules): ABI as selectable view on module code tab

### DIFF
--- a/app/pages/Account/Components/CodeSnippet.tsx
+++ b/app/pages/Account/Components/CodeSnippet.tsx
@@ -14,9 +14,11 @@ import {
   SyntaxHighlighter,
   useHighlighterStyles,
 } from "../../../components/CodeHighlighter";
+import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
 import StyledTooltip, {
   StyledLearnMoreTooltip,
 } from "../../../components/StyledTooltip";
+import type {Types} from "~/types/aptos";
 import {
   type DecompilationView,
   getDecompiledCodeView,
@@ -39,7 +41,8 @@ function useStartingLineNumber(sourceCode?: string) {
 type CodeView =
   | "published-source"
   | "decompiled-source"
-  | "bytecode-disassembly";
+  | "bytecode-disassembly"
+  | "abi";
 
 type BytecodeViewState = {
   bytecodeKey: string;
@@ -137,12 +140,21 @@ function ExpandCode({
   );
 }
 
+export type CodeModuleQueryProps = {
+  address: string;
+  data: Types.MoveModuleBytecode | undefined;
+  isLoading: boolean;
+  isSuccess: boolean;
+};
+
 export function Code({
   sourceBytecode,
   moduleBytecode,
+  moduleQuery,
 }: {
   sourceBytecode?: string;
   moduleBytecode?: string;
+  moduleQuery?: CodeModuleQueryProps;
 }) {
   const {selectedModuleName} = useModulesPathParams();
   const logEvent = useLogEventWithBasic();
@@ -178,6 +190,14 @@ export function Code({
   }, [hasPublishedSourceCode, hasModuleBytecode]);
 
   useEffect(() => {
+    if (activeView === "abi" && !moduleQuery) {
+      setActiveView(
+        hasPublishedSourceCode ? "published-source" : "decompiled-source",
+      );
+    }
+  }, [activeView, moduleQuery, hasPublishedSourceCode]);
+
+  useEffect(() => {
     const missingActiveViewCode =
       activeView === "decompiled-source"
         ? !decompiledSource ||
@@ -191,6 +211,7 @@ export function Code({
       !hasModuleBytecode ||
       !moduleBytecodeKey ||
       activeView === "published-source" ||
+      activeView === "abi" ||
       !missingActiveViewCode
     ) {
       return;
@@ -391,6 +412,15 @@ export function Code({
             </Button>
           </>
         )}
+        {moduleQuery && (
+          <Button
+            size="small"
+            variant={activeView === "abi" ? "contained" : "outlined"}
+            onClick={() => setActiveView("abi")}
+          >
+            ABI
+          </Button>
+        )}
       </Stack>
       {activeView === "published-source" && displayedCode && (
         <Typography
@@ -404,7 +434,22 @@ export function Code({
           different from the actual bytecode.
         </Typography>
       )}
-      {activeView !== "published-source" && (
+      {activeView !== "published-source" &&
+        activeView !== "abi" &&
+        (activeView === "decompiled-source" ||
+          activeView === "bytecode-disassembly") && (
+          <Typography
+            variant="body1"
+            fontSize={14}
+            fontWeight={400}
+            marginBottom={"16px"}
+            color={theme.palette.text.secondary}
+          >
+            This view is generated from on-chain bytecode using the Move
+            decompiler WASM.
+          </Typography>
+        )}
+      {activeView === "abi" && moduleQuery && (
         <Typography
           variant="body1"
           fontSize={14}
@@ -412,11 +457,21 @@ export function Code({
           marginBottom={"16px"}
           color={theme.palette.text.secondary}
         >
-          This view is generated from on-chain bytecode using the Move
-          decompiler WASM.
+          Module ABI metadata returned by the node for this on-chain module.
         </Typography>
       )}
-      {!hasPublishedSourceCode && !hasModuleBytecode ? (
+      {activeView === "abi" && moduleQuery ? (
+        moduleQuery.isSuccess ? (
+          <JsonViewCard data={moduleQuery.data?.abi} />
+        ) : (
+          <Stack direction="row" spacing={1.5} alignItems="center" py={2}>
+            <CircularProgress size={18} />
+            <Typography variant="body2" color="text.secondary">
+              Loading module ABI...
+            </Typography>
+          </Stack>
+        )
+      ) : !hasPublishedSourceCode && !hasModuleBytecode ? (
         <Box>
           This module does not expose published source or bytecode for
           decompilation.

--- a/app/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/app/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -16,12 +16,12 @@ import {
   useGetAccountPackages,
 } from "../../../../api/hooks/useGetAccountResource";
 import EmptyTabContent from "../../../../components/IndividualPageContent/EmptyTabContent";
-import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import {useNavigate} from "../../../../routing";
 import {getBytecodeSizeInKB} from "../../../../utils";
 import {Code} from "../../Components/CodeSnippet";
 import SidebarItem from "../../Components/SidebarItem";
 import AccountError from "../../Error";
+import type {Types} from "~/types/aptos";
 import {accountPagePath} from "../../Index";
 import {useModulesPathParams} from "./Tabs";
 
@@ -202,11 +202,12 @@ function ModuleContent({
   ledgerVersion,
 }: ModuleContentProps) {
   const theme = useTheme();
-  const {data: moduleBytecodeResponse} = useGetAccountModule(
-    address,
-    moduleName,
-    ledgerVersion,
-  );
+  const {
+    data: moduleData,
+    isLoading: isModuleLoading,
+    isSuccess: isModuleSuccess,
+    error: moduleError,
+  } = useGetAccountModule(address, moduleName, ledgerVersion);
   return (
     <Stack
       direction="column"
@@ -215,41 +216,34 @@ function ModuleContent({
       bgcolor={theme.palette.background.paper}
       borderRadius={1}
     >
-      <ModuleHeader
-        address={address}
-        moduleName={moduleName}
-        ledgerVersion={ledgerVersion}
-      />
+      <ModuleHeader module={moduleData} moduleName={moduleName} />
       <Divider />
+      {moduleError && <AccountError address={address} error={moduleError} />}
       <Code
         sourceBytecode={sourceBytecode}
-        moduleBytecode={moduleBytecodeResponse?.bytecode}
-      />
-      <Divider />
-      <ABI
-        address={address}
-        moduleName={moduleName}
-        ledgerVersion={ledgerVersion}
+        moduleBytecode={moduleData?.bytecode}
+        moduleQuery={
+          moduleError
+            ? undefined
+            : {
+                address,
+                data: moduleData,
+                isLoading: isModuleLoading,
+                isSuccess: isModuleSuccess,
+              }
+        }
       />
     </Stack>
   );
 }
 
 function ModuleHeader({
-  address,
+  module,
   moduleName,
-  ledgerVersion,
 }: {
-  address: string;
+  module: Types.MoveModuleBytecode | undefined;
   moduleName: string;
-  ledgerVersion?: number;
 }) {
-  const {data: module} = useGetAccountModule(
-    address,
-    moduleName,
-    ledgerVersion,
-  );
-
   return (
     <Box
       display="flex"
@@ -261,51 +255,14 @@ function ModuleHeader({
         {moduleName}
       </Typography>
       <Box>
-        {module && (
+        {module ? (
           <Typography fontSize={10}>
             {module.abi?.exposed_functions?.filter((fn) => fn.is_entry)?.length}{" "}
             entry functions | Bytecode: {getBytecodeSizeInKB(module.bytecode)}{" "}
             KB
           </Typography>
-        )}
+        ) : null}
       </Box>
-    </Box>
-  );
-}
-
-function ABI({
-  address,
-  moduleName,
-  ledgerVersion,
-}: {
-  address: string;
-  moduleName: string;
-  ledgerVersion?: number;
-}) {
-  const {
-    data: module,
-    isLoading,
-    error,
-  } = useGetAccountModule(address, moduleName, ledgerVersion);
-
-  if (isLoading) {
-    return null;
-  }
-
-  if (error) {
-    return <AccountError address={address} error={error} />;
-  }
-
-  if (!module) {
-    return <EmptyTabContent />;
-  }
-
-  return (
-    <Box>
-      <Typography fontSize={20} fontWeight={700} marginY={"16px"}>
-        ABI
-      </Typography>
-      <JsonViewCard data={module.abi} />
     </Box>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The module **Code** tab previously showed decompiled/disassembly (and published source when present) in a chip row, with **ABI** as a separate block below. ABI is now a fourth chip in that same row and uses the same `JsonViewCard` content as before.

`useGetAccountModule` is called once per `ModuleContent` and feeds the header, bytecode props, and ABI view. When the module request fails, `AccountError` is shown above the code panel (matching prior visibility of the standalone ABI error state).

The **Contract** tab still uses `Code` without `moduleQuery`, so it keeps only published/decompiled/disassembly chips.

### Related Links

N/A

### Checklist

- [x] `pnpm fmt` / `pnpm lint` / `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52ad573f-32c3-4469-a334-7ab8233fe6ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52ad573f-32c3-4469-a334-7ab8233fe6ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

