### PR TITLE
fix(account): fix "Cannot convert object to primitive value" crash for Object accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Object account pages (e.g. Decibel perp DEX) crashing with "Cannot convert object to primitive value" — the `/account/` → `/object/` redirect now correctly passes TanStack Router's parsed search params instead of interpolating the search object in a URL template literal
+
 ### Removed
 
 - AIP-141 gas impact UI: account **Gas Impact** tab, gas warnings on account transaction lists, and the user-transaction overview banner; removed `useGetGasScheduleVersion` and related utilities.

--- a/app/pages/Account/Index.tsx
+++ b/app/pages/Account/Index.tsx
@@ -130,7 +130,8 @@ export default function AccountPage({
           "/object/",
         );
         navigate({
-          to: `${objectPath}${location.search}`,
+          to: objectPath,
+          search: location.search,
           replace: true,
         });
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes a crash on all pages for Move Object accounts (accounts with `ObjectCore` but no `Account` resource, e.g. the Decibel perp DEX at `0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06`).

**Root cause:** In `AccountPage`, when an address is detected as an Object, the component redirects from `/account/` to `/object/`. The redirect code interpolated `location.search` (from TanStack Router's `useLocation()`) in a template literal:

```ts
navigate({ to: `${objectPath}${location.search}`, replace: true });
```

In TanStack Router, `location.search` is a **parsed search params object** (e.g. `{network: "mainnet"}`), not a string like `"?network=mainnet"`. When this object has a null prototype (as TanStack Router creates internally), JavaScript cannot coerce it to a string, throwing `"Cannot convert object to primitive value"`.

**Fix:** Pass `search` as a proper object to `navigate()`:

```ts
navigate({ to: objectPath, search: location.search, replace: true });
```

This is the idiomatic TanStack Router approach and the custom `useNavigate` wrapper correctly preserves the `network` param.

### Related Links

- Production URL that crashes: https://explorer.aptoslabs.com/account/0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06/modules/code/public_apis/process_perp_market_pending_requests?network=mainnet

### Checklist

- [x] Lint passes (`pnpm fmt && pnpm lint`)
- [x] Tests pass (`pnpm test --run` — 279 tests, 21 suites)
- [x] Production build succeeds (`pnpm build`)
- [x] Manually tested with the production build (`vite preview`) — confirmed the page loads correctly and redirects to `/object/` URL
- [x] CHANGELOG updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eb6c8d9-e70c-4246-9213-edfd40c9fb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eb6c8d9-e70c-4246-9213-edfd40c9fb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

