### PR TITLE
chore(vite): use tanstackRouter instead of deprecated TanStackRouterVite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import netlify from "@netlify/vite-plugin-tanstack-start";
 import {tanstackStart} from "@tanstack/react-start/plugin/vite";
-import {TanStackRouterVite} from "@tanstack/router-plugin/vite";
+import {tanstackRouter} from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react-swc";
 import {visualizer} from "rollup-plugin-visualizer";
 import {defineConfig, type PluginOption} from "vite";
@@ -9,7 +9,7 @@ import viteSvgr from "vite-plugin-svgr";
 
 export default defineConfig({
   plugins: [
-    TanStackRouterVite({
+    tanstackRouter({
       routesDirectory: "./app/routes",
       generatedRouteTree: "./app/routeTree.gen.ts",
       autoCodeSplitting: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Replaces the deprecated `TanStackRouterVite` export from `@tanstack/router-plugin/vite` with `tanstackRouter`, which is the current API (the deprecated symbol is an alias to the same implementation).

### Related Links

TanStack Router plugin: `@tanstack/router-plugin` documents `tanstackRouter` as the supported Vite plugin entry point.

### Checklist

- [x] `pnpm fmt` and `pnpm lint` pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7107cac-d279-4f86-a1a1-7de3cf4187a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7107cac-d279-4f86-a1a1-7de3cf4187a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

