### PR TITLE
feat(theme): traditional light mode palette (neutral canvas, white cards)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Light theme**: neutral grey app background (`#ECEEF2`), white cards/panels, cooler borders, and soft grey stripes for tables and filled inputs instead of warm cream-on-bright-off-white; primary body text uses ink (`#171612`) for slightly softer contrast than pure black. Light `theme-color` meta updated to match the canvas.
+
 ### Fixed
 
 - Object account pages (e.g. Decibel perp DEX) crashing with "Cannot convert object to primitive value" — the `/account/` → `/object/` redirect now correctly passes TanStack Router's parsed search params instead of interpolating the search object in a URL template literal

--- a/app/components/HashButton.tsx
+++ b/app/components/HashButton.tsx
@@ -247,8 +247,7 @@ const HashButtonInner = memo(function HashButtonInner({
       <Button
         sx={{
           textTransform: "none",
-          // Light: paper rows use creme (`background.paper`); chips must not use
-          // `neutralShade.darker` (also creme) or the pill is invisible.
+          // Light: paper rows are white; chips use canvas grey so the pill reads on the row.
           backgroundColor:
             theme.palette.mode === "dark"
               ? theme.palette.neutralShade.lighter

--- a/app/themes/colors/aptosBrandColors.ts
+++ b/app/themes/colors/aptosBrandColors.ts
@@ -21,8 +21,29 @@ export const brandColors = {
 } as const;
 
 /**
- * WCAG 2.1 AA text contrast (≥4.5:1) on {@link brandColors.white} and
- * {@link brandColors.creme} (light) or {@link brandColors.black} / {@link brandColors.ink}
+ * Light-mode surfaces: neutral grey canvas with white cards (traditional app chrome),
+ * instead of bright cream-on-bright-warm-white. Keeps brand accents via semantic tokens.
+ */
+export const lightSurfaces = {
+  /** Page / app background */
+  canvas: "#ECEEF2",
+  /** Cards, panels, modals */
+  raised: "#FFFFFF",
+  /** Filled inputs at rest (subtle vs. {@link lightSurfaces.raised}) */
+  field: "#F3F5F7",
+  /** Filled inputs on hover */
+  fieldHover: "#E8EBEF",
+} as const;
+
+const lightBorders = {
+  /** Dividers and outlines on neutral surfaces */
+  main: "#C5CAD4",
+  subtle: "#D9DDE5",
+} as const;
+
+/**
+ * WCAG 2.1 AA text contrast (≥4.5:1) on light surfaces ({@link lightSurfaces.canvas},
+ * {@link lightSurfaces.raised}) or {@link brandColors.black} / {@link brandColors.ink}
  * (dark). Pure brand mint/babyBlue/coral are kept above for fills and dark mode;
  * these tokens tune foreground / light-mode UI hues for readability.
  */
@@ -32,7 +53,7 @@ const a11y = {
     interactiveBlue: "#34648F",
     interactiveBlueHover: "#2E5C85",
     /** Success / secondary text & filled buttons — was #7BC47F (~2:1 as text) */
-    successGreen: "#2F7D38",
+    successGreen: "#256B2E",
     /** Error text on light bg — brand coral stays for fills / dark mode */
     errorText: "#B84722",
     /** Warning text (distinct from error on light surfaces) */
@@ -42,7 +63,7 @@ const a11y = {
     /** JSON keys on creme paper */
     jsonKey: "#A84318",
     /** Null / brackets in JSON on tinted code panels */
-    codeMutedBlue: "#4F6F88",
+    codeMutedBlue: "#45647A",
   },
   dark: {
     /** Disabled on near-black / ink — was graphite (~1.4:1) */
@@ -64,22 +85,22 @@ export const getSemanticColors = (mode: PaletteMode) => {
 
     // Background colors
     background: {
-      default: isDark ? brandColors.black : brandColors.white,
-      paper: isDark ? brandColors.ink : brandColors.creme,
-      elevated: isDark ? brandColors.coal : brandColors.white,
+      default: isDark ? brandColors.black : lightSurfaces.canvas,
+      paper: isDark ? brandColors.ink : lightSurfaces.raised,
+      elevated: isDark ? brandColors.coal : lightSurfaces.raised,
     },
 
     // Text colors
     text: {
-      primary: isDark ? brandColors.white : brandColors.black,
+      primary: isDark ? brandColors.white : brandColors.ink,
       secondary: isDark ? brandColors.creme : brandColors.graphite,
       disabled: isDark ? a11y.dark.disabledText : a11y.light.disabledText,
     },
 
     // Border and line colors
     border: {
-      main: isDark ? brandColors.coal : brandColors.tan, // Use tan instead of sand for better visibility
-      light: isDark ? brandColors.graphite : brandColors.tan,
+      main: isDark ? brandColors.coal : lightBorders.main,
+      light: isDark ? brandColors.graphite : lightBorders.subtle,
       dark: isDark ? brandColors.ink : brandColors.graphite,
     },
 

--- a/app/themes/theme.ts
+++ b/app/themes/theme.ts
@@ -1,7 +1,11 @@
 import {alpha, type PaletteMode} from "@mui/material";
 import type {ThemeOptions} from "@mui/material/styles";
 import type React from "react";
-import {brandColors, getSemanticColors} from "./colors/aptosBrandColors";
+import {
+  brandColors,
+  getSemanticColors,
+  lightSurfaces,
+} from "./colors/aptosBrandColors";
 import {fontFamilyMono, fontFamilySans, fontFamilySerif} from "./typography";
 
 // Button variants
@@ -172,9 +176,9 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => {
             },
 
             neutralShade: {
-              main: brandColors.white,
-              lighter: brandColors.white,
-              darker: brandColors.creme,
+              main: lightSurfaces.fieldHover,
+              lighter: lightSurfaces.raised,
+              darker: lightSurfaces.field,
             },
           }
         : {

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     />
     <meta
       name="theme-color"
-      content="#F9F9F0"
+      content="#ECEEF2"
       media="(prefers-color-scheme: light)"
     />
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Light mode was easy to read but visually harsh: warm cream panels on a bright off-white page felt like “bright on bright.” This update moves to a more traditional app pattern: a soft neutral **canvas** behind **white** cards and panels, with cooler grey **borders** and **table/input** stripes.

## Changes

- **`app/themes/colors/aptosBrandColors.ts`**: Introduce `lightSurfaces` / `lightBorders`; map semantic `background.*` and `border.*` for light mode; export `lightSurfaces` for the MUI theme. Slightly darken light-mode `successGreen` and `codeMutedBlue` so WCAG 2.1 AA text contrast still passes on the grey default background (see `aptosBrandColors.a11y.test.ts`).
- **`app/themes/theme.ts`**: Light `neutralShade` uses field greys instead of white/creme so filled inputs and chrome don’t flash brighter on hover.
- **`index.html`**: Light `theme-color` matches the canvas (`#ECEEF2`).
- **`HashButton.tsx`**: Comment only (paper is no longer cream).
- **`CHANGELOG.md`**: Unreleased entry.

## Verification

- `pnpm fmt && pnpm lint`
- `pnpm test --run` (279 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ce193cb-6463-4354-9dfe-34af4fc82be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ce193cb-6463-4354-9dfe-34af4fc82be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

