### PR TITLE
fix(txn): DCBL-3137 function arguments table alignment and Arguments row layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Light theme**: neutral grey app background (`#ECEEF2`), white cards/panels, cooler borders, and soft grey stripes for tables and filled inputs instead of warm cream-on-bright-off-white; primary body text uses ink (`#171612`) for slightly softer contrast than pure black. Light `theme-color` meta updated to match the canvas.
-||||||| parent of 766c6302 (feat(data): add function argument name overrides with Decibel stubs)
 
 ### Added
 - Registry for optional Move **function argument display names** (`app/data/functionArgumentNameOverrides/`), used in transaction payload arguments and the account Run / View contract tab; Decibel mainnet public entry/view functions ship with positional stubs (`arg0`, …) ready to replace with real labels
 
 ### Fixed
 
+- Transaction overview **Arguments** table: column widths follow content again (no fixed 100px/140px layout), so long argument names no longer overlap type chips; type badges stay on one line where possible; the **Arguments:** label row uses a compact title column so the table has more horizontal room
 - Object account pages (e.g. Decibel perp DEX) crashing with "Cannot convert object to primitive value" — the `/account/` → `/object/` redirect now correctly passes TanStack Router's parsed search params instead of interpolating the search object in a URL template literal
 
 ### Removed

--- a/app/components/IndividualPageContent/ContentRow.tsx
+++ b/app/components/IndividualPageContent/ContentRow.tsx
@@ -8,6 +8,12 @@ type ContentRowProps = {
   value: React.ReactNode;
   tooltip?: React.ReactNode;
   i?: string | number;
+  /**
+   * `fit`: on sm+ screens the title column sizes to its content so the value
+   * column gets the rest (better for wide tables like transaction arguments).
+   * Default keeps the historical 3/12 · 9/12 split.
+   */
+  titleLayout?: "grid" | "fit";
 };
 
 // Extracted static styles to avoid recreation on every render
@@ -37,8 +43,17 @@ const ContentRow = memo(function ContentRow({
   value,
   tooltip,
   i,
+  titleLayout = "grid",
 }: ContentRowProps) {
   const theme = useTheme();
+  const titleSize =
+    titleLayout === "fit"
+      ? ({xs: 12, sm: "auto"} as const)
+      : ({xs: 12, sm: 3} as const);
+  const valueSize =
+    titleLayout === "fit"
+      ? ({xs: 12, sm: "grow"} as const)
+      : ({xs: 12, sm: 9} as const);
   return (
     <Box>
       <Grid
@@ -48,7 +63,11 @@ const ContentRow = memo(function ContentRow({
         alignItems="start"
         key={i}
       >
-        <Grid container size={{xs: 12, sm: 3}}>
+        <Grid
+          container
+          size={titleSize}
+          sx={titleLayout === "fit" ? {flexShrink: 0} : undefined}
+        >
           <Box sx={{fontSize: "0.875rem", color: theme.palette.text.secondary}}>
             {title}
             <Box component="span" sx={tooltipWrapperStyle}>
@@ -57,7 +76,7 @@ const ContentRow = memo(function ContentRow({
             </Box>
           </Box>
         </Grid>
-        <Grid size={{xs: 12, sm: 9}} sx={valueGridStyle}>
+        <Grid size={valueSize} sx={valueGridStyle}>
           {value ? <Box sx={valueBoxStyle}>{value}</Box> : <EmptyValue />}
         </Grid>
       </Grid>

--- a/app/pages/Transaction/Tabs/Components/MoveFunctionParamTypeBadge.tsx
+++ b/app/pages/Transaction/Tabs/Components/MoveFunctionParamTypeBadge.tsx
@@ -22,12 +22,13 @@ export default function MoveFunctionParamTypeBadge({
   const chipSx = {
     fontFamily: "monospace",
     fontSize: variant === "card" ? "0.7rem" : "0.75rem",
-    maxWidth: 240,
+    // Table cells size to content; card layout keeps a max width for narrow viewports.
+    maxWidth: variant === "card" ? 240 : "none",
     height: "auto",
     minHeight: 24,
     "& .MuiChip-label": {
       display: "block",
-      whiteSpace: "normal",
+      whiteSpace: variant === "card" ? "normal" : "nowrap",
       textAlign: "left",
       lineHeight: 1.25,
       py: 0.5,

--- a/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
+++ b/app/pages/Transaction/Tabs/Components/TransactionArguments.tsx
@@ -100,6 +100,7 @@ const cellSx = {
   fontSize: "0.8rem",
   py: 1,
   px: 1.5,
+  verticalAlign: "top",
 } as const;
 
 export default function TransactionArguments({
@@ -307,11 +308,8 @@ export default function TransactionArguments({
                   ))}
                 </Box>
               ) : (
-                <TableContainer sx={{maxWidth: "100%"}}>
-                  <Table
-                    size="small"
-                    sx={{tableLayout: "fixed", width: "100%"}}
-                  >
+                <TableContainer sx={{maxWidth: "100%", overflowX: "auto"}}>
+                  <Table size="small" sx={{tableLayout: "auto", width: "100%"}}>
                     <TableHead>
                       <TableRow>
                         <TableCell
@@ -321,7 +319,8 @@ export default function TransactionArguments({
                             fontSize: "0.75rem",
                             color: theme.palette.text.secondary,
                             borderBottom: `1px solid ${theme.palette.divider}`,
-                            width: showTypeArgNames ? 100 : 40,
+                            whiteSpace: "nowrap",
+                            width: showTypeArgNames ? undefined : "1%",
                           }}
                         >
                           {showTypeArgNames ? "Name" : "#"}
@@ -335,7 +334,7 @@ export default function TransactionArguments({
                                 fontSize: "0.75rem",
                                 color: theme.palette.text.secondary,
                                 borderBottom: `1px solid ${theme.palette.divider}`,
-                                width: 120,
+                                whiteSpace: "nowrap",
                               }}
                             >
                               Constraint
@@ -433,11 +432,8 @@ export default function TransactionArguments({
                   ))}
                 </Box>
               ) : (
-                <TableContainer sx={{maxWidth: "100%"}}>
-                  <Table
-                    size="small"
-                    sx={{tableLayout: "fixed", width: "100%"}}
-                  >
+                <TableContainer sx={{maxWidth: "100%", overflowX: "auto"}}>
+                  <Table size="small" sx={{tableLayout: "auto", width: "100%"}}>
                     <TableHead>
                       <TableRow>
                         <TableCell
@@ -447,7 +443,8 @@ export default function TransactionArguments({
                             fontSize: "0.75rem",
                             color: theme.palette.text.secondary,
                             borderBottom: `1px solid ${theme.palette.divider}`,
-                            width: showFunctionArgNames ? 100 : 40,
+                            whiteSpace: "nowrap",
+                            width: showFunctionArgNames ? undefined : "1%",
                           }}
                         >
                           {showFunctionArgNames ? "Name" : "#"}
@@ -460,7 +457,7 @@ export default function TransactionArguments({
                               fontSize: "0.75rem",
                               color: theme.palette.text.secondary,
                               borderBottom: `1px solid ${theme.palette.divider}`,
-                              width: 140,
+                              whiteSpace: "nowrap",
                             }}
                           >
                             Type

--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -267,6 +267,7 @@ function TransactionArgumentsRow({
   return (
     <ContentRow
       title="Arguments:"
+      titleLayout="fit"
       value={<TransactionArguments transaction={transaction} />}
       tooltip={getLearnMoreTooltip("arguments")}
     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes overlap and awkward wrapping in the transaction **Function Arguments** desktop table after long Decibel-style argument names shipped, and reduces unused horizontal space beside the **Arguments:** label.

## Changes

- **`TransactionArguments`**: Switch desktop type-args and function-args tables from `table-layout: fixed` with 100px/140px columns to `auto` so Name, Type, and Value size from content. Add `overflow-x: auto` on the table container for narrow viewports. Top-align all body/header cells via shared `cellSx`.
- **`MoveFunctionParamTypeBadge`**: In table variants, drop the 240px chip max width and use `nowrap` on the label so types like `vector<address>` stay on one line when the column allows it.
- **`ContentRow`**: Optional `titleLayout="fit"` uses MUI Grid `auto` + `grow` for title/value on sm+ instead of the fixed 3/12 · 9/12 split. **`UserTransactionOverviewTab`** passes this for the Arguments row only.
- **`CHANGELOG`**: Document the fix; removed an accidental merge-marker line under `[Unreleased]`.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run`

Linear: **DCBL-3137**
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DCBL-3137](https://linear.app/aptoslabs/issue/DCBL-3137/fix-alignment-issues-in-explorer-function-arguments)

<div><a href="https://cursor.com/agents/bc-3469b29d-457f-40a9-ac72-62f5e237f9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3469b29d-457f-40a9-ac72-62f5e237f9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

