### PR TITLE
feat(coin/fa): redesign holders with top-100 display + CSV export, remove transactions tab, add account asset filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rate-limit drawer: a bottom sheet appears when any API request receives HTTP 429, informing the user they have been rate-limited and offering a button to open Settings and set an API key override or wait ~5 minutes for the limit to reset
 - **Trace tab failure highlighting**: when a transaction failed, the Trace tab shows an error banner with the VM status and visually highlights the failed call (red background, error chip with the abort reason) along with a dashed-red path from the root to the failing node
+- **Coin/FA holders**: top-100 holders displayed on the Holders tab; "Export All Holders CSV" button paginates through every holder with rate-limit-aware backoff and streams a CSV download
+- **Account asset filter**: new `?asset=` search-param filter on account transactions tab shows only deposit/withdrawal/mint/burn activity for a specific coin type or fungible asset address
 
 ### Improved
 
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - AIP-141 gas impact UI: account **Gas Impact** tab, gas warnings on account transaction lists, and the user-transaction overview banner; removed `useGetGasScheduleVersion` and related utilities.
+- **Coin/FA transactions tab**: removed the "Beta - Transactions" tab from coin and fungible asset detail pages; per-account coin activity is now accessible via the asset filter on the account transactions tab. Old `/coin/{type}/transactions` and `/fungible_asset/{address}/transactions` URLs redirect to the info tab.
 
 ## [1.1.0] - 2026-03-23
 

--- a/app/api/hooks/useAssetFilter.ts
+++ b/app/api/hooks/useAssetFilter.ts
@@ -1,0 +1,25 @@
+import {useCallback} from "react";
+import {useSearchParams} from "../../routing";
+
+export default function useAssetFilter(): {
+  assetFilter: string;
+  handleAssetFilterChange: (value: string) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const assetFilter = searchParams.get("asset") ?? "";
+
+  const handleAssetFilterChange = useCallback(
+    (value: string) => {
+      if (value) {
+        searchParams.set("asset", value);
+      } else {
+        searchParams.delete("asset");
+      }
+      searchParams.delete("page");
+      setSearchParams(searchParams);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return {assetFilter, handleAssetFilterChange};
+}

--- a/app/api/hooks/useGetAccountCoinActivities.ts
+++ b/app/api/hooks/useGetAccountCoinActivities.ts
@@ -1,0 +1,115 @@
+import {useQuery} from "@tanstack/react-query";
+import {useNetworkValue, useSdkV2Client} from "../../global-config";
+import {tryStandardizeAddress} from "../../utils";
+
+export type AccountCoinActivity = {
+  transaction_version: number;
+  event_index: number;
+  type: string;
+  amount: number | null;
+  asset_type: string;
+};
+
+const ACCOUNT_COIN_ACTIVITIES_QUERY = `
+  query GetAccountCoinActivities($owner: String!, $asset: String!, $limit: Int!, $offset: Int!) {
+    fungible_asset_activities(
+      where: {
+        owner_address: {_eq: $owner}
+        asset_type: {_eq: $asset}
+        type: {_neq: "0x1::aptos_coin::GasFeeEvent"}
+      }
+      limit: $limit
+      offset: $offset
+      order_by: [{transaction_version: desc}, {event_index: desc}]
+    ) {
+      transaction_version
+      event_index
+      type
+      amount
+      asset_type
+    }
+  }
+`;
+
+const ACCOUNT_COIN_ACTIVITIES_COUNT_QUERY = `
+  query GetAccountCoinActivitiesCount($owner: String!, $asset: String!) {
+    fungible_asset_activities_aggregate(
+      where: {
+        owner_address: {_eq: $owner}
+        asset_type: {_eq: $asset}
+        type: {_neq: "0x1::aptos_coin::GasFeeEvent"}
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export function useGetAccountCoinActivities(
+  address: string,
+  assetType: string,
+  limit: number,
+  offset: number,
+): {
+  isLoading: boolean;
+  error: Error | undefined;
+  data: AccountCoinActivity[] | undefined;
+} {
+  const addr = tryStandardizeAddress(address);
+  const client = useSdkV2Client();
+  const networkValue = useNetworkValue();
+
+  const {isLoading, error, data} = useQuery({
+    queryKey: [
+      "accountCoinActivities",
+      addr,
+      assetType,
+      limit,
+      offset,
+      networkValue,
+    ],
+    queryFn: () =>
+      client.queryIndexer<{
+        fungible_asset_activities: AccountCoinActivity[];
+      }>({
+        query: {
+          query: ACCOUNT_COIN_ACTIVITIES_QUERY,
+          variables: {owner: addr, asset: assetType, limit, offset},
+        },
+      }),
+    enabled: !!addr && assetType.length > 0,
+  });
+
+  return {
+    isLoading,
+    error: error ? (error as Error) : undefined,
+    data: data?.fungible_asset_activities,
+  };
+}
+
+export function useGetAccountCoinActivitiesCount(
+  address: string,
+  assetType: string,
+): number | undefined {
+  const addr = tryStandardizeAddress(address);
+  const client = useSdkV2Client();
+  const networkValue = useNetworkValue();
+
+  const {data} = useQuery({
+    queryKey: ["accountCoinActivitiesCount", addr, assetType, networkValue],
+    queryFn: () =>
+      client.queryIndexer<{
+        fungible_asset_activities_aggregate: {aggregate: {count: number}};
+      }>({
+        query: {
+          query: ACCOUNT_COIN_ACTIVITIES_COUNT_QUERY,
+          variables: {owner: addr, asset: assetType},
+        },
+      }),
+    enabled: !!addr && assetType.length > 0,
+  });
+
+  return data?.fungible_asset_activities_aggregate?.aggregate?.count;
+}

--- a/app/pages/Account/Components/AccountAllTransactions.tsx
+++ b/app/pages/Account/Components/AccountAllTransactions.tsx
@@ -12,6 +12,7 @@ import Box from "@mui/material/Box";
 import React from "react";
 import type {Types} from "~/types/aptos";
 import {getTransaction} from "../../../api";
+import useAssetFilter from "../../../api/hooks/useAssetFilter";
 import useFunctionFilter from "../../../api/hooks/useFunctionFilter";
 import {
   useGetAccountAllTransactionCount,
@@ -29,6 +30,8 @@ import FunctionFilter from "../../Transactions/Components/FunctionFilter";
 import {UserTransactionsTable} from "../../Transactions/TransactionsTable";
 import {downloadCSV, transactionsToCSV} from "../../utils";
 import {useLogEventWithBasic} from "../hooks/useLogEventWithBasic";
+import AssetFilter from "./AssetFilter";
+import AssetFilteredTransactions from "./AssetFilteredTransactions";
 
 // Maximum transactions we can display due to indexer query performance constraints
 const MAX_DISPLAYABLE_TRANSACTIONS = 10000;
@@ -194,6 +197,7 @@ export default function AccountAllTransactions({
   address,
 }: AccountAllTransactionsProps) {
   const {functionFilter, handleFunctionFilterChange} = useFunctionFilter();
+  const {assetFilter, handleAssetFilterChange} = useAssetFilter();
 
   const rawTxnCount = useGetAccountAllTransactionCount(address);
 
@@ -203,13 +207,18 @@ export default function AccountAllTransactions({
   const countPerPage = 25;
   const numPages = Math.ceil(txnCount / countPerPage);
 
+  const hasActiveFilter = !!functionFilter || !!assetFilter;
+
   return (
     <Stack spacing={2}>
-      <FunctionFilter
-        value={functionFilter}
-        onChange={handleFunctionFilterChange}
-      />
-      {!functionFilter && isCountUnknown && (
+      <Stack spacing={1}>
+        <FunctionFilter
+          value={functionFilter}
+          onChange={handleFunctionFilterChange}
+        />
+        <AssetFilter value={assetFilter} onChange={handleAssetFilterChange} />
+      </Stack>
+      {!hasActiveFilter && isCountUnknown && (
         <Alert
           severity="info"
           icon={<InfoOutlined />}
@@ -227,7 +236,12 @@ export default function AccountAllTransactions({
           still be accessed directly by their version number.
         </Alert>
       )}
-      {functionFilter ? (
+      {assetFilter ? (
+        <AssetFilteredTransactions
+          address={address}
+          assetFilter={assetFilter}
+        />
+      ) : functionFilter ? (
         <FilteredAccountTransactions
           address={address}
           functionFilter={functionFilter}

--- a/app/pages/Account/Components/AssetFilter.tsx
+++ b/app/pages/Account/Components/AssetFilter.tsx
@@ -1,0 +1,106 @@
+import ClearIcon from "@mui/icons-material/Clear";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import {
+  IconButton,
+  InputAdornment,
+  TextField,
+  Tooltip,
+  useTheme,
+} from "@mui/material";
+import type {KeyboardEvent} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
+
+type AssetFilterProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export default function AssetFilter({value, onChange}: AssetFilterProps) {
+  const theme = useTheme();
+  const [inputValue, setInputValue] = useState(value);
+  const isClearing = useRef(false);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (trimmed !== value) {
+      onChange(trimmed);
+    }
+  }, [inputValue, value, onChange]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (isClearing.current) {
+      isClearing.current = false;
+      return;
+    }
+    handleSubmit();
+  }, [handleSubmit]);
+
+  const handleClear = useCallback(() => {
+    isClearing.current = true;
+    setInputValue("");
+    onChange("");
+  }, [onChange]);
+
+  return (
+    <TextField
+      size="small"
+      fullWidth
+      aria-label="Filter transactions by coin or fungible asset"
+      placeholder="Filter by coin/FA (e.g. 0x1::aptos_coin::AptosCoin or FA address)"
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      variant="outlined"
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <Tooltip title="Filter by coin type or FA metadata address (press Enter to apply)">
+                <FilterListIcon
+                  sx={{fontSize: 20, color: theme.palette.text.secondary}}
+                />
+              </Tooltip>
+            </InputAdornment>
+          ),
+          endAdornment: inputValue ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="Clear asset filter"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleClear}
+                edge="end"
+                size="small"
+              >
+                <ClearIcon sx={{fontSize: 18}} />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
+          sx: {
+            fontFamily: "monospace",
+            fontSize: "0.875rem",
+          },
+        },
+      }}
+      sx={{
+        maxWidth: 560,
+        "& .MuiOutlinedInput-root": {
+          borderRadius: 1.5,
+        },
+      }}
+    />
+  );
+}

--- a/app/pages/Account/Components/AssetFilteredTransactions.tsx
+++ b/app/pages/Account/Components/AssetFilteredTransactions.tsx
@@ -1,0 +1,178 @@
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Pagination,
+  Stack,
+  Typography,
+} from "@mui/material";
+import Table from "@mui/material/Table";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import type React from "react";
+import {
+  type AccountCoinActivity,
+  useGetAccountCoinActivities,
+  useGetAccountCoinActivitiesCount,
+} from "../../../api/hooks/useGetAccountCoinActivities";
+import HashButton, {HashType} from "../../../components/HashButton";
+import GeneralTableBody from "../../../components/Table/GeneralTableBody";
+import GeneralTableCell from "../../../components/Table/GeneralTableCell";
+import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
+import GeneralTableRow from "../../../components/Table/GeneralTableRow";
+import {useSearchParams} from "../../../routing";
+
+const PAGE_SIZE = 25;
+
+function getActivityLabel(type: string): string {
+  if (type.includes("GasFeeEvent")) return "Gas Fee";
+  if (type.includes("Deposit")) return "Deposit";
+  if (type.includes("Withdraw")) return "Withdraw";
+  if (type.includes("Mint")) return "Mint";
+  if (type.includes("Burn")) return "Burn";
+  if (type.includes("Freeze")) return "Freeze";
+  if (type.includes("Transfer")) return "Transfer";
+  const parts = type.split("::");
+  return parts.length > 0 ? parts[parts.length - 1] : type;
+}
+
+function getActivityColor(
+  type: string,
+): "default" | "success" | "error" | "info" | "warning" {
+  if (type.includes("Mint")) return "success";
+  if (type.includes("Burn")) return "error";
+  if (type.includes("Deposit")) return "info";
+  if (type.includes("Withdraw")) return "warning";
+  return "default";
+}
+
+type Props = {
+  address: string;
+  assetFilter: string;
+};
+
+export default function AssetFilteredTransactions({
+  address,
+  assetFilter,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  const count = useGetAccountCoinActivitiesCount(address, assetFilter);
+  const {data, isLoading, error} = useGetAccountCoinActivities(
+    address,
+    assetFilter,
+    PAGE_SIZE,
+    offset,
+  );
+
+  const numPages = count !== undefined ? Math.ceil(count / PAGE_SIZE) : 1;
+
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    newPage: number,
+  ) => {
+    searchParams.set("page", newPage.toString());
+    setSearchParams(searchParams);
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{display: "flex", justifyContent: "center", py: 4}}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error">
+        Failed to filter transactions by asset. The asset type may be invalid or
+        the indexer may be temporarily unavailable.
+      </Alert>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Box sx={{py: 4, textAlign: "center"}}>
+        <Typography color="text.secondary">
+          No activity found for asset &ldquo;{assetFilter}&rdquo; on this
+          account
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={2}>
+      {count !== undefined && (
+        <Typography variant="body2" color="text.secondary">
+          {count.toLocaleString()} activit{count !== 1 ? "ies" : "y"} for this
+          asset
+        </Typography>
+      )}
+      <Box sx={{width: "auto", overflowX: "auto"}}>
+        <ActivityTable activities={data} />
+      </Box>
+      {numPages > 1 && (
+        <Box sx={{display: "flex", justifyContent: "center"}}>
+          <Pagination
+            sx={{mt: 3}}
+            count={numPages}
+            variant="outlined"
+            showFirstButton
+            showLastButton
+            page={currentPage}
+            siblingCount={4}
+            boundaryCount={0}
+            shape="rounded"
+            onChange={handlePageChange}
+          />
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+function ActivityTable({activities}: {activities: AccountCoinActivity[]}) {
+  return (
+    <Table
+      aria-label="Account coin/FA activities"
+      data-entity-type="transaction"
+    >
+      <TableHead>
+        <TableRow>
+          <GeneralTableHeaderCell header="version" />
+          <GeneralTableHeaderCell header="type" />
+          <GeneralTableHeaderCell header="amount" textAlignRight />
+        </TableRow>
+      </TableHead>
+      <GeneralTableBody>
+        {activities.map((a) => (
+          <GeneralTableRow key={`${a.transaction_version}-${a.event_index}`}>
+            <GeneralTableCell>
+              <HashButton
+                hash={a.transaction_version.toString()}
+                type={HashType.TRANSACTION}
+              />
+            </GeneralTableCell>
+            <GeneralTableCell>
+              <Chip
+                label={getActivityLabel(a.type)}
+                color={getActivityColor(a.type)}
+                size="small"
+                variant="outlined"
+              />
+            </GeneralTableCell>
+            <GeneralTableCell align="right">
+              {a.amount != null ? a.amount.toLocaleString() : "—"}
+            </GeneralTableCell>
+          </GeneralTableRow>
+        ))}
+      </GeneralTableBody>
+    </Table>
+  );
+}

--- a/app/pages/Coin/Index.tsx
+++ b/app/pages/Coin/Index.tsx
@@ -17,7 +17,7 @@ import CoinError from "./Error";
 import CoinTabs, {type TabValue} from "./Tabs";
 import CoinTitle from "./Title";
 
-const TAB_VALUES_FULL: TabValue[] = ["info", "holders", "transactions"];
+const TAB_VALUES_FULL: TabValue[] = ["info", "holders"];
 
 const TAB_VALUES: TabValue[] = ["info"];
 

--- a/app/pages/Coin/Tabs.tsx
+++ b/app/pages/Coin/Tabs.tsx
@@ -12,12 +12,10 @@ import {assertNever} from "../../utils";
 import type {CoinData} from "./Components/CoinData";
 import HoldersTab from "./Tabs/HoldersTab";
 import InfoTab from "./Tabs/InfoTab";
-import TransactionsTab from "./Tabs/TransactionsTab";
 
-const TAB_VALUES: TabValue[] = ["info", "holders", "transactions"];
+const TAB_VALUES: TabValue[] = ["info", "holders"];
 
 const TabComponents = Object.freeze({
-  transactions: TransactionsTab,
   holders: HoldersTab,
   info: InfoTab,
 });
@@ -28,10 +26,8 @@ function getTabLabel(value: TabValue): string {
   switch (value) {
     case "info":
       return "Info";
-    case "transactions":
-      return "Beta - Transactions";
     case "holders":
-      return "Beta - Holders";
+      return "Holders";
     default:
       return assertNever(value);
   }
@@ -41,8 +37,6 @@ function getTabIcon(value: TabValue) {
   switch (value) {
     case "info":
       return <DescriptionOutlinedIcon fontSize="small" />;
-    case "transactions":
-      return <WysiwygIcon fontSize="small" />;
     case "holders":
       return <WysiwygIcon fontSize="small" />;
     default:
@@ -88,7 +82,6 @@ type CoinTabsProps = {
   coinData: CoinDescription | undefined;
 };
 
-// TODO: create reusable Tabs for all pages
 export default function CoinTabs({
   struct,
   data,

--- a/app/pages/Coin/Tabs/HoldersTab.tsx
+++ b/app/pages/Coin/Tabs/HoldersTab.tsx
@@ -1,8 +1,17 @@
-import {Box, Button, CircularProgress} from "@mui/material";
+import {GetApp as DownloadIcon} from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import {useReducer} from "react";
+import {useCallback, useReducer, useState} from "react";
 import {
   type CoinHolder,
   useGetCoinHolders,
@@ -14,6 +23,8 @@ import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
+import {useSdkV2Client} from "../../../global-config";
+import {downloadCSV} from "../../../utils";
 import type {CoinData} from "../Components/CoinData";
 
 type HoldersTabProps = {
@@ -21,9 +32,9 @@ type HoldersTabProps = {
   data: CoinData | undefined;
 };
 
-const LIMIT = 25;
+const TOP_HOLDER_LIMIT = 100;
+const FETCH_PAGE_SIZE = 100;
 
-// Wrapper component that remounts HoldersContent when struct changes
 export default function HoldersTab({struct, data}: HoldersTabProps) {
   return <HoldersContent key={struct} struct={struct} data={data} />;
 }
@@ -44,10 +55,10 @@ function holdersReducer(
 ): HoldersState {
   switch (action.type) {
     case "LOAD_MORE":
-      return {...state, offset: state.offset + LIMIT};
+      return {...state, offset: state.offset + FETCH_PAGE_SIZE};
     case "DATA_LOADED":
       if (action.payload.offset === state.lastLoadedOffset) {
-        return state; // Already processed this offset
+        return state;
       }
       if (action.payload.offset === 0) {
         return {
@@ -73,9 +84,8 @@ function HoldersContent({struct, data}: HoldersTabProps) {
     lastLoadedOffset: -1,
   });
 
-  const holderData = useGetCoinHolders(struct, LIMIT, state.offset);
+  const holderData = useGetCoinHolders(struct, TOP_HOLDER_LIMIT, state.offset);
 
-  // Process loaded data via reducer dispatch
   if (
     holderData.data &&
     holderData.data.length > 0 &&
@@ -87,7 +97,6 @@ function HoldersContent({struct, data}: HoldersTabProps) {
     });
   }
 
-  // Show loading only on initial load
   if (holderData.isLoading && state.holders.length === 0) {
     return (
       <Box sx={{display: "flex", justifyContent: "center", padding: 4}}>
@@ -99,27 +108,26 @@ function HoldersContent({struct, data}: HoldersTabProps) {
     return <EmptyTabContent />;
   }
 
-  const handleLoadMore = () => {
-    dispatch({type: "LOAD_MORE"});
-  };
+  const top100 = state.holders.slice(0, TOP_HOLDER_LIMIT);
 
   return (
     <Box>
-      <HoldersTable data={data} holders={state.holders} offset={0} />
-      {holderData.hasMore && (
-        <Box sx={{display: "flex", justifyContent: "center", padding: 2}}>
-          <Button
-            variant="outlined"
-            onClick={handleLoadMore}
-            disabled={holderData.isLoading}
-            startIcon={
-              holderData.isLoading ? <CircularProgress size={16} /> : null
-            }
-          >
-            {holderData.isLoading ? "Loading..." : "Load more"}
-          </Button>
-        </Box>
-      )}
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{px: 2, py: 1.5}}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Top {top100.length} holders by balance
+        </Typography>
+        <HoldersCSVExportButton
+          coinType={struct}
+          decimals={data.data.decimals}
+          symbol={data.data.symbol}
+        />
+      </Stack>
+      <HoldersTable data={data} holders={top100} offset={0} />
     </Box>
   );
 }
@@ -166,5 +174,174 @@ export function HoldersTable({
         })}
       </GeneralTableBody>
     </Table>
+  );
+}
+
+type CSVExportState =
+  | {status: "idle"}
+  | {status: "fetching"; fetched: number; error?: undefined}
+  | {status: "done"; fetched: number}
+  | {status: "error"; message: string};
+
+function HoldersCSVExportButton({
+  coinType,
+  decimals,
+  symbol,
+}: {
+  coinType: string;
+  decimals: number;
+  symbol: string;
+}) {
+  const client = useSdkV2Client();
+  const [exportState, setExportState] = useState<CSVExportState>({
+    status: "idle",
+  });
+
+  const isRateLimitError = useCallback((error: unknown): boolean => {
+    if (error && typeof error === "object") {
+      const e = error as Record<string, unknown>;
+      if (e.statusCode === 429) return true;
+      const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
+      if (msg.includes("rate limit")) return true;
+    }
+    return false;
+  }, []);
+
+  const sleep = useCallback(
+    (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setExportState({status: "fetching", fetched: 0});
+    const allHolders: CoinHolder[] = [];
+    const pageSize = FETCH_PAGE_SIZE;
+    let offset = 0;
+    let hasMore = true;
+    let consecutiveErrors = 0;
+
+    while (hasMore) {
+      try {
+        const result = await client.queryIndexer<{
+          current_fungible_asset_balances: CoinHolder[];
+        }>({
+          query: {
+            query: `
+              query GetFungibleAssetBalances($coin_type: String!, $limit: Int!, $offset: Int!) {
+                current_fungible_asset_balances(
+                  where: {asset_type: {_eq: $coin_type}}
+                  limit: $limit
+                  offset: $offset
+                  order_by: {amount: desc}
+                ) {
+                  owner_address
+                  amount
+                }
+              }
+            `,
+            variables: {coin_type: coinType, limit: pageSize, offset},
+          },
+        });
+
+        const page = result?.current_fungible_asset_balances ?? [];
+        consecutiveErrors = 0;
+        allHolders.push(...page);
+        setExportState({status: "fetching", fetched: allHolders.length});
+
+        if (page.length < pageSize) {
+          hasMore = false;
+        } else {
+          offset += pageSize;
+          await sleep(250);
+        }
+      } catch (error) {
+        consecutiveErrors++;
+        if (isRateLimitError(error)) {
+          const delay = 2000 * 2 ** (consecutiveErrors - 1);
+          setExportState({status: "fetching", fetched: allHolders.length});
+          await sleep(delay);
+        } else if (consecutiveErrors >= 3) {
+          setExportState({
+            status: "error",
+            message: `Export stopped after errors. ${allHolders.length} holders collected so far.`,
+          });
+          if (allHolders.length > 0) {
+            buildAndDownload(allHolders, coinType, decimals, symbol);
+          }
+          return;
+        } else {
+          await sleep(1000 * consecutiveErrors);
+        }
+      }
+    }
+
+    if (allHolders.length === 0) {
+      setExportState({status: "error", message: "No holders found."});
+      return;
+    }
+
+    buildAndDownload(allHolders, coinType, decimals, symbol);
+    setExportState({status: "done", fetched: allHolders.length});
+    setTimeout(() => setExportState({status: "idle"}), 5000);
+  }, [client, coinType, decimals, symbol, isRateLimitError, sleep]);
+
+  return (
+    <Stack spacing={1} alignItems="flex-end">
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={
+          exportState.status === "fetching" ? (
+            <CircularProgress size={16} />
+          ) : (
+            <DownloadIcon />
+          )
+        }
+        onClick={handleExport}
+        disabled={exportState.status === "fetching"}
+      >
+        {exportState.status === "fetching"
+          ? `Collecting holders… ${exportState.fetched.toLocaleString()}`
+          : "Export All Holders CSV"}
+      </Button>
+      {exportState.status === "fetching" && (
+        <Box sx={{width: 220}}>
+          <LinearProgress variant="indeterminate" />
+          <Typography variant="caption" color="text.secondary" sx={{mt: 0.5}}>
+            Paginating through all holders — this may take a while for popular
+            assets due to API rate limits.
+          </Typography>
+        </Box>
+      )}
+      {exportState.status === "done" && (
+        <Typography variant="caption" color="success.main">
+          Exported {exportState.fetched.toLocaleString()} holders
+        </Typography>
+      )}
+      {exportState.status === "error" && (
+        <Alert severity="warning" sx={{maxWidth: 340}}>
+          {exportState.message}
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+function buildAndDownload(
+  holders: CoinHolder[],
+  coinType: string,
+  decimals: number,
+  symbol: string,
+) {
+  const headers = ["rank", "owner_address", "raw_amount", "formatted_amount"];
+  let csv = `${headers.join(",")}\n`;
+  holders.forEach((h, i) => {
+    const formatted = getFormattedBalanceStr(h.amount.toString(), decimals);
+    csv += `${i + 1},${h.owner_address},${h.amount},"${formatted} ${symbol}"\n`;
+  });
+  const safeName = coinType.replace(/[^a-zA-Z0-9_:]/g, "_").slice(0, 60);
+  downloadCSV(
+    csv,
+    `holders_${safeName}_${new Date().toISOString().split("T")[0]}.csv`,
   );
 }

--- a/app/pages/Coin/coinTabMeta.ts
+++ b/app/pages/Coin/coinTabMeta.ts
@@ -3,8 +3,6 @@
  */
 export function getCoinTabHeadLabel(tab: string | undefined): string {
   switch (tab ?? "info") {
-    case "transactions":
-      return "Transactions";
     case "holders":
       return "Holders";
     default:

--- a/app/pages/FungibleAsset/Index.tsx
+++ b/app/pages/FungibleAsset/Index.tsx
@@ -22,7 +22,7 @@ import FungibleAssetError from "./Error";
 import FATabs, {type TabValue} from "./Tabs";
 import FATitle from "./Title";
 
-const TAB_VALUES_FULL: TabValue[] = ["info", "holders", "transactions"];
+const TAB_VALUES_FULL: TabValue[] = ["info", "holders"];
 
 const TAB_VALUES: TabValue[] = ["info"];
 

--- a/app/pages/FungibleAsset/Tabs.tsx
+++ b/app/pages/FungibleAsset/Tabs.tsx
@@ -10,12 +10,10 @@ import {assertNever} from "../../utils";
 import type {FACombinedData} from "./Index";
 import HoldersTab from "./Tabs/HoldersTab";
 import InfoTab from "./Tabs/InfoTab";
-import TransactionsTab from "./Tabs/TransactionsTab";
 
-const TAB_VALUES: TabValue[] = ["info", "holders", "transactions"];
+const TAB_VALUES: TabValue[] = ["info", "holders"];
 
 const TabComponents = Object.freeze({
-  transactions: TransactionsTab,
   holders: HoldersTab,
   info: InfoTab,
 });
@@ -27,9 +25,7 @@ function getTabLabel(value: TabValue): string {
     case "info":
       return "Info";
     case "holders":
-      return "Beta - Holders";
-    case "transactions":
-      return "Beta - Transactions";
+      return "Holders";
     default:
       return assertNever(value);
   }
@@ -40,8 +36,6 @@ function getTabIcon(value: TabValue): React.JSX.Element {
     case "info":
       return <DescriptionOutlinedIcon fontSize="small" />;
     case "holders":
-      return <WysiwygIcon fontSize="small" />;
-    case "transactions":
       return <WysiwygIcon fontSize="small" />;
     default:
       return assertNever(value);
@@ -65,7 +59,6 @@ type FATabsProps = {
   tabValues?: TabValue[];
 };
 
-// TODO: create reusable Tabs for all pages
 export default function FATabs({
   address,
   data,

--- a/app/pages/FungibleAsset/Tabs/HoldersTab.tsx
+++ b/app/pages/FungibleAsset/Tabs/HoldersTab.tsx
@@ -1,8 +1,17 @@
-import {Box, Button, CircularProgress} from "@mui/material";
+import {GetApp as DownloadIcon} from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import {useReducer} from "react";
+import {useCallback, useReducer, useState} from "react";
 import {
   type CoinHolder,
   useGetCoinHolders,
@@ -14,6 +23,8 @@ import GeneralTableBody from "../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
+import {useSdkV2Client} from "../../../global-config";
+import {downloadCSV} from "../../../utils";
 import type {FACombinedData} from "../Index";
 
 type HoldersTabProps = {
@@ -21,9 +32,9 @@ type HoldersTabProps = {
   data: FACombinedData | undefined;
 };
 
-const LIMIT = 25;
+const TOP_HOLDER_LIMIT = 100;
+const FETCH_PAGE_SIZE = 100;
 
-// Wrapper component that remounts HoldersContent when address changes
 export default function HoldersTab({address, data}: HoldersTabProps) {
   return <HoldersContent key={address} address={address} data={data} />;
 }
@@ -44,10 +55,10 @@ function holdersReducer(
 ): HoldersState {
   switch (action.type) {
     case "LOAD_MORE":
-      return {...state, offset: state.offset + LIMIT};
+      return {...state, offset: state.offset + FETCH_PAGE_SIZE};
     case "DATA_LOADED":
       if (action.payload.offset === state.lastLoadedOffset) {
-        return state; // Already processed this offset
+        return state;
       }
       if (action.payload.offset === 0) {
         return {
@@ -73,9 +84,8 @@ function HoldersContent({address, data}: HoldersTabProps) {
     lastLoadedOffset: -1,
   });
 
-  const holderData = useGetCoinHolders(address, LIMIT, state.offset);
+  const holderData = useGetCoinHolders(address, TOP_HOLDER_LIMIT, state.offset);
 
-  // Process loaded data via reducer dispatch
   if (
     holderData.data &&
     holderData.data.length > 0 &&
@@ -87,7 +97,6 @@ function HoldersContent({address, data}: HoldersTabProps) {
     });
   }
 
-  // Show loading only on initial load
   if (holderData.isLoading && state.holders.length === 0) {
     return (
       <Box sx={{display: "flex", justifyContent: "center", padding: 4}}>
@@ -99,27 +108,28 @@ function HoldersContent({address, data}: HoldersTabProps) {
     return <EmptyTabContent />;
   }
 
-  const handleLoadMore = () => {
-    dispatch({type: "LOAD_MORE"});
-  };
+  const decimals = data.coinData?.decimals ?? data.metadata?.decimals ?? 0;
+  const symbol = (data.coinData?.symbol ?? data.metadata?.symbol) || "unknown";
+  const top100 = state.holders.slice(0, TOP_HOLDER_LIMIT);
 
   return (
     <Box>
-      <HoldersTable data={data} holders={state.holders} offset={0} />
-      {holderData.hasMore && (
-        <Box sx={{display: "flex", justifyContent: "center", padding: 2}}>
-          <Button
-            variant="outlined"
-            onClick={handleLoadMore}
-            disabled={holderData.isLoading}
-            startIcon={
-              holderData.isLoading ? <CircularProgress size={16} /> : null
-            }
-          >
-            {holderData.isLoading ? "Loading..." : "Load more"}
-          </Button>
-        </Box>
-      )}
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{px: 2, py: 1.5}}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Top {top100.length} holders by balance
+        </Typography>
+        <HoldersCSVExportButton
+          coinType={address}
+          decimals={decimals}
+          symbol={symbol}
+        />
+      </Stack>
+      <HoldersTable data={data} holders={top100} offset={0} />
     </Box>
   );
 }
@@ -166,5 +176,174 @@ export function HoldersTable({
         })}
       </GeneralTableBody>
     </Table>
+  );
+}
+
+type CSVExportState =
+  | {status: "idle"}
+  | {status: "fetching"; fetched: number; error?: undefined}
+  | {status: "done"; fetched: number}
+  | {status: "error"; message: string};
+
+function HoldersCSVExportButton({
+  coinType,
+  decimals,
+  symbol,
+}: {
+  coinType: string;
+  decimals: number;
+  symbol: string;
+}) {
+  const client = useSdkV2Client();
+  const [exportState, setExportState] = useState<CSVExportState>({
+    status: "idle",
+  });
+
+  const isRateLimitError = useCallback((error: unknown): boolean => {
+    if (error && typeof error === "object") {
+      const e = error as Record<string, unknown>;
+      if (e.statusCode === 429) return true;
+      const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
+      if (msg.includes("rate limit")) return true;
+    }
+    return false;
+  }, []);
+
+  const sleep = useCallback(
+    (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setExportState({status: "fetching", fetched: 0});
+    const allHolders: CoinHolder[] = [];
+    const pageSize = FETCH_PAGE_SIZE;
+    let offset = 0;
+    let hasMore = true;
+    let consecutiveErrors = 0;
+
+    while (hasMore) {
+      try {
+        const result = await client.queryIndexer<{
+          current_fungible_asset_balances: CoinHolder[];
+        }>({
+          query: {
+            query: `
+              query GetFungibleAssetBalances($coin_type: String!, $limit: Int!, $offset: Int!) {
+                current_fungible_asset_balances(
+                  where: {asset_type: {_eq: $coin_type}}
+                  limit: $limit
+                  offset: $offset
+                  order_by: {amount: desc}
+                ) {
+                  owner_address
+                  amount
+                }
+              }
+            `,
+            variables: {coin_type: coinType, limit: pageSize, offset},
+          },
+        });
+
+        const page = result?.current_fungible_asset_balances ?? [];
+        consecutiveErrors = 0;
+        allHolders.push(...page);
+        setExportState({status: "fetching", fetched: allHolders.length});
+
+        if (page.length < pageSize) {
+          hasMore = false;
+        } else {
+          offset += pageSize;
+          await sleep(250);
+        }
+      } catch (error) {
+        consecutiveErrors++;
+        if (isRateLimitError(error)) {
+          const delay = 2000 * 2 ** (consecutiveErrors - 1);
+          setExportState({status: "fetching", fetched: allHolders.length});
+          await sleep(delay);
+        } else if (consecutiveErrors >= 3) {
+          setExportState({
+            status: "error",
+            message: `Export stopped after errors. ${allHolders.length} holders collected so far.`,
+          });
+          if (allHolders.length > 0) {
+            buildAndDownload(allHolders, coinType, decimals, symbol);
+          }
+          return;
+        } else {
+          await sleep(1000 * consecutiveErrors);
+        }
+      }
+    }
+
+    if (allHolders.length === 0) {
+      setExportState({status: "error", message: "No holders found."});
+      return;
+    }
+
+    buildAndDownload(allHolders, coinType, decimals, symbol);
+    setExportState({status: "done", fetched: allHolders.length});
+    setTimeout(() => setExportState({status: "idle"}), 5000);
+  }, [client, coinType, decimals, symbol, isRateLimitError, sleep]);
+
+  return (
+    <Stack spacing={1} alignItems="flex-end">
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={
+          exportState.status === "fetching" ? (
+            <CircularProgress size={16} />
+          ) : (
+            <DownloadIcon />
+          )
+        }
+        onClick={handleExport}
+        disabled={exportState.status === "fetching"}
+      >
+        {exportState.status === "fetching"
+          ? `Collecting holders… ${exportState.fetched.toLocaleString()}`
+          : "Export All Holders CSV"}
+      </Button>
+      {exportState.status === "fetching" && (
+        <Box sx={{width: 220}}>
+          <LinearProgress variant="indeterminate" />
+          <Typography variant="caption" color="text.secondary" sx={{mt: 0.5}}>
+            Paginating through all holders — this may take a while for popular
+            assets due to API rate limits.
+          </Typography>
+        </Box>
+      )}
+      {exportState.status === "done" && (
+        <Typography variant="caption" color="success.main">
+          Exported {exportState.fetched.toLocaleString()} holders
+        </Typography>
+      )}
+      {exportState.status === "error" && (
+        <Alert severity="warning" sx={{maxWidth: 340}}>
+          {exportState.message}
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+function buildAndDownload(
+  holders: CoinHolder[],
+  coinType: string,
+  decimals: number,
+  symbol: string,
+) {
+  const headers = ["rank", "owner_address", "raw_amount", "formatted_amount"];
+  let csv = `${headers.join(",")}\n`;
+  holders.forEach((h, i) => {
+    const formatted = getFormattedBalanceStr(h.amount.toString(), decimals);
+    csv += `${i + 1},${h.owner_address},${h.amount},"${formatted} ${symbol}"\n`;
+  });
+  const safeName = coinType.replace(/[^a-zA-Z0-9_:]/g, "_").slice(0, 60);
+  downloadCSV(
+    csv,
+    `holders_${safeName}_${new Date().toISOString().split("T")[0]}.csv`,
   );
 }

--- a/app/pages/FungibleAsset/fungibleAssetTabMeta.ts
+++ b/app/pages/FungibleAsset/fungibleAssetTabMeta.ts
@@ -3,8 +3,6 @@
  */
 export function getFungibleAssetTabHeadLabel(tab: string | undefined): string {
   switch (tab ?? "info") {
-    case "transactions":
-      return "Transactions";
     case "holders":
       return "Holders";
     default:

--- a/app/routes/coin.$struct.tsx
+++ b/app/routes/coin.$struct.tsx
@@ -1,20 +1,33 @@
 import {createFileRoute, Outlet, redirect} from "@tanstack/react-router";
 
+const VALID_TABS = new Set(["info", "holders"]);
+
 // Layout route for /coin/:struct/*
 // Handles backward compatibility redirects from query params to path-based tabs
 export const Route = createFileRoute("/coin/$struct")({
   beforeLoad: ({params, search, location}) => {
     const searchParams = search as {tab?: string; network?: string};
 
-    // Check if we're on the exact /coin/:struct path (no child route)
     const pathSegments = location.pathname.split("/").filter(Boolean);
     const isExactMatch = pathSegments.length === 2; // ["coin", "struct"]
 
-    // If there's a tab query param, redirect to path-based route
-    if (searchParams?.tab) {
+    // Redirect removed "transactions" tab → info
+    if (pathSegments.length === 3 && !VALID_TABS.has(pathSegments[2])) {
       throw redirect({
         to: "/coin/$struct/$tab",
-        params: {struct: params.struct, tab: searchParams.tab},
+        params: {struct: params.struct, tab: "info"},
+        search: searchParams?.network
+          ? {network: searchParams.network}
+          : undefined,
+      });
+    }
+
+    // If there's a tab query param, redirect to path-based route
+    if (searchParams?.tab) {
+      const tab = VALID_TABS.has(searchParams.tab) ? searchParams.tab : "info";
+      throw redirect({
+        to: "/coin/$struct/$tab",
+        params: {struct: params.struct, tab},
         search: searchParams.network
           ? {network: searchParams.network}
           : undefined,

--- a/app/routes/fungible_asset.$address.tsx
+++ b/app/routes/fungible_asset.$address.tsx
@@ -1,20 +1,33 @@
 import {createFileRoute, Outlet, redirect} from "@tanstack/react-router";
 
+const VALID_TABS = new Set(["info", "holders"]);
+
 // Layout route for /fungible_asset/:address/*
 // Handles backward compatibility redirects from query params to path-based tabs
 export const Route = createFileRoute("/fungible_asset/$address")({
   beforeLoad: ({params, search, location}) => {
     const searchParams = search as {tab?: string; network?: string};
 
-    // Check if we're on the exact /fungible_asset/:address path (no child route)
     const pathSegments = location.pathname.split("/").filter(Boolean);
     const isExactMatch = pathSegments.length === 2; // ["fungible_asset", "address"]
 
-    // If there's a tab query param, redirect to path-based route
-    if (searchParams?.tab) {
+    // Redirect removed "transactions" tab → info
+    if (pathSegments.length === 3 && !VALID_TABS.has(pathSegments[2])) {
       throw redirect({
         to: "/fungible_asset/$address/$tab",
-        params: {address: params.address, tab: searchParams.tab},
+        params: {address: params.address, tab: "info"},
+        search: searchParams?.network
+          ? {network: searchParams.network}
+          : undefined,
+      });
+    }
+
+    // If there's a tab query param, redirect to path-based route
+    if (searchParams?.tab) {
+      const tab = VALID_TABS.has(searchParams.tab) ? searchParams.tab : "info";
+      throw redirect({
+        to: "/fungible_asset/$address/$tab",
+        params: {address: params.address, tab},
         search: searchParams.network
           ? {network: searchParams.network}
           : undefined,

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Aptos Explorer — Full LLM Reference
 
-> Last updated: 2026-03-23 (rev 11)
+> Last updated: 2026-03-24 (rev 12)
 
 > Comprehensive reference for AI systems interacting with or answering questions about the Aptos Explorer at [explorer.aptoslabs.com](https://explorer.aptoslabs.com).
 
@@ -51,7 +51,7 @@ Each detail page has tabs accessible via path segments:
 #### Accounts
 - `/account/{address}` — account overview (redirects to `/account/{address}/transactions`)
 - Tab paths:
-  - `/account/{address}/transactions` — full transaction history (supports `?fn={entry_function_id}` to filter by function, server-side via indexer)
+  - `/account/{address}/transactions` — full transaction history (supports `?fn={entry_function_id}` to filter by function, and `?asset={coin_type_or_fa_address}` to filter by coin/fungible asset — both server-side via indexer)
   - `/account/{address}/coins` — fungible token balances
   - `/account/{address}/tokens` — NFTs owned by this account
   - `/account/{address}/resources` — raw Move resources stored under the account
@@ -79,9 +79,11 @@ Each detail page has tabs accessible via path segments:
 #### Coins and Fungible Assets
 - `/coins` — list of known coins and fungible assets
 - `/coin/{type}` — coin details by Move type (e.g., `/coin/0x1::aptos_coin::AptosCoin`)
-  - Tab paths: `/coin/{type}/info`, `/coin/{type}/transactions`, `/coin/{type}/holders`
+  - Tab paths: `/coin/{type}/info`, `/coin/{type}/holders`
+  - Holders tab shows top 100 by balance; full list available via CSV export
 - `/fungible_asset/{address}` — fungible asset by metadata address
-  - Tab paths: `/fungible_asset/{address}/info`, `/fungible_asset/{address}/transactions`, `/fungible_asset/{address}/holders`
+  - Tab paths: `/fungible_asset/{address}/info`, `/fungible_asset/{address}/holders`
+  - Holders tab shows top 100 by balance; full list available via CSV export
 
 #### Tokens (NFTs)
 - `/token/{tokenId}` — individual NFT/token details
@@ -190,7 +192,7 @@ A: Visit `https://explorer.aptoslabs.com/account/0x1/modules` — this lists all
 A: Yes. Open a module code page such as `https://explorer.aptoslabs.com/account/0x1/modules/code/coin` and select **Decompiled** or **Disassembly**. These are generated client-side in the browser using Move decompiler WASM.
 
 **Q: "Is there an APT coin page?"**
-A: Yes — `https://explorer.aptoslabs.com/coin/0x1::aptos_coin::AptosCoin` shows supply, metadata, and recent transactions for native APT.
+A: Yes — `https://explorer.aptoslabs.com/coin/0x1::aptos_coin::AptosCoin` shows supply, metadata, and top holders for native APT. To see coin-specific transactions for a particular account, use the asset filter on the account's transactions tab (e.g. `/account/{address}/transactions?asset=0x1::aptos_coin::AptosCoin`).
 
 **Q: "What's the current TPS on Aptos?"**
 A: Visit `https://explorer.aptoslabs.com/analytics` — the analytics page shows real-time and historical TPS charts along with other network metrics.
@@ -293,6 +295,7 @@ Charts and metrics for:
 - `network` — Select network: mainnet (default), testnet, devnet, local
 - `search` — On the home page (`/?search={query}`), pre-fills the search bar and executes the query immediately. Results are displayed inline on the page below the search input. Use this when the exact entity type is unknown — the explorer will auto-detect and show matching results grouped by type (accounts, transactions, blocks, coins, etc.). On Enter or a single unambiguous result, navigates directly to the entity page.
 - `fn` — On `/transactions` and `/account/{address}/transactions`, filters transactions by entry function ID (e.g. `?fn=0x1::coin::transfer`). The value must be a fully qualified Move function identifier (`{address}::{module}::{function}`). On the User Transactions view and account transactions view, this filters server-side via the GraphQL indexer. On the All Transactions view, this filters client-side on the currently loaded page.
+- `asset` — On `/account/{address}/transactions`, filters to show only activity (deposits, withdrawals, mints, burns) for a specific coin type or fungible asset address (e.g. `?asset=0x1::aptos_coin::AptosCoin`). Server-side via the GraphQL indexer.
 - `type` — On `/transactions`, selects between `user` (user transactions only, default) and `all` (all transaction types)
 - Page/tab selection is path-based (e.g., `/account/0x1/modules`), not query-param-based
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,9 +33,9 @@ All URLs default to mainnet. Append `?network=testnet`, `?network=devnet`, or `?
   - Tabs: `/validators/all`, `/validators/delegation`, `/validators/enhanced_delegation`
 - Individual validator: `/validator/{address}`
 - Coin: `/coin/{type}` — e.g., `/coin/0x1::aptos_coin::AptosCoin`
-  - Tabs: `/coin/{type}/info`, `/coin/{type}/transactions`, `/coin/{type}/holders`
+  - Tabs: `/coin/{type}/info`, `/coin/{type}/holders`
 - Fungible asset: `/fungible_asset/{address}`
-  - Tabs: `/fungible_asset/{address}/info`, `/fungible_asset/{address}/transactions`, `/fungible_asset/{address}/holders`
+  - Tabs: `/fungible_asset/{address}/info`, `/fungible_asset/{address}/holders`
 - NFT token: `/token/{tokenId}`
   - Tabs: `/token/{tokenId}/overview`, `/token/{tokenId}/activities`
 - Move object: `/object/{address}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Three related changes to the coin/FA detail pages and account transactions:

1. **Holders tab redesign**: Shows the top 100 holders by balance (was unlimited paginated load-more). Adds an "Export All Holders CSV" button that paginates through every holder with rate-limit-aware backoff, streams progress, and downloads a CSV when complete.

2. **Transactions tab removed from coin/FA pages**: The "Beta - Transactions" tab is removed from both `/coin/{type}` and `/fungible_asset/{address}` pages. Old bookmark URLs (`/coin/{type}/transactions`, `/fungible_asset/{address}/transactions`) redirect to the info tab.

3. **Account asset filter**: A new `?asset=` search-param filter on the account transactions tab (`/account/{address}/transactions`) lets users view deposit/withdrawal/mint/burn activity for a specific coin type or FA address. This replaces the removed coin/FA transactions tab with a more useful per-account perspective.

### Changes

- `app/pages/Coin/Tabs/HoldersTab.tsx` — top-100 display + CSV export button
- `app/pages/FungibleAsset/Tabs/HoldersTab.tsx` — same for FA
- `app/pages/Coin/Tabs.tsx`, `app/pages/FungibleAsset/Tabs.tsx` — removed `transactions` from tab definitions
- `app/pages/Coin/Index.tsx`, `app/pages/FungibleAsset/Index.tsx` — updated `TAB_VALUES_FULL`
- `app/routes/coin.$struct.tsx`, `app/routes/fungible_asset.$address.tsx` — redirect invalid tabs (including old `transactions`) to `info`
- `app/api/hooks/useGetAccountCoinActivities.ts` — new GraphQL hook for account-specific coin activity
- `app/api/hooks/useAssetFilter.ts` — URL state management for `?asset=` param
- `app/pages/Account/Components/AssetFilter.tsx` — filter input component
- `app/pages/Account/Components/AssetFilteredTransactions.tsx` — paginated activity table
- `app/pages/Account/Components/AccountAllTransactions.tsx` — integrated asset filter alongside function filter
- `public/llms.txt`, `public/llms-full.txt` — updated route/tab documentation
- `CHANGELOG.md` — documented changes

### Related Links

N/A

### Checklist

- [x] `pnpm fmt` — no issues
- [x] `pnpm lint` — no issues (tsc + biome)
- [x] `pnpm test --run` — 337 tests pass
- [x] Route changes documented in `llms.txt`, `llms-full.txt`
- [x] CHANGELOG updated
- [x] Manual testing — coin page tabs, redirect, FA page, account asset filter all verified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60d67794-7261-4b07-aeec-2337c88d1f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60d67794-7261-4b07-aeec-2337c88d1f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

