### PR TITLE
feat(settings): per-network geomi.dev API key overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Settings**: optional geomi.dev API key override can be set **per network** (instead of one key for all networks). Existing saved single keys are migrated to all networks on load until you save again.
 - Features Specification (`docs/FEATURES_SPECIFICATION.md`): canonical catalog of every user-facing explorer feature with unique `FEAT-*` identifiers, test coverage map (Appendix B), and prioritized coverage gaps (Appendix C)
 - `AGENTS.md`: regression prevention rules requiring agents to reference `docs/FEATURES_SPECIFICATION.md` when adding, modifying, or removing features and to keep the spec in sync with the codebase
 - Behavioral tests for 25+ spec features covering search, transactions, accounts, validators, coins, tokens, network config, rate limiting, analytics, wallet, modules, SEO, and more — see `docs/FEATURES_SPECIFICATION.md` Appendix B for the full list

--- a/app/api/createClient.ts
+++ b/app/api/createClient.ts
@@ -62,7 +62,10 @@ export function createAptosClient(
   const apiKey =
     typeof window === "undefined"
       ? getServerApiKey(networkName)
-      : getApiKey(networkName, apiKeyOverride ?? getGeomiDevApiKeyOverride());
+      : getApiKey(
+          networkName,
+          apiKeyOverride ?? getGeomiDevApiKeyOverride(networkName),
+        );
   const indexerUri = getGraphqlURI(networkName);
 
   // Map network name to SDK Network enum
@@ -113,7 +116,9 @@ export function clearCachedSearchClients() {
  */
 export function getCachedClient(networkName: NetworkName): Aptos {
   const apiKeyOverride =
-    typeof window === "undefined" ? undefined : getGeomiDevApiKeyOverride();
+    typeof window === "undefined"
+      ? undefined
+      : getGeomiDevApiKeyOverride(networkName);
   const cacheKey = getClientCacheKey(networkName, apiKeyOverride);
 
   if (!clientCache.has(cacheKey)) {

--- a/app/components/layout/SettingsDialog.tsx
+++ b/app/components/layout/SettingsDialog.tsx
@@ -23,12 +23,41 @@ import {useEffect, useMemo, useRef, useState} from "react";
 import {clearCachedSearchClients} from "../../api/createClient";
 import {emitApiKeySaved} from "../../context/rate-limit";
 import {clearCachedV2Clients} from "../../global-config";
+import {networks, type NetworkName} from "../../lib/constants";
 import {
   defaultExplorerClientSettings,
   type ExplorerClientSettings,
   normalizeGeomiDevApiKeyOverride,
+  sanitizeExplorerClientSettings,
   useExplorerSettings,
 } from "../../settings";
+
+const SETTINGS_NETWORKS = Object.keys(networks) as NetworkName[];
+
+function networkLabel(name: NetworkName): string {
+  if (name === "local") {
+    return "Local";
+  }
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function settingsEqual(
+  a: ExplorerClientSettings,
+  b: ExplorerClientSettings,
+): boolean {
+  return (
+    JSON.stringify(sanitizeExplorerClientSettings(a)) ===
+    JSON.stringify(sanitizeExplorerClientSettings(b))
+  );
+}
+
+function hasAnyOverride(settings: ExplorerClientSettings): boolean {
+  return (
+    Object.keys(
+      sanitizeExplorerClientSettings(settings).geomiDevApiKeyOverridesByNetwork,
+    ).length > 0
+  );
+}
 
 type SettingsDialogProps = {
   onClose: () => void;
@@ -42,23 +71,19 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
   const [draftSettings, setDraftSettings] =
     useState<ExplorerClientSettings>(settings);
   const [isSaving, setIsSaving] = useState(false);
-  const [showGeomiDevApiKey, setShowGeomiDevApiKey] = useState(false);
+  const [showApiKeys, setShowApiKeys] = useState(false);
   const wasOpenRef = useRef(open);
 
   useEffect(() => {
     if (open && !wasOpenRef.current) {
       setDraftSettings(settings);
-      setShowGeomiDevApiKey(false);
+      setShowApiKeys(false);
     }
     wasOpenRef.current = open;
   }, [open, settings]);
 
   const hasChanges = useMemo(
-    () =>
-      normalizeGeomiDevApiKeyOverride(draftSettings.geomiDevApiKeyOverride) !==
-        settings.geomiDevApiKeyOverride ||
-      draftSettings.rememberGeomiDevApiKeyOverride !==
-        settings.rememberGeomiDevApiKeyOverride,
+    () => !settingsEqual(draftSettings, settings),
     [draftSettings, settings],
   );
 
@@ -71,9 +96,7 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
     setIsSaving(true);
 
     try {
-      const hasApiKey =
-        normalizeGeomiDevApiKeyOverride(draftSettings.geomiDevApiKeyOverride)
-          .length > 0;
+      const hasApiKey = hasAnyOverride(draftSettings);
       setExplorerSettings(draftSettings);
       if (hasApiKey) {
         emitApiKeySaved();
@@ -86,6 +109,22 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
     } finally {
       setIsSaving(false);
     }
+  };
+
+  const updateOverride = (network: NetworkName, value: string) => {
+    setDraftSettings((current) => {
+      const next = {...current.geomiDevApiKeyOverridesByNetwork};
+      const trimmed = normalizeGeomiDevApiKeyOverride(value);
+      if (trimmed) {
+        next[network] = value;
+      } else {
+        delete next[network];
+      }
+      return {
+        ...current,
+        geomiDevApiKeyOverridesByNetwork: next,
+      };
+    });
   };
 
   return (
@@ -103,49 +142,51 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
               API overrides
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Used only in your browser. By default the override is stored for
-              the current browser session and cleared when the session ends.
+              Optional geomi.dev API keys per network. Used only in your
+              browser. Leave a network empty to use the default key from the
+              build (if any). By default, overrides are stored for the current
+              browser session and cleared when the session ends.
             </Typography>
           </Box>
 
-          <TextField
-            autoComplete="off"
-            fullWidth
-            label="geomi.dev API key override"
-            onChange={(event) =>
-              setDraftSettings((currentSettings) => ({
-                ...currentSettings,
-                geomiDevApiKeyOverride: event.target.value,
-              }))
-            }
-            placeholder="Paste your geomi.dev API key"
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      aria-label={
-                        showGeomiDevApiKey ? "Hide API key" : "Show API key"
-                      }
-                      edge="end"
-                      onClick={() => setShowGeomiDevApiKey((value) => !value)}
-                    >
-                      {showGeomiDevApiKey ? (
-                        <VisibilityOffIcon />
-                      ) : (
-                        <VisibilityIcon />
-                      )}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              },
-              htmlInput: {
-                spellCheck: false,
-              },
-            }}
-            type={showGeomiDevApiKey ? "text" : "password"}
-            value={draftSettings.geomiDevApiKeyOverride}
-          />
+          {SETTINGS_NETWORKS.map((network) => (
+            <TextField
+              key={network}
+              autoComplete="off"
+              fullWidth
+              label={`${networkLabel(network)} API key`}
+              onChange={(event) => updateOverride(network, event.target.value)}
+              placeholder={`Paste key for ${networkLabel(network)} (optional)`}
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label={
+                          showApiKeys ? "Hide API keys" : "Show API keys"
+                        }
+                        edge="end"
+                        onClick={() => setShowApiKeys((value) => !value)}
+                      >
+                        {showApiKeys ? (
+                          <VisibilityOffIcon />
+                        ) : (
+                          <VisibilityIcon />
+                        )}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+                htmlInput: {
+                  spellCheck: false,
+                },
+              }}
+              type={showApiKeys ? "text" : "password"}
+              value={
+                draftSettings.geomiDevApiKeyOverridesByNetwork[network] ?? ""
+              }
+            />
+          ))}
 
           <Typography variant="body2" color="text.secondary">
             Don&apos;t have a key?{" "}
@@ -174,20 +215,20 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
           />
 
           <Alert severity="warning">
-            Remembering the key stores it in this browser&apos;s local storage.
+            Remembering keys stores them in this browser&apos;s local storage.
             Avoid enabling this on shared or untrusted devices.
           </Alert>
 
           <Alert severity="info">
-            This key is not stored by the explorer application server. Your
-            browser uses it only for client-side API requests. For best
-            security, use a client key with only the origin{" "}
+            Keys are not stored by the explorer application server. Your browser
+            uses them only for client-side API requests. For best security, use
+            client keys with only the origin{" "}
             <code>https://explorer.aptoslabs.com</code> enabled and enforced.
           </Alert>
 
           <Alert severity="info">
             Existing data will refresh after save so new requests use the
-            updated key immediately.
+            updated keys immediately.
           </Alert>
         </Stack>
       </DialogContent>
@@ -197,7 +238,7 @@ export default function SettingsDialog({onClose, open}: SettingsDialogProps) {
         </Button>
         <Button
           onClick={() => setDraftSettings(defaultExplorerClientSettings)}
-          disabled={isSaving || !draftSettings.geomiDevApiKeyOverride}
+          disabled={isSaving || !hasAnyOverride(draftSettings)}
         >
           Clear
         </Button>

--- a/app/global-config/GlobalConfig.tsx
+++ b/app/global-config/GlobalConfig.tsx
@@ -165,7 +165,7 @@ export function useNetworkValue(): string {
 // Create Aptos clients
 function createAptosClient(
   networkName: NetworkName,
-  apiKeyOverride = getGeomiDevApiKeyOverride(),
+  apiKeyOverride?: string,
 ): AptosClient {
   const nodeUrl = networks[networkName];
   const apiKey = getApiKey(networkName, apiKeyOverride);
@@ -178,7 +178,7 @@ function createAptosClient(
 
 function createAptosV2Client(
   networkName: NetworkName,
-  apiKeyOverride = getGeomiDevApiKeyOverride(),
+  apiKeyOverride?: string,
 ): Aptos {
   const nodeUrl = networks[networkName];
   const apiKey = getApiKey(networkName, apiKeyOverride);
@@ -229,7 +229,7 @@ export function clearCachedV2Clients() {
 
 export function getCachedV2Client(
   networkName: NetworkName,
-  apiKeyOverride = getGeomiDevApiKeyOverride(),
+  apiKeyOverride = getGeomiDevApiKeyOverride(networkName),
 ): Aptos {
   const cacheKey = getClientCacheKey(networkName, apiKeyOverride);
   const existing = clientCache.get(cacheKey);
@@ -243,24 +243,26 @@ export function getCachedV2Client(
 export function useAptosClient(): AptosClient {
   const networkName = useNetworkName();
   const {
-    settings: {geomiDevApiKeyOverride},
+    settings: {geomiDevApiKeyOverridesByNetwork},
   } = useExplorerSettings();
+  const apiKeyOverride = geomiDevApiKeyOverridesByNetwork[networkName];
 
   return useMemo(
-    () => createAptosClient(networkName, geomiDevApiKeyOverride),
-    [networkName, geomiDevApiKeyOverride],
+    () => createAptosClient(networkName, apiKeyOverride),
+    [networkName, apiKeyOverride],
   );
 }
 
 export function useAptosClientV2(): Aptos {
   const networkName = useNetworkName();
   const {
-    settings: {geomiDevApiKeyOverride},
+    settings: {geomiDevApiKeyOverridesByNetwork},
   } = useExplorerSettings();
+  const apiKeyOverride = geomiDevApiKeyOverridesByNetwork[networkName];
 
   return useMemo(
-    () => getCachedV2Client(networkName, geomiDevApiKeyOverride),
-    [networkName, geomiDevApiKeyOverride],
+    () => getCachedV2Client(networkName, apiKeyOverride),
+    [networkName, apiKeyOverride],
   );
 }
 
@@ -279,11 +281,12 @@ export function useGlobalState(): GlobalState {
   const networkName = useNetworkName();
   const networkValue = networks[networkName];
   const {
-    settings: {geomiDevApiKeyOverride},
+    settings: {geomiDevApiKeyOverridesByNetwork},
   } = useExplorerSettings();
+  const apiKeyOverride = geomiDevApiKeyOverridesByNetwork[networkName];
   const sdk_v2_client = useMemo(
-    () => getCachedV2Client(networkName, geomiDevApiKeyOverride),
-    [networkName, geomiDevApiKeyOverride],
+    () => getCachedV2Client(networkName, apiKeyOverride),
+    [networkName, apiKeyOverride],
   );
 
   return useMemo(

--- a/app/settings/ExplorerSettings.tsx
+++ b/app/settings/ExplorerSettings.tsx
@@ -52,7 +52,9 @@ export function ExplorerSettingsProvider({children}: {children: ReactNode}) {
 
   const setExplorerSettings = useCallback((value: ExplorerClientSettings) => {
     const nextSettings = sanitizeExplorerClientSettings(value);
-    if (!nextSettings.geomiDevApiKeyOverride) {
+    if (
+      Object.keys(nextSettings.geomiDevApiKeyOverridesByNetwork).length === 0
+    ) {
       clearExplorerClientSettings();
     } else {
       persistExplorerClientSettings(nextSettings);

--- a/app/settings/clientSettings.test.ts
+++ b/app/settings/clientSettings.test.ts
@@ -59,25 +59,60 @@ describe("clientSettings", () => {
   });
 
   describe("sanitizeExplorerClientSettings", () => {
-    it("normalizes the geomi override value", () => {
+    it("normalizes per-network override values", () => {
       expect(
         sanitizeExplorerClientSettings({
-          geomiDevApiKeyOverride: "  override-key  ",
+          geomiDevApiKeyOverridesByNetwork: {
+            mainnet: "  override-key  ",
+            testnet: "",
+          },
           rememberGeomiDevApiKeyOverride: true,
         }),
       ).toEqual({
-        geomiDevApiKeyOverride: "override-key",
+        geomiDevApiKeyOverridesByNetwork: {mainnet: "override-key"},
         rememberGeomiDevApiKeyOverride: true,
       });
     });
 
-    it("forces remember to false when the key is empty", () => {
+    it("forces remember to false when no keys are set", () => {
       expect(
         sanitizeExplorerClientSettings({
-          geomiDevApiKeyOverride: "   ",
+          geomiDevApiKeyOverridesByNetwork: {},
           rememberGeomiDevApiKeyOverride: true,
         }),
       ).toEqual(defaultExplorerClientSettings);
+    });
+
+    it("migrates legacy single key to all networks", () => {
+      expect(
+        sanitizeExplorerClientSettings({
+          geomiDevApiKeyOverride: "  legacy  ",
+          rememberGeomiDevApiKeyOverride: true,
+        }),
+      ).toEqual({
+        geomiDevApiKeyOverridesByNetwork: {
+          mainnet: "legacy",
+          testnet: "legacy",
+          devnet: "legacy",
+          decibel: "legacy",
+          shelbynet: "legacy",
+          local: "legacy",
+        },
+        rememberGeomiDevApiKeyOverride: true,
+      });
+    });
+
+    it("does not use legacy key when per-network map is present", () => {
+      expect(
+        sanitizeExplorerClientSettings({
+          geomiDevApiKeyOverride: "ignored",
+          geomiDevApiKeyOverridesByNetwork: {mainnet: "only-main"},
+          rememberGeomiDevApiKeyOverride: true,
+        }),
+      ).toEqual({
+        geomiDevApiKeyOverridesByNetwork: {mainnet: "only-main"},
+        rememberGeomiDevApiKeyOverride: true,
+      });
     });
 
     it("falls back to the default settings shape", () => {
@@ -98,16 +133,16 @@ describe("clientSettings", () => {
     it("prefers session settings over local settings", () => {
       const storages = createStorageCollection({
         localValue: JSON.stringify({
-          geomiDevApiKeyOverride: "local-key",
+          geomiDevApiKeyOverridesByNetwork: {mainnet: "local-key"},
           rememberGeomiDevApiKeyOverride: true,
         }),
         sessionValue: JSON.stringify({
-          geomiDevApiKeyOverride: "  session-key  ",
+          geomiDevApiKeyOverridesByNetwork: {testnet: "  session-key  "},
         }),
       });
 
       expect(loadExplorerClientSettings(storages)).toEqual({
-        geomiDevApiKeyOverride: "session-key",
+        geomiDevApiKeyOverridesByNetwork: {testnet: "session-key"},
         rememberGeomiDevApiKeyOverride: false,
       });
     });
@@ -115,14 +150,28 @@ describe("clientSettings", () => {
     it("reads and sanitizes remembered local settings", () => {
       const storages = createStorageCollection({
         localValue: JSON.stringify({
-          geomiDevApiKeyOverride: "  saved-key  ",
+          geomiDevApiKeyOverridesByNetwork: {devnet: "  saved-key  "},
         }),
       });
 
       expect(loadExplorerClientSettings(storages)).toEqual({
-        geomiDevApiKeyOverride: "saved-key",
+        geomiDevApiKeyOverridesByNetwork: {devnet: "saved-key"},
         rememberGeomiDevApiKeyOverride: true,
       });
+    });
+
+    it("migrates legacy persisted shape on load", () => {
+      const storages = createStorageCollection({
+        localValue: JSON.stringify({
+          geomiDevApiKeyOverride: "one-key",
+          rememberGeomiDevApiKeyOverride: true,
+        }),
+      });
+
+      const loaded = loadExplorerClientSettings(storages);
+      expect(loaded.geomiDevApiKeyOverridesByNetwork.mainnet).toBe("one-key");
+      expect(loaded.geomiDevApiKeyOverridesByNetwork.local).toBe("one-key");
+      expect(loaded.rememberGeomiDevApiKeyOverride).toBe(true);
     });
   });
 
@@ -132,14 +181,14 @@ describe("clientSettings", () => {
 
       persistExplorerClientSettings(
         {
-          geomiDevApiKeyOverride: "  persisted-key  ",
+          geomiDevApiKeyOverridesByNetwork: {mainnet: "  persisted-key  "},
           rememberGeomiDevApiKeyOverride: false,
         },
         storages,
       );
 
       expect(loadExplorerClientSettings(storages)).toEqual({
-        geomiDevApiKeyOverride: "persisted-key",
+        geomiDevApiKeyOverridesByNetwork: {mainnet: "persisted-key"},
         rememberGeomiDevApiKeyOverride: false,
       });
     });
@@ -149,31 +198,31 @@ describe("clientSettings", () => {
 
       persistExplorerClientSettings(
         {
-          geomiDevApiKeyOverride: "persisted-key",
+          geomiDevApiKeyOverridesByNetwork: {testnet: "persisted-key"},
           rememberGeomiDevApiKeyOverride: true,
         },
         storages,
       );
 
       expect(loadExplorerClientSettings(storages)).toEqual({
-        geomiDevApiKeyOverride: "persisted-key",
+        geomiDevApiKeyOverridesByNetwork: {testnet: "persisted-key"},
         rememberGeomiDevApiKeyOverride: true,
       });
     });
 
-    it("clears stored settings when the key is emptied", () => {
+    it("clears stored settings when all keys are emptied", () => {
       const storages = createStorageCollection({
         localValue: JSON.stringify({
-          geomiDevApiKeyOverride: "persisted-key",
+          geomiDevApiKeyOverridesByNetwork: {mainnet: "persisted-key"},
         }),
         sessionValue: JSON.stringify({
-          geomiDevApiKeyOverride: "session-key",
+          geomiDevApiKeyOverridesByNetwork: {testnet: "session-key"},
         }),
       });
 
       persistExplorerClientSettings(
         {
-          geomiDevApiKeyOverride: "",
+          geomiDevApiKeyOverridesByNetwork: {},
           rememberGeomiDevApiKeyOverride: false,
         },
         storages,
@@ -187,10 +236,10 @@ describe("clientSettings", () => {
     it("clears keys from both local and session storage", () => {
       const storages = createStorageCollection({
         localValue: JSON.stringify({
-          geomiDevApiKeyOverride: "persisted-key",
+          geomiDevApiKeyOverridesByNetwork: {mainnet: "persisted-key"},
         }),
         sessionValue: JSON.stringify({
-          geomiDevApiKeyOverride: "session-key",
+          geomiDevApiKeyOverridesByNetwork: {testnet: "session-key"},
         }),
       });
 
@@ -207,7 +256,7 @@ describe("clientSettings", () => {
       expect(() =>
         persistExplorerClientSettings(
           {
-            geomiDevApiKeyOverride: "persisted-key",
+            geomiDevApiKeyOverridesByNetwork: {mainnet: "persisted-key"},
             rememberGeomiDevApiKeyOverride: true,
           },
           storages,

--- a/app/settings/clientSettings.ts
+++ b/app/settings/clientSettings.ts
@@ -1,12 +1,21 @@
+import {networks, type NetworkName} from "../lib/constants";
+
+/** Per-network geomi.dev API key overrides (trimmed non-empty strings only). */
+export type GeomiDevApiKeyOverridesByNetwork = Partial<
+  Record<NetworkName, string>
+>;
+
 export interface ExplorerClientSettings {
-  geomiDevApiKeyOverride: string;
+  geomiDevApiKeyOverridesByNetwork: GeomiDevApiKeyOverridesByNetwork;
   rememberGeomiDevApiKeyOverride: boolean;
 }
 
 export const EXPLORER_SETTINGS_STORAGE_KEY = "aptos-explorer-settings";
 
+const ALL_NETWORK_NAMES = Object.keys(networks) as NetworkName[];
+
 export const defaultExplorerClientSettings: ExplorerClientSettings = {
-  geomiDevApiKeyOverride: "",
+  geomiDevApiKeyOverridesByNetwork: {},
   rememberGeomiDevApiKeyOverride: false,
 };
 
@@ -58,26 +67,87 @@ export function normalizeGeomiDevApiKeyOverride(
   return value?.trim() ?? "";
 }
 
+function sanitizeOverrides(value: unknown): GeomiDevApiKeyOverridesByNetwork {
+  const out: GeomiDevApiKeyOverridesByNetwork = {};
+  if (!value || typeof value !== "object") {
+    return out;
+  }
+
+  const raw = value as Record<string, unknown>;
+  for (const network of ALL_NETWORK_NAMES) {
+    const entry = raw[network];
+    const trimmed = normalizeGeomiDevApiKeyOverride(
+      typeof entry === "string" ? entry : "",
+    );
+    if (trimmed) {
+      out[network] = trimmed;
+    }
+  }
+  return out;
+}
+
+function hasStoredPerNetworkOverrides(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const raw = (value as {geomiDevApiKeyOverridesByNetwork?: unknown})
+    .geomiDevApiKeyOverridesByNetwork;
+  return typeof raw === "object" && raw !== null && Object.keys(raw).length > 0;
+}
+
+function migrateLegacySingleKey(
+  legacyKey: string,
+): GeomiDevApiKeyOverridesByNetwork {
+  const out: GeomiDevApiKeyOverridesByNetwork = {};
+  for (const network of ALL_NETWORK_NAMES) {
+    out[network] = legacyKey;
+  }
+  return out;
+}
+
+function hasAnyApiKeyOverride(
+  overrides: GeomiDevApiKeyOverridesByNetwork,
+): boolean {
+  return Object.keys(overrides).length > 0;
+}
+
 export function sanitizeExplorerClientSettings(
-  value: Partial<ExplorerClientSettings> | null | undefined,
+  value:
+    | (Partial<ExplorerClientSettings> & {
+        geomiDevApiKeyOverride?: string;
+      })
+    | null
+    | undefined,
 ): ExplorerClientSettings {
-  const geomiDevApiKeyOverride = normalizeGeomiDevApiKeyOverride(
+  let geomiDevApiKeyOverridesByNetwork = sanitizeOverrides(
+    value?.geomiDevApiKeyOverridesByNetwork,
+  );
+
+  const legacyKey = normalizeGeomiDevApiKeyOverride(
     value?.geomiDevApiKeyOverride,
   );
 
+  if (!hasStoredPerNetworkOverrides(value) && legacyKey.length > 0) {
+    geomiDevApiKeyOverridesByNetwork = migrateLegacySingleKey(legacyKey);
+  }
+
+  const rememberGeomiDevApiKeyOverride =
+    hasAnyApiKeyOverride(geomiDevApiKeyOverridesByNetwork) &&
+    normalizeRememberGeomiDevApiKeyOverride(
+      value?.rememberGeomiDevApiKeyOverride,
+    );
+
   return {
-    geomiDevApiKeyOverride,
-    rememberGeomiDevApiKeyOverride:
-      geomiDevApiKeyOverride.length > 0 &&
-      normalizeRememberGeomiDevApiKeyOverride(
-        value?.rememberGeomiDevApiKeyOverride,
-      ),
+    geomiDevApiKeyOverridesByNetwork,
+    rememberGeomiDevApiKeyOverride,
   };
 }
 
 function loadStoredExplorerClientSettings(
   storage: StorageLike | null,
-): Partial<ExplorerClientSettings> | null {
+):
+  | (Partial<ExplorerClientSettings> & {geomiDevApiKeyOverride?: string})
+  | null {
   if (!storage) {
     return null;
   }
@@ -88,7 +158,9 @@ function loadStoredExplorerClientSettings(
       return null;
     }
 
-    return JSON.parse(rawSettings) as Partial<ExplorerClientSettings>;
+    return JSON.parse(rawSettings) as Partial<ExplorerClientSettings> & {
+      geomiDevApiKeyOverride?: string;
+    };
   } catch {
     return null;
   }
@@ -141,7 +213,9 @@ export function persistExplorerClientSettings(
   const sanitizedSettings = sanitizeExplorerClientSettings(settings);
   clearExplorerClientSettings(storages);
 
-  if (!sanitizedSettings.geomiDevApiKeyOverride) {
+  if (
+    !hasAnyApiKeyOverride(sanitizedSettings.geomiDevApiKeyOverridesByNetwork)
+  ) {
     return;
   }
 
@@ -163,7 +237,10 @@ export function persistExplorerClientSettings(
   }
 }
 
-export function getGeomiDevApiKeyOverride(): string | undefined {
-  const apiKeyOverride = loadExplorerClientSettings().geomiDevApiKeyOverride;
-  return apiKeyOverride || undefined;
+export function getGeomiDevApiKeyOverride(
+  networkName: NetworkName,
+): string | undefined {
+  const key =
+    loadExplorerClientSettings().geomiDevApiKeyOverridesByNetwork[networkName];
+  return key || undefined;
 }

--- a/app/settings/index.ts
+++ b/app/settings/index.ts
@@ -2,6 +2,7 @@ export {
   defaultExplorerClientSettings,
   EXPLORER_SETTINGS_STORAGE_KEY,
   type ExplorerClientSettings,
+  type GeomiDevApiKeyOverridesByNetwork,
   getGeomiDevApiKeyOverride,
   loadExplorerClientSettings,
   normalizeGeomiDevApiKeyOverride,

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -791,7 +791,8 @@ The app shell that wraps every page.
 
 | Aspect | Detail |
 |--------|--------|
-| **API key override** | Masked input for geomi.dev API key with show/hide toggle. |
+| **API key overrides** | One optional masked geomi.dev API key field per network (mainnet, testnet, devnet, decibel, shelbynet, local); shared show/hide toggle for all fields. Empty network uses the build default key (if any). |
+| **Migration** | Previously saved single-key settings load as the same key applied to every network until the user saves again. |
 | **Persistence** | "Remember on this device" → localStorage, cross-tab sync via `storage` events. |
 | **On save** | Clears cached SDK clients (`clearCachedV2Clients`, `clearCachedSearchClients`), invalidates all React Query queries, invalidates router. If non-empty API key saved, fires `emitApiKeySaved()` to dismiss rate-limit drawer (see FEAT-RATELIMIT-001). |
 | **External trigger** | Can be opened programmatically via `emitOpenSettings()` (used by Rate Limit Drawer). |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings now supports **optional geomi.dev API keys per network** (mainnet, testnet, devnet, decibel, shelbynet, local). Empty fields fall back to the build’s default `VITE_APTOS_*_API_KEY` for that network when present.

## Migration

JSON stored under `aptos-explorer-settings` that used the legacy single `geomiDevApiKeyOverride` field is **migrated on load**: the same key is applied to every network until the user saves again (then the new per-network shape is persisted).

## Implementation notes

- `ExplorerClientSettings.geomiDevApiKeyOverridesByNetwork` replaces the single string field.
- `getGeomiDevApiKeyOverride(networkName)` resolves the override for loaders and cached clients.
- Client cache keys remain per `(network, override)` so switching networks or overrides still behaves correctly.

## Testing

- `pnpm fmt && pnpm lint && pnpm test --run`

## Docs

- `docs/FEATURES_SPECIFICATION.md` (FEAT-SETTINGS-001)
- `CHANGELOG.md` under [Unreleased]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bb08860-5a4a-456c-a68d-47a3a9736363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bb08860-5a4a-456c-a68d-47a3a9736363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

