### PR TITLE
Settings: info icon explaining custom Geomi API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **Settings**: API Key Overrides section includes an info icon with a short explanation of why to use your own geomi.dev key (dedicated rate limits) and a link to geomi.dev
 - Rate-limit drawer is now non-blocking (persistent banner instead of modal overlay) so users can still interact with the page, settings, and navigation while the notice is visible
 - Saving an API key in Settings automatically dismisses the rate-limit drawer and suppresses re-triggering for 10 seconds, preventing stale in-flight 429 responses from immediately re-showing the drawer
 

--- a/app/pages/Settings/SettingsPage.tsx
+++ b/app/pages/Settings/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
@@ -13,6 +14,7 @@ import {
   InputAdornment,
   Link as MuiLink,
   Paper,
+  Popover,
   Stack,
   Switch,
   TextField,
@@ -72,6 +74,9 @@ export default function SettingsPage() {
     useState<ExplorerClientSettings>(settings);
   const [isSaving, setIsSaving] = useState(false);
   const [showApiKeys, setShowApiKeys] = useState(false);
+  const [apiKeyInfoAnchor, setApiKeyInfoAnchor] = useState<HTMLElement | null>(
+    null,
+  );
   const initialSettingsRef = useRef(settings);
 
   useEffect(() => {
@@ -227,9 +232,54 @@ export default function SettingsPage() {
           <Paper variant="outlined" sx={{p: 3}}>
             <Stack spacing={2.5}>
               <Box>
-                <Typography variant="h6" fontWeight={600}>
-                  API Key Overrides
-                </Typography>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Typography variant="h6" fontWeight={600} component="span">
+                    API Key Overrides
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    aria-label="Why use your own API key?"
+                    aria-expanded={Boolean(apiKeyInfoAnchor)}
+                    aria-haspopup="true"
+                    onClick={(event) =>
+                      setApiKeyInfoAnchor(
+                        apiKeyInfoAnchor ? null : event.currentTarget,
+                      )
+                    }
+                    sx={{color: "text.secondary"}}
+                  >
+                    <InfoOutlinedIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+                <Popover
+                  open={Boolean(apiKeyInfoAnchor)}
+                  anchorEl={apiKeyInfoAnchor}
+                  onClose={() => setApiKeyInfoAnchor(null)}
+                  anchorOrigin={{vertical: "bottom", horizontal: "left"}}
+                  transformOrigin={{vertical: "top", horizontal: "left"}}
+                  slotProps={{
+                    paper: {
+                      sx: {maxWidth: 360, p: 2},
+                    },
+                  }}
+                >
+                  <Typography variant="body2" sx={{mb: 1.5}}>
+                    The explorer uses a shared geomi.dev API key by default.
+                    Adding your own key gives you a dedicated rate limit, which
+                    helps if you browse heavily or hit HTTP 429 responses.
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Create and manage keys at{" "}
+                    <MuiLink
+                      href="https://geomi.dev"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      geomi.dev
+                    </MuiLink>
+                    .
+                  </Typography>
+                </Popover>
                 <Typography
                   variant="body2"
                   color="text.secondary"

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -793,7 +793,7 @@ The app shell that wraps every page.
 |--------|--------|
 | **Route** | `/settings` — dedicated full-page settings (replaced the former header popup dialog). |
 | **Navigation** | Header gear icon and mobile nav "Settings" item link to `/settings`. Rate Limit Drawer "Set API key override" button also links there. |
-| **API key overrides** | One optional masked geomi.dev API key field per network (mainnet, testnet, devnet, decibel, shelbynet, local); shared show/hide toggle for all fields. Empty network uses the build default key (if any). |
+| **API key overrides** | One optional masked geomi.dev API key field per network (mainnet, testnet, devnet, decibel, shelbynet, local); shared show/hide toggle for all fields. Empty network uses the build default key (if any). An info icon next to the section title opens a popover explaining that a personal key provides a dedicated rate limit (useful for heavy use or after HTTP 429) and links to geomi.dev. |
 | **Migration** | Previously saved single-key settings load as the same key applied to every network until the user saves again. |
 | **Persistence** | "Remember on this device" → localStorage, cross-tab sync via `storage` events. Non-API-key preferences (e.g. decompilation) persist to localStorage. |
 | **On save** | Clears cached SDK clients (`clearCachedV2Clients`, `clearCachedSearchClients`), invalidates all React Query queries, invalidates router. If non-empty API key saved, fires `emitApiKeySaved()` to dismiss rate-limit drawer (see FEAT-RATELIMIT-001). |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses review feedback: the Settings page **API Key Overrides** section now has an **info icon** next to the heading. Clicking it opens a **popover** that explains why developers add their own [geomi.dev](https://geomi.dev) key (dedicated rate limits vs the shared default key, helpful for heavy use or HTTP 429) and links to geomi.dev for key management.

## Changes

- `app/pages/Settings/SettingsPage.tsx` — info `IconButton` + `Popover` with accessible label (`aria-label`, `aria-expanded`, `aria-haspopup`)
- `docs/FEATURES_SPECIFICATION.md` — **FEAT-SETTINGS-001** updated to describe the info popover
- `CHANGELOG.md` — **[Unreleased] → Improved** entry

## Testing

- `pnpm fmt` / `pnpm lint` (pass; pre-existing biome infos/warnings in other files unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-680eae16-9b46-4bec-97fa-2b802fcd282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-680eae16-9b46-4bec-97fa-2b802fcd282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

