### PR TITLE
fix(account): show Assets tab filters when indexer returns no rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Account Assets tab**: verification filters and “Show Zero Balance” now appear even when the indexer returns no fungible-asset rows (previously the tab showed only “No Data Found” and hid those controls). An info note clarifies that the sidebar APT balance can still come from on-chain coin state.
 - **Coins page** (`/coins`): changing verification filters or the Emojicoins toggle no longer freezes the tab when thousands of assets match — the table virtualizes rows via an on-demand `renderRow` path and scrolls inside a bounded-height container instead of allocating every row up front
 - **Dev mode**: `useFeatureName()` now reads from a `feature_name` cookie or the `VITE_FEATURE_NAME` env var instead of always returning `"prod"` — the Development Mode banner, Early Development Mode banner, and dev-only UI (e.g. Aptos Names banner) are functional again
 - **SSR dev server**: removed duplicate `tanstackRouter()` plugin from `vite.config.ts` — it conflicted with the code-splitting plugins already bundled inside `tanstackStart()`, causing `ReferenceError: TSRSplitComponent is not defined` on every SSR request during `pnpm dev`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Account Assets tab**: verification filters and “Show Zero Balance” now appear even when the indexer returns no fungible-asset rows (previously the tab showed only “No Data Found” and hid those controls). An info note clarifies that the sidebar APT balance can still come from on-chain coin state.
+- **Account Assets tab**: when native APT exists in `0x1::coin` but the indexer omits it (or returns an APT row without metadata), the explorer merges the on-chain `coin::balance` amount so APT shows in the Assets table alongside indexer-backed fungible assets.
 - **Coins page** (`/coins`): changing verification filters or the Emojicoins toggle no longer freezes the tab when thousands of assets match — the table virtualizes rows via an on-demand `renderRow` path and scrolls inside a bounded-height container instead of allocating every row up front
 - **Dev mode**: `useFeatureName()` now reads from a `feature_name` cookie or the `VITE_FEATURE_NAME` env var instead of always returning `"prod"` — the Development Mode banner, Early Development Mode banner, and dev-only UI (e.g. Aptos Names banner) are functional again
 - **SSR dev server**: removed duplicate `tanstackRouter()` plugin from `vite.config.ts` — it conflicted with the code-splitting plugins already bundled inside `tanstackStart()`, causing `ReferenceError: TSRSplitComponent is not defined` on every SSR request during `pnpm dev`

--- a/app/pages/Account/Components/CoinsTable.tsx
+++ b/app/pages/Account/Components/CoinsTable.tsx
@@ -1,5 +1,6 @@
 import {Network} from "@aptos-labs/ts-sdk";
 import {
+  Alert,
   Box,
   Button,
   FormControlLabel,
@@ -300,7 +301,16 @@ function CoinCard({
   );
 }
 
-export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
+type CoinsTableProps = {
+  coins: CoinDescriptionPlusAmount[];
+  /** True when the indexer returned zero balance rows (sidebar APT may still show via on-chain coin view). */
+  indexerReturnedNoRows?: boolean;
+};
+
+export function CoinsTable({
+  coins,
+  indexerReturnedNoRows = false,
+}: CoinsTableProps) {
   const theme = useTheme();
   const networkName = useNetworkName();
   const [verificationFilter, setVerificationFilter] = React.useState(
@@ -419,6 +429,14 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
     theme.palette.mode === "dark"
       ? theme.palette.neutralShade.lighter
       : theme.palette.neutralShade.darker;
+
+  const indexerEmptyHint = indexerReturnedNoRows ? (
+    <Alert severity="info" sx={{mb: 1}}>
+      The indexer has no fungible asset balance rows for this account yet. The
+      APT total in the balance card uses on-chain coin state and can differ from
+      what appears here.
+    </Alert>
+  ) : null;
 
   const filterSelector = (
     <Stack
@@ -569,6 +587,7 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
   if (isMobile) {
     return (
       <>
+        {indexerEmptyHint}
         {filterSelector}
         <Box>
           {filteredCoins.length > 0 ? (
@@ -596,6 +615,7 @@ export function CoinsTable({coins}: {coins: CoinDescriptionPlusAmount[]}) {
   // Desktop table view
   return (
     <>
+      {indexerEmptyHint}
       {filterSelector}
       <Box sx={{overflowX: "auto"}}>
         <Table aria-label="Account coins" data-entity-type="coin">

--- a/app/pages/Account/Tabs/CoinsTab.tsx
+++ b/app/pages/Account/Tabs/CoinsTab.tsx
@@ -1,9 +1,14 @@
 import type {Types} from "~/types/aptos";
 import {useGetAllAccountCoins} from "../../../api/hooks/useGetAccountCoins";
+import {useGetAccountAPTBalance} from "../../../api/hooks/useGetAccountAPTBalance";
 import {
   type CoinDescription,
   useGetCoinList,
 } from "../../../api/hooks/useGetCoinList";
+import {
+  type FaBalanceRow,
+  mergeOnChainAptIntoIndexerRows,
+} from "../accountCoinsMerge";
 import {findCoinData} from "../../Transaction/utils";
 import {coinOrderIndex} from "../../utils";
 import {
@@ -19,9 +24,11 @@ type TokenTabsProps = {
 export default function CoinsTab({address}: TokenTabsProps) {
   const {data: coinData} = useGetCoinList();
 
-  const {isLoading, error, data} = useGetAllAccountCoins(address);
+  const {isLoading: coinsLoading, error, data} = useGetAllAccountCoins(address);
+  const {data: aptBalance, isLoading: aptLoading} =
+    useGetAccountAPTBalance(address);
 
-  if (isLoading) {
+  if (coinsLoading || aptLoading) {
     return null;
   }
 
@@ -30,14 +37,20 @@ export default function CoinsTab({address}: TokenTabsProps) {
     return null;
   }
 
-  const rawCoins = data ?? [];
+  const rawCoins = mergeOnChainAptIntoIndexerRows(data ?? [], aptBalance);
 
   function parse_coins(): CoinDescriptionPlusAmount[] {
     if (!rawCoins || rawCoins.length <= 0) {
       return [];
     }
     return rawCoins
-      .filter((coin) => Boolean(coin.metadata))
+      .filter(
+        (
+          coin,
+        ): coin is FaBalanceRow & {
+          metadata: NonNullable<FaBalanceRow["metadata"]>;
+        } => coin.metadata != null,
+      )
       .map((coin): CoinDescriptionPlusAmount => {
         const foundCoin = findCoinData(coinData?.data ?? [], coin.asset_type);
 
@@ -102,10 +115,20 @@ export default function CoinsTab({address}: TokenTabsProps) {
       });
   }
 
+  const indexerHadNoRows = (data ?? []).length === 0;
+  let onChainAptOctas = 0n;
+  if (aptBalance !== undefined) {
+    try {
+      onChainAptOctas = BigInt(aptBalance);
+    } catch {
+      onChainAptOctas = 0n;
+    }
+  }
+
   return (
     <CoinsTable
       coins={parse_coins()}
-      indexerReturnedNoRows={rawCoins.length === 0}
+      indexerReturnedNoRows={indexerHadNoRows && onChainAptOctas === 0n}
     />
   );
 }

--- a/app/pages/Account/Tabs/CoinsTab.tsx
+++ b/app/pages/Account/Tabs/CoinsTab.tsx
@@ -4,7 +4,6 @@ import {
   type CoinDescription,
   useGetCoinList,
 } from "../../../api/hooks/useGetCoinList";
-import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import {findCoinData} from "../../Transaction/utils";
 import {coinOrderIndex} from "../../utils";
 import {
@@ -31,17 +30,13 @@ export default function CoinsTab({address}: TokenTabsProps) {
     return null;
   }
 
-  const coins = data ?? [];
-
-  if (coins.length === 0) {
-    return <EmptyTabContent />;
-  }
+  const rawCoins = data ?? [];
 
   function parse_coins(): CoinDescriptionPlusAmount[] {
-    if (!coins || coins.length <= 0) {
+    if (!rawCoins || rawCoins.length <= 0) {
       return [];
     }
-    return coins
+    return rawCoins
       .filter((coin) => Boolean(coin.metadata))
       .map((coin): CoinDescriptionPlusAmount => {
         const foundCoin = findCoinData(coinData?.data ?? [], coin.asset_type);
@@ -107,5 +102,10 @@ export default function CoinsTab({address}: TokenTabsProps) {
       });
   }
 
-  return <CoinsTable coins={parse_coins()} />;
+  return (
+    <CoinsTable
+      coins={parse_coins()}
+      indexerReturnedNoRows={rawCoins.length === 0}
+    />
+  );
 }

--- a/app/pages/Account/accountCoinsMerge.test.ts
+++ b/app/pages/Account/accountCoinsMerge.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from "vitest";
+import {
+  APT_MOVE_COIN_TYPE,
+  mergeOnChainAptIntoIndexerRows,
+} from "./accountCoinsMerge";
+
+describe("mergeOnChainAptIntoIndexerRows", () => {
+  it("adds synthetic APT row when indexer is empty and on-chain balance > 0", () => {
+    const merged = mergeOnChainAptIntoIndexerRows([], "100000000");
+    expect(merged).toHaveLength(1);
+    expect(merged[0].asset_type).toBe(APT_MOVE_COIN_TYPE);
+    expect(merged[0].amount).toBe(100_000_000);
+    expect(merged[0].metadata?.symbol).toBe("APT");
+  });
+
+  it("does not duplicate when indexer already has APT coin type", () => {
+    const rows = [
+      {
+        asset_type: APT_MOVE_COIN_TYPE,
+        amount: 50_000_000,
+        metadata: {
+          name: "Aptos Coin",
+          decimals: 8,
+          symbol: "APT",
+          token_standard: "v1",
+        },
+      },
+    ];
+    const merged = mergeOnChainAptIntoIndexerRows(rows, "100000000");
+    expect(merged).toHaveLength(1);
+    expect(merged[0].amount).toBe(50_000_000);
+  });
+
+  it("fills null metadata for APT FA address 0xa", () => {
+    const rows = [
+      {
+        asset_type:
+          "0x000000000000000000000000000000000000000000000000000000000000000a",
+        amount: 1,
+        metadata: null,
+      },
+    ];
+    const merged = mergeOnChainAptIntoIndexerRows(rows, "0");
+    expect(merged[0].metadata).not.toBeNull();
+    expect(merged[0].metadata?.symbol).toBe("APT");
+  });
+
+  it("does not add row when on-chain balance is zero", () => {
+    expect(mergeOnChainAptIntoIndexerRows([], "0")).toHaveLength(0);
+  });
+});

--- a/app/pages/Account/accountCoinsMerge.ts
+++ b/app/pages/Account/accountCoinsMerge.ts
@@ -1,0 +1,86 @@
+import {tryStandardizeAddress} from "../../utils";
+
+/** Coin type for native APT in `0x1::coin` (matches `getBalance` default). */
+export const APT_MOVE_COIN_TYPE = "0x1::aptos_coin::AptosCoin";
+
+const SYNTHETIC_APT_METADATA = {
+  name: "Aptos Coin",
+  decimals: 8,
+  symbol: "APT",
+  token_standard: "v1",
+} as const;
+
+export type FaBalanceRow = {
+  amount: number;
+  asset_type: string;
+  metadata: {
+    name: string;
+    decimals: number;
+    symbol: string;
+    token_standard: string;
+  } | null;
+};
+
+function isAptIndexerAssetType(assetType: string): boolean {
+  if (assetType === APT_MOVE_COIN_TYPE) {
+    return true;
+  }
+  const std = tryStandardizeAddress(assetType);
+  const aptFa = tryStandardizeAddress("0xa");
+  return Boolean(std && aptFa && std === aptFa);
+}
+
+function enrichAptRowMissingMetadata(row: FaBalanceRow): FaBalanceRow {
+  if (row.metadata !== null || !isAptIndexerAssetType(row.asset_type)) {
+    return row;
+  }
+  return {
+    ...row,
+    metadata: {...SYNTHETIC_APT_METADATA},
+  };
+}
+
+/**
+ * When the indexer has no row for native APT (or returns APT with null metadata),
+ * merge in the on-chain `0x1::coin::balance` result so the Assets tab matches the sidebar card.
+ */
+export function mergeOnChainAptIntoIndexerRows(
+  indexerRows: FaBalanceRow[],
+  onChainAptOctas: string | undefined,
+): FaBalanceRow[] {
+  const enriched = indexerRows.map(enrichAptRowMissingMetadata);
+
+  if (onChainAptOctas === undefined) {
+    return enriched;
+  }
+
+  let octas: bigint;
+  try {
+    octas = BigInt(onChainAptOctas);
+  } catch {
+    return enriched;
+  }
+
+  if (octas <= 0n) {
+    return enriched;
+  }
+
+  const hasApt = enriched.some((r) => isAptIndexerAssetType(r.asset_type));
+  if (hasApt) {
+    return enriched;
+  }
+
+  const amountNum = Number(octas);
+  if (!Number.isSafeInteger(amountNum)) {
+    return enriched;
+  }
+
+  return [
+    {
+      asset_type: APT_MOVE_COIN_TYPE,
+      amount: amountNum,
+      metadata: {...SYNTHETIC_APT_METADATA},
+    },
+    ...enriched,
+  ];
+}

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -365,6 +365,7 @@ The app shell that wraps every page.
 |--------|--------|
 | **Data** | `useGetAllAccountCoins` merged with Panora/coin list. |
 | **Table** | Asset name, symbol, balance, type. Virtualized for large sets. |
+| **Empty indexer** | Verification filter controls and “Show Zero Balance” remain visible when the indexer returns no rows; an info note explains that the sidebar APT card may still reflect on-chain coin state. |
 
 ### FEAT-ACCOUNT-008 — NFTs (Tokens) Tab
 

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -366,6 +366,7 @@ The app shell that wraps every page.
 | **Data** | `useGetAllAccountCoins` merged with Panora/coin list. |
 | **Table** | Asset name, symbol, balance, type. Virtualized for large sets. |
 | **Empty indexer** | Verification filter controls and “Show Zero Balance” remain visible when the indexer returns no rows; an info note explains that the sidebar APT card may still reflect on-chain coin state. |
+| **Native APT fallback** | When `0x1::coin::balance` for `0x1::aptos_coin::AptosCoin` is non-zero but the indexer has no APT row (or returns APT with null metadata), the tab merges that on-chain balance so APT appears in the table. |
 
 ### FEAT-ACCOUNT-008 — NFTs (Tokens) Tab
 
@@ -1167,6 +1168,7 @@ The app shell that wraps every page.
 | `app/pages/Transaction/txnTabValues.test.ts` | FEAT-TXN-001 (tab selection by transaction type, trace tab only for user txns) |
 | `app/pages/Transaction/txnTabInvariants.test.ts` | FEAT-TXN-009 (DEX/LSD protocol coverage), TransactionTypeName enum values |
 | `app/pages/Account/hooks/useAccountTabValues.test.ts` | FEAT-ACCOUNT-005 (tab set computation: all GraphQL/object/multisig combos, invariants) |
+| `app/pages/Account/accountCoinsMerge.test.ts` | FEAT-ACCOUNT-007 (merge on-chain APT when indexer omits or lacks metadata) |
 | `app/pages/Account/Tabs/ModulesTab/Contract.test.ts` | FEAT-MODULES-001 (contract result utilities, copy serialization) |
 | `app/pages/layout/Search/searchUtils.test.ts` | FEAT-SEARCH-003 (fallback address results) |
 | `app/pages/layout/Search/searchDetection.test.ts` | FEAT-SEARCH-002 (all input type detection: ANS, struct, numeric, hex, address, emoji, generic) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users reported that the Account **Assets** tab showed no fungible-asset rows (while the sidebar APT card could still show a balance) and the **Verified / Recognized / All** and **Show Zero Balance** controls never appeared.

## Root cause

1. `CoinsTab` returned `EmptyTabContent` whenever `useGetAllAccountCoins` returned an empty array, so filter controls inside `CoinsTable` never mounted.
2. Even after showing filters, **native APT** can exist in `0x1::coin` (what `getBalance` / the sidebar card uses) while the indexer `current_fungible_asset_balances` table has **no row** or a row with **null `metadata`**, so the Assets table had nothing to render after filtering.

## Changes

- Always render `CoinsTable` after successful loads (including zero indexer rows).
- When the indexer returns no rows **and** on-chain APT is also zero, show an info alert explaining indexer vs on-chain coin state.
- **`mergeOnChainAptIntoIndexerRows`**: if `0x1::coin::balance` for `0x1::aptos_coin::AptosCoin` is non-zero and the indexer has no APT row, inject a synthetic APT row; if the indexer returns APT (`0x1::aptos_coin::AptosCoin` or FA `0xa`) with null metadata, fill minimal metadata so the row passes the existing filter.
- `CoinsTab` waits for both `useGetAllAccountCoins` and `useGetAccountAPTBalance` before rendering.
- Unit tests: `app/pages/Account/accountCoinsMerge.test.ts` (covers FEAT-ACCOUNT-007).
- Updated `FEAT-ACCOUNT-007` in `docs/FEATURES_SPECIFICATION.md`, Appendix B, and `CHANGELOG.md` under **[Unreleased]**.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f0d9c1-b22d-4793-bb33-5b28a9c6a0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f0d9c1-b22d-4793-bb33-5b28a9c6a0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

