### PR TITLE
feat(txn): table-style signature overview on transaction tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **Transaction overview** (`/txn/.../userTxnOverview`): the **Signature** block uses the same outlined table layout as the Fee Statement event view—labeled rows for scheme, public key, and signature (with expandable hex chips)—instead of only a collapsible JSON tree. Pending transactions use the same presentation.
 - **Settings**: API Key Overrides section includes an info icon with a short explanation of why to use your own geomi.dev key (dedicated rate limits) and a link to geomi.dev
 - Rate-limit drawer is now non-blocking (persistent banner instead of modal overlay) so users can still interact with the page, settings, and navigation while the notice is visible
 - Saving an API key in Settings automatically dismisses the rate-limit drawer and suppresses re-triggering for 10 seconds, preventing stale in-flight 429 responses from immediately re-showing the drawer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
-- **Transaction overview** (`/txn/.../userTxnOverview`): the **Signature** block uses the same outlined table layout as the Fee Statement event view—labeled rows for scheme, public key, and signature (with expandable hex chips)—instead of only a collapsible JSON tree. Pending transactions use the same presentation.
+- **Transaction overview** (`/txn/.../userTxnOverview`): the **Signature** block uses the same outlined table layout as the Fee Statement event view—labeled rows for scheme, public key, and signature (with expandable hex chips)—instead of only a collapsible JSON tree. Pending transactions use the same presentation. On small screens, label and value stack vertically; wide content can scroll horizontally so nothing is clipped.
 - **Settings**: API Key Overrides section includes an info icon with a short explanation of why to use your own geomi.dev key (dedicated rate limits) and a link to geomi.dev
 - Rate-limit drawer is now non-blocking (persistent banner instead of modal overlay) so users can still interact with the page, settings, and navigation while the notice is visible
 - Saving an API key in Settings automatically dismisses the rate-limit drawer and suppresses re-triggering for 10 seconds, preventing stale in-flight 429 responses from immediately re-showing the drawer

--- a/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx
+++ b/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import {createTheme, ThemeProvider} from "@mui/material/styles";
+import {render} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {describe, expect, it} from "vitest";
+import SignatureOverviewTable from "./SignatureOverviewTable";
+
+const theme = createTheme();
+
+function withTheme(ui: ReactNode) {
+  return <ThemeProvider theme={theme}>{ui}</ThemeProvider>;
+}
+
+describe("SignatureOverviewTable — FEAT-TXN-002", () => {
+  it("renders Ed25519 signature as labeled rows (fee-statement-style table)", () => {
+    const signature = {
+      type: "ed25519_signature",
+      public_key:
+        "0x8d2a6dc60eaeacf89cba9e53db787d77165c63be218175c24009252eaf57c513",
+      signature:
+        "0x19ad346523d83bd0626aaf8e6910c4ec1f54f124eb6fefc2fdd004619e54a281ca4ae756675d331458bd968a1cf7a42263fc6fe1aebe0cd91d041bd291355503",
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+
+    const text = container.textContent ?? "";
+    expect(container.querySelector("table")).toBeTruthy();
+    expect(text).toContain("Scheme");
+    expect(text).toContain("Public key");
+    expect(text).toContain("Signature");
+    expect(text).toContain("Ed25519");
+  });
+
+  it("shows empty state when signature is missing", () => {
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={undefined} />),
+    );
+    expect(container.textContent).toContain("N/A");
+  });
+});

--- a/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx
+++ b/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx
@@ -1,8 +1,35 @@
 // @vitest-environment jsdom
 import {createTheme, ThemeProvider} from "@mui/material/styles";
-import {render} from "@testing-library/react";
+import {cleanup, render} from "@testing-library/react";
 import type {ReactNode} from "react";
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+vi.mock("../../../../components/IndividualPageContent/JsonViewCard", () => ({
+  default: function JsonViewCardStub({data}: {data: unknown}) {
+    return (
+      <span data-testid="json-view-stub">
+        {typeof data === "object" && data !== null
+          ? JSON.stringify(data)
+          : String(data)}
+      </span>
+    );
+  },
+}));
+
+vi.mock("../../../../components/HashButton", () => ({
+  default: function HashButtonStub({hash}: {hash: string}) {
+    return <span data-testid="hash-stub">{hash.slice(0, 6)}…</span>;
+  },
+  HashType: {
+    ACCOUNT: "account",
+    OTHERS: "others",
+    TRANSACTION: "transaction",
+    OBJECT: "object",
+    COIN: "coin",
+    FUNGIBLE_ASSET: "fungible_asset",
+  },
+}));
+
 import SignatureOverviewTable from "./SignatureOverviewTable";
 
 const theme = createTheme();
@@ -11,18 +38,22 @@ function withTheme(ui: ReactNode) {
   return <ThemeProvider theme={theme}>{ui}</ThemeProvider>;
 }
 
-describe("SignatureOverviewTable — FEAT-TXN-002", () => {
-  it("renders Ed25519 signature as labeled rows (fee-statement-style table)", () => {
-    const signature = {
-      type: "ed25519_signature",
-      public_key:
-        "0x8d2a6dc60eaeacf89cba9e53db787d77165c63be218175c24009252eaf57c513",
-      signature:
-        "0x19ad346523d83bd0626aaf8e6910c4ec1f54f124eb6fefc2fdd004619e54a281ca4ae756675d331458bd968a1cf7a42263fc6fe1aebe0cd91d041bd291355503",
-    };
+const ed25519Account = {
+  type: "ed25519_signature",
+  public_key:
+    "0x8d2a6dc60eaeacf89cba9e53db787d77165c63be218175c24009252eaf57c513",
+  signature:
+    "0x19ad346523d83bd0626aaf8e6910c4ec1f54f124eb6fefc2fdd004619e54a281ca4ae756675d331458bd968a1cf7a42263fc6fe1aebe0cd91d041bd291355503",
+};
 
+describe("SignatureOverviewTable — FEAT-TXN-002", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders Ed25519 signature as labeled rows (fee-statement-style table)", () => {
     const {container} = render(
-      withTheme(<SignatureOverviewTable signature={signature} />),
+      withTheme(<SignatureOverviewTable signature={ed25519Account} />),
     );
 
     const text = container.textContent ?? "";
@@ -38,5 +69,142 @@ describe("SignatureOverviewTable — FEAT-TXN-002", () => {
       withTheme(<SignatureOverviewTable signature={undefined} />),
     );
     expect(container.textContent).toContain("N/A");
+  });
+
+  it("renders multi-Ed25519 threshold, bitmap, and per-key rows", () => {
+    const signature = {
+      type: "multi_ed25519_signature",
+      public_keys: [
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      ],
+      signatures: [
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      ],
+      threshold: "2",
+      bitmap: "0x03",
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Multi-Ed25519");
+    expect(text).toContain("Threshold");
+    expect(text).toContain("2");
+    expect(text).toContain("Bitmap");
+    expect(text).toContain("Public key 1");
+    expect(text).toContain("Public key 2");
+    expect(text).toContain("Signature 1");
+    expect(text).toContain("Signature 2");
+  });
+
+  it("renders single_sender public key and signature sub-objects", () => {
+    const signature = {
+      type: "single_sender",
+      public_key: {type: "ed25519", value: ed25519Account.public_key},
+      signature: {type: "ed25519", value: ed25519Account.signature},
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Single sender");
+    expect(text).toContain("Public key type");
+    expect(text).toContain("ed25519");
+    expect(text).toContain("Signature type");
+  });
+
+  it("renders multi_agent_signature with nested sender and secondary signers", () => {
+    const secondaryAddr =
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const signature = {
+      type: "multi_agent_signature",
+      sender: ed25519Account,
+      secondary_signer_addresses: [secondaryAddr],
+      secondary_signers: [ed25519Account],
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Multi-agent");
+    expect(text).toContain("Top-level scheme");
+    expect(text).toContain("Primary signer authenticator");
+    expect(text).toContain("Secondary signer 1 (address)");
+  });
+
+  it("uses distinct React keys when secondary signer addresses repeat", () => {
+    const addr =
+      "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    const signature = {
+      type: "multi_agent_signature",
+      sender: ed25519Account,
+      secondary_signer_addresses: [addr, addr],
+      secondary_signers: [ed25519Account, ed25519Account],
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    expect(container.querySelectorAll("table").length).toBeGreaterThanOrEqual(
+      3,
+    );
+  });
+
+  it("renders fee_payer_signature with fee payer address and nested signers", () => {
+    const feePayer =
+      "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    const signature = {
+      type: "fee_payer_signature",
+      fee_payer_address: feePayer,
+      sender: ed25519Account,
+      secondary_signer_addresses: [],
+      secondary_signers: [],
+      fee_payer_signer: ed25519Account,
+    };
+
+    const {container} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Fee payer");
+    expect(text).toContain("Fee payer address");
+    expect(text).toContain("Fee payer signer");
+    expect(text).toContain("Authenticator used by the fee payer");
+  });
+
+  it("falls back to raw JSON view for unknown nested signature shape", () => {
+    const signature = {
+      type: "custom_wrapper",
+      inner: {a: 1},
+    };
+
+    const {getByTestId} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    expect(getByTestId("json-view-stub").textContent).toContain(
+      "custom_wrapper",
+    );
+  });
+
+  it("renders Signer data JSON fallback for unrecognized account authenticator", () => {
+    const inner = {type: "not_a_real_variant", foo: "bar"};
+    const signature = {
+      type: "multi_agent_signature",
+      sender: inner,
+      secondary_signer_addresses: [],
+      secondary_signers: [],
+    };
+
+    const {getByTestId} = render(
+      withTheme(<SignatureOverviewTable signature={signature} />),
+    );
+    expect(getByTestId("json-view-stub").textContent).toContain(
+      "not_a_real_variant",
+    );
   });
 });

--- a/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
+++ b/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
@@ -1,10 +1,27 @@
-import {Paper, Table, TableRow, Typography, useTheme} from "@mui/material";
+import {Box, Paper, Table, TableRow, Typography, useTheme} from "@mui/material";
 import type React from "react";
 import HashButton, {HashType} from "../../../../components/HashButton";
 import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
 import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import EmptyValue from "../../../../components/IndividualPageContent/ContentValue/EmptyValue";
+
+/** Lets wide hash chips / JSON scroll horizontally on narrow screens without clipping. */
+const signatureTableScrollBoxSx = {
+  width: "100%",
+  maxWidth: "100%",
+  minWidth: 0,
+  overflowX: "auto",
+  WebkitOverflowScrolling: "touch",
+} as const;
+
+const signatureValueCellSx = {
+  verticalAlign: "top",
+  minWidth: 0,
+  maxWidth: "100%",
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
+} as const;
 
 type SignatureFieldRowProps = {
   label: string;
@@ -21,6 +38,7 @@ function SignatureFieldRow({
   return (
     <TableRow
       sx={{
+        display: {xs: "block", sm: "table-row"},
         backgroundColor: theme.palette.background.paper,
       }}
     >
@@ -28,10 +46,14 @@ function SignatureFieldRow({
         component="th"
         scope="row"
         sx={{
+          display: {xs: "block", sm: "table-cell"},
+          width: {xs: "100%", sm: "38%"},
+          boxSizing: "border-box",
           verticalAlign: "top",
           fontWeight: 600,
           color: "text.primary",
-          width: "38%",
+          borderBottom: {xs: 0, sm: undefined},
+          pb: {xs: 0, sm: undefined},
         }}
       >
         {label}
@@ -49,10 +71,38 @@ function SignatureFieldRow({
           </Typography>
         ) : null}
       </GeneralTableCell>
-      <GeneralTableCell sx={{verticalAlign: "top"}}>
-        {children}
+      <GeneralTableCell
+        sx={{
+          display: {xs: "block", sm: "table-cell"},
+          width: {xs: "100%", sm: "62%"},
+          boxSizing: "border-box",
+          pb: {xs: 2, sm: undefined},
+          pt: {xs: 0.5, sm: undefined},
+          ...signatureValueCellSx,
+          "& .MuiStack-root": {maxWidth: "100%"},
+          "& .MuiButton-root": {maxWidth: "100%"},
+        }}
+      >
+        <Box sx={{minWidth: 0, maxWidth: "100%"}}>{children}</Box>
       </GeneralTableCell>
     </TableRow>
+  );
+}
+
+function SignatureNestedTable({children}: {children: React.ReactNode}) {
+  return (
+    <Box sx={{...signatureTableScrollBoxSx, mt: {xs: 0, sm: 0.5}}}>
+      <Table
+        size="small"
+        sx={{
+          tableLayout: {xs: "auto", sm: "fixed"},
+          width: "100%",
+          minWidth: 0,
+        }}
+      >
+        {children}
+      </Table>
+    </Box>
   );
 }
 
@@ -226,7 +276,10 @@ export default function SignatureOverviewTable({
 }: SignatureOverviewTableProps) {
   if (signature === undefined || signature === null) {
     return (
-      <Paper variant="outlined" sx={{overflow: "hidden", p: 2}}>
+      <Paper
+        variant="outlined"
+        sx={{overflow: "hidden", maxWidth: "100%", p: 2}}
+      >
         <EmptyValue />
       </Paper>
     );
@@ -234,14 +287,23 @@ export default function SignatureOverviewTable({
 
   if (typeof signature !== "object" || Array.isArray(signature)) {
     return (
-      <Paper variant="outlined" sx={{overflow: "hidden"}}>
-        <Table size="small" sx={{tableLayout: "fixed"}}>
-          <GeneralTableBody>
-            <SignatureFieldRow label="Raw">
-              <JsonViewCard data={signature} collapsedByDefault />
-            </SignatureFieldRow>
-          </GeneralTableBody>
-        </Table>
+      <Paper variant="outlined" sx={{overflow: "hidden", maxWidth: "100%"}}>
+        <Box sx={signatureTableScrollBoxSx}>
+          <Table
+            size="small"
+            sx={{
+              tableLayout: {xs: "auto", sm: "fixed"},
+              width: "100%",
+              minWidth: 0,
+            }}
+          >
+            <GeneralTableBody>
+              <SignatureFieldRow label="Raw">
+                <JsonViewCard data={signature} collapsedByDefault />
+              </SignatureFieldRow>
+            </GeneralTableBody>
+          </Table>
+        </Box>
       </Paper>
     );
   }
@@ -271,12 +333,15 @@ export default function SignatureOverviewTable({
           label="Sender"
           description="Primary signer authenticator."
         >
-          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
-            <Table size="small" sx={{tableLayout: "fixed"}}>
+          <Paper
+            variant="outlined"
+            sx={{overflow: "hidden", maxWidth: "100%", mt: 0.5}}
+          >
+            <SignatureNestedTable>
               <GeneralTableBody>
                 <AccountSignatureRows sig={s.sender} />
               </GeneralTableBody>
-            </Table>
+            </SignatureNestedTable>
           </Paper>
         </SignatureFieldRow>
         {Array.isArray(s.secondary_signer_addresses) &&
@@ -298,12 +363,15 @@ export default function SignatureOverviewTable({
                 label={`Secondary signer ${i + 1}`}
                 description="Authenticator for this secondary address."
               >
-                <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
-                  <Table size="small" sx={{tableLayout: "fixed"}}>
+                <Paper
+                  variant="outlined"
+                  sx={{overflow: "hidden", maxWidth: "100%", mt: 0.5}}
+                >
+                  <SignatureNestedTable>
                     <GeneralTableBody>
                       <AccountSignatureRows sig={sub} />
                     </GeneralTableBody>
-                  </Table>
+                  </SignatureNestedTable>
                 </Paper>
               </SignatureFieldRow>
             ))}
@@ -326,12 +394,15 @@ export default function SignatureOverviewTable({
           label="Sender"
           description="Primary signer authenticator."
         >
-          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
-            <Table size="small" sx={{tableLayout: "fixed"}}>
+          <Paper
+            variant="outlined"
+            sx={{overflow: "hidden", maxWidth: "100%", mt: 0.5}}
+          >
+            <SignatureNestedTable>
               <GeneralTableBody>
                 <AccountSignatureRows sig={s.sender} />
               </GeneralTableBody>
-            </Table>
+            </SignatureNestedTable>
           </Paper>
         </SignatureFieldRow>
         {Array.isArray(s.secondary_signer_addresses) &&
@@ -352,12 +423,15 @@ export default function SignatureOverviewTable({
                 key={JSON.stringify(sub)}
                 label={`Secondary signer ${i + 1}`}
               >
-                <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
-                  <Table size="small" sx={{tableLayout: "fixed"}}>
+                <Paper
+                  variant="outlined"
+                  sx={{overflow: "hidden", maxWidth: "100%", mt: 0.5}}
+                >
+                  <SignatureNestedTable>
                     <GeneralTableBody>
                       <AccountSignatureRows sig={sub} />
                     </GeneralTableBody>
-                  </Table>
+                  </SignatureNestedTable>
                 </Paper>
               </SignatureFieldRow>
             ))}
@@ -367,12 +441,15 @@ export default function SignatureOverviewTable({
           label="Fee payer signer"
           description="Authenticator used by the fee payer."
         >
-          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
-            <Table size="small" sx={{tableLayout: "fixed"}}>
+          <Paper
+            variant="outlined"
+            sx={{overflow: "hidden", maxWidth: "100%", mt: 0.5}}
+          >
+            <SignatureNestedTable>
               <GeneralTableBody>
                 <AccountSignatureRows sig={s.fee_payer_signer} />
               </GeneralTableBody>
-            </Table>
+            </SignatureNestedTable>
           </Paper>
         </SignatureFieldRow>
       </>
@@ -416,10 +493,19 @@ export default function SignatureOverviewTable({
   }
 
   return (
-    <Paper variant="outlined" sx={{overflow: "hidden"}}>
-      <Table size="small" sx={{tableLayout: "fixed"}}>
-        <GeneralTableBody>{body}</GeneralTableBody>
-      </Table>
+    <Paper variant="outlined" sx={{overflow: "hidden", maxWidth: "100%"}}>
+      <Box sx={signatureTableScrollBoxSx}>
+        <Table
+          size="small"
+          sx={{
+            tableLayout: {xs: "auto", sm: "fixed"},
+            width: "100%",
+            minWidth: 0,
+          }}
+        >
+          <GeneralTableBody>{body}</GeneralTableBody>
+        </Table>
+      </Box>
     </Paper>
   );
 }

--- a/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
+++ b/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
@@ -110,6 +110,16 @@ function isHexString(value: unknown): value is string {
   return typeof value === "string" && /^0x[0-9a-fA-F]+$/.test(value);
 }
 
+function secondarySignerAuthenticatorKey(
+  addresses: unknown[] | undefined,
+  index: number,
+): string {
+  const addr = addresses?.[index];
+  return typeof addr === "string"
+    ? `secondary-signer-${addr}-${index}`
+    : `secondary-signer-${index}`;
+}
+
 function humanizeSignatureType(type: string): string {
   const map: Record<string, string> = {
     ed25519_signature: "Ed25519",
@@ -216,17 +226,17 @@ function AccountSignatureRows({sig}: {sig: unknown}): React.ReactNode {
 
   if (t === "single_sender") {
     const pk = o.public_key;
-    const sig = o.signature;
+    const signaturePayload = o.signature;
     if (
       pk &&
       typeof pk === "object" &&
       !Array.isArray(pk) &&
-      sig &&
-      typeof sig === "object" &&
-      !Array.isArray(sig)
+      signaturePayload &&
+      typeof signaturePayload === "object" &&
+      !Array.isArray(signaturePayload)
     ) {
       const pkRec = pk as Record<string, unknown>;
-      const sigRec = sig as Record<string, unknown>;
+      const sigRec = signaturePayload as Record<string, unknown>;
       return (
         <>
           <SignatureFieldRow label="Scheme">
@@ -350,7 +360,10 @@ export default function SignatureOverviewTable({
             {(s.secondary_signer_addresses as unknown[]).map((addr, i) =>
               typeof addr === "string" ? (
                 <SignatureFieldRow
-                  key={addr}
+                  key={
+                    // biome-ignore lint/suspicious/noArrayIndexKey: same address may appear twice; index disambiguates list position
+                    `secondary-address-${addr}-${i}`
+                  }
                   label={`Secondary signer ${i + 1} (address)`}
                 >
                   <HashButton hash={addr} type={HashType.ACCOUNT} />
@@ -359,7 +372,10 @@ export default function SignatureOverviewTable({
             )}
             {(s.secondary_signers as unknown[]).map((sub, i) => (
               <SignatureFieldRow
-                key={JSON.stringify(sub)}
+                key={secondarySignerAuthenticatorKey(
+                  s.secondary_signer_addresses as unknown[] | undefined,
+                  i,
+                )}
                 label={`Secondary signer ${i + 1}`}
                 description="Authenticator for this secondary address."
               >
@@ -411,7 +427,10 @@ export default function SignatureOverviewTable({
             {(s.secondary_signer_addresses as unknown[]).map((addr, i) =>
               typeof addr === "string" ? (
                 <SignatureFieldRow
-                  key={addr}
+                  key={
+                    // biome-ignore lint/suspicious/noArrayIndexKey: same address may appear twice; index disambiguates list position
+                    `secondary-address-${addr}-${i}`
+                  }
                   label={`Secondary signer ${i + 1} (address)`}
                 >
                   <HashButton hash={addr} type={HashType.ACCOUNT} />
@@ -420,7 +439,10 @@ export default function SignatureOverviewTable({
             )}
             {(s.secondary_signers as unknown[]).map((sub, i) => (
               <SignatureFieldRow
-                key={JSON.stringify(sub)}
+                key={secondarySignerAuthenticatorKey(
+                  s.secondary_signer_addresses as unknown[] | undefined,
+                  i,
+                )}
                 label={`Secondary signer ${i + 1}`}
               >
                 <Paper

--- a/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
+++ b/app/pages/Transaction/Tabs/Components/SignatureOverviewTable.tsx
@@ -1,0 +1,425 @@
+import {Paper, Table, TableRow, Typography, useTheme} from "@mui/material";
+import type React from "react";
+import HashButton, {HashType} from "../../../../components/HashButton";
+import GeneralTableBody from "../../../../components/Table/GeneralTableBody";
+import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
+import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
+import EmptyValue from "../../../../components/IndividualPageContent/ContentValue/EmptyValue";
+
+type SignatureFieldRowProps = {
+  label: string;
+  children: React.ReactNode;
+  description?: string;
+};
+
+function SignatureFieldRow({
+  label,
+  children,
+  description,
+}: SignatureFieldRowProps) {
+  const theme = useTheme();
+  return (
+    <TableRow
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+      }}
+    >
+      <GeneralTableCell
+        component="th"
+        scope="row"
+        sx={{
+          verticalAlign: "top",
+          fontWeight: 600,
+          color: "text.primary",
+          width: "38%",
+        }}
+      >
+        {label}
+        {description ? (
+          <Typography
+            component="div"
+            variant="caption"
+            sx={{
+              display: "block",
+              color: theme.palette.text.secondary,
+              mt: 0.5,
+            }}
+          >
+            {description}
+          </Typography>
+        ) : null}
+      </GeneralTableCell>
+      <GeneralTableCell sx={{verticalAlign: "top"}}>
+        {children}
+      </GeneralTableCell>
+    </TableRow>
+  );
+}
+
+function isHexString(value: unknown): value is string {
+  return typeof value === "string" && /^0x[0-9a-fA-F]+$/.test(value);
+}
+
+function humanizeSignatureType(type: string): string {
+  const map: Record<string, string> = {
+    ed25519_signature: "Ed25519",
+    multi_ed25519_signature: "Multi-Ed25519",
+    single_sender: "Single sender",
+    multi_agent_signature: "Multi-agent",
+    fee_payer_signature: "Fee payer",
+    secp256k1_ecdsa_signature: "Secp256k1 ECDSA",
+  };
+  return map[type] ?? type.replaceAll("_", " ");
+}
+
+function AccountSignatureRows({sig}: {sig: unknown}): React.ReactNode {
+  if (!sig || typeof sig !== "object" || Array.isArray(sig)) {
+    return (
+      <SignatureFieldRow label="Signer">
+        <Typography variant="body2" color="text.secondary">
+          <EmptyValue />
+        </Typography>
+      </SignatureFieldRow>
+    );
+  }
+
+  const o = sig as Record<string, unknown>;
+  const t = typeof o.type === "string" ? o.type : "";
+
+  const isSecp256k1 =
+    t.includes("secp256k1") || t === "secp256k1_ecdsa_signature";
+  if (
+    (t === "ed25519_signature" || isSecp256k1) &&
+    isHexString(o.public_key) &&
+    isHexString(o.signature)
+  ) {
+    return (
+      <>
+        <SignatureFieldRow label="Scheme">
+          {humanizeSignatureType(t)}
+        </SignatureFieldRow>
+        <SignatureFieldRow
+          label="Public key"
+          description={
+            isSecp256k1
+              ? "Uncompressed secp256k1 public key (hex)."
+              : "32-byte Ed25519 public key (hex)."
+          }
+        >
+          <HashButton hash={o.public_key} type={HashType.OTHERS} />
+        </SignatureFieldRow>
+        <SignatureFieldRow
+          label="Signature"
+          description={
+            isSecp256k1
+              ? "ECDSA signature over the signing message (hex)."
+              : "64-byte Ed25519 signature over the signing message (hex)."
+          }
+        >
+          <HashButton hash={o.signature} type={HashType.OTHERS} />
+        </SignatureFieldRow>
+      </>
+    );
+  }
+
+  if (
+    t === "multi_ed25519_signature" &&
+    Array.isArray(o.public_keys) &&
+    Array.isArray(o.signatures)
+  ) {
+    const publicKeys = o.public_keys.filter(isHexString);
+    const signatures = o.signatures.filter(isHexString);
+    return (
+      <>
+        <SignatureFieldRow label="Scheme">
+          {humanizeSignatureType(t)}
+        </SignatureFieldRow>
+        {typeof o.threshold === "string" || typeof o.threshold === "number" ? (
+          <SignatureFieldRow
+            label="Threshold"
+            description="Minimum number of signatures required."
+          >
+            {String(o.threshold)}
+          </SignatureFieldRow>
+        ) : null}
+        {isHexString(o.bitmap) ? (
+          <SignatureFieldRow
+            label="Bitmap"
+            description="Bitmask of which keys signed."
+          >
+            <HashButton hash={o.bitmap} type={HashType.OTHERS} />
+          </SignatureFieldRow>
+        ) : null}
+        {publicKeys.map((pk, i) => (
+          <SignatureFieldRow key={pk} label={`Public key ${i + 1}`}>
+            <HashButton hash={pk} type={HashType.OTHERS} />
+          </SignatureFieldRow>
+        ))}
+        {signatures.map((sigHex, i) => (
+          <SignatureFieldRow key={sigHex} label={`Signature ${i + 1}`}>
+            <HashButton hash={sigHex} type={HashType.OTHERS} />
+          </SignatureFieldRow>
+        ))}
+      </>
+    );
+  }
+
+  if (t === "single_sender") {
+    const pk = o.public_key;
+    const sig = o.signature;
+    if (
+      pk &&
+      typeof pk === "object" &&
+      !Array.isArray(pk) &&
+      sig &&
+      typeof sig === "object" &&
+      !Array.isArray(sig)
+    ) {
+      const pkRec = pk as Record<string, unknown>;
+      const sigRec = sig as Record<string, unknown>;
+      return (
+        <>
+          <SignatureFieldRow label="Scheme">
+            {humanizeSignatureType(t)}
+          </SignatureFieldRow>
+          {typeof pkRec.type === "string" ? (
+            <SignatureFieldRow label="Public key type">
+              {pkRec.type}
+            </SignatureFieldRow>
+          ) : null}
+          {isHexString(pkRec.value) ? (
+            <SignatureFieldRow label="Public key">
+              <HashButton hash={pkRec.value} type={HashType.OTHERS} />
+            </SignatureFieldRow>
+          ) : null}
+          {typeof sigRec.type === "string" ? (
+            <SignatureFieldRow label="Signature type">
+              {sigRec.type}
+            </SignatureFieldRow>
+          ) : null}
+          {isHexString(sigRec.value) ? (
+            <SignatureFieldRow label="Signature">
+              <HashButton hash={sigRec.value} type={HashType.OTHERS} />
+            </SignatureFieldRow>
+          ) : null}
+        </>
+      );
+    }
+  }
+
+  return (
+    <SignatureFieldRow label="Signer data">
+      <JsonViewCard data={sig} collapsedByDefault />
+    </SignatureFieldRow>
+  );
+}
+
+export type SignatureOverviewTableProps = {
+  signature: unknown;
+};
+
+/**
+ * Structured, table-style summary of transaction `signature` JSON (same layout family as FeeStatementEventView).
+ */
+export default function SignatureOverviewTable({
+  signature,
+}: SignatureOverviewTableProps) {
+  if (signature === undefined || signature === null) {
+    return (
+      <Paper variant="outlined" sx={{overflow: "hidden", p: 2}}>
+        <EmptyValue />
+      </Paper>
+    );
+  }
+
+  if (typeof signature !== "object" || Array.isArray(signature)) {
+    return (
+      <Paper variant="outlined" sx={{overflow: "hidden"}}>
+        <Table size="small" sx={{tableLayout: "fixed"}}>
+          <GeneralTableBody>
+            <SignatureFieldRow label="Raw">
+              <JsonViewCard data={signature} collapsedByDefault />
+            </SignatureFieldRow>
+          </GeneralTableBody>
+        </Table>
+      </Paper>
+    );
+  }
+
+  const s = signature as Record<string, unknown>;
+  const typeField = typeof s.type === "string" ? s.type : "";
+
+  let body: React.ReactNode;
+
+  if (
+    typeField === "ed25519_signature" &&
+    isHexString(s.public_key) &&
+    isHexString(s.signature)
+  ) {
+    body = <AccountSignatureRows sig={signature} />;
+  } else if (typeField === "multi_ed25519_signature") {
+    body = <AccountSignatureRows sig={signature} />;
+  } else if (typeField === "single_sender") {
+    body = <AccountSignatureRows sig={signature} />;
+  } else if (typeField === "multi_agent_signature") {
+    body = (
+      <>
+        <SignatureFieldRow label="Top-level scheme">
+          {humanizeSignatureType(typeField)}
+        </SignatureFieldRow>
+        <SignatureFieldRow
+          label="Sender"
+          description="Primary signer authenticator."
+        >
+          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
+            <Table size="small" sx={{tableLayout: "fixed"}}>
+              <GeneralTableBody>
+                <AccountSignatureRows sig={s.sender} />
+              </GeneralTableBody>
+            </Table>
+          </Paper>
+        </SignatureFieldRow>
+        {Array.isArray(s.secondary_signer_addresses) &&
+        Array.isArray(s.secondary_signers) ? (
+          <>
+            {(s.secondary_signer_addresses as unknown[]).map((addr, i) =>
+              typeof addr === "string" ? (
+                <SignatureFieldRow
+                  key={addr}
+                  label={`Secondary signer ${i + 1} (address)`}
+                >
+                  <HashButton hash={addr} type={HashType.ACCOUNT} />
+                </SignatureFieldRow>
+              ) : null,
+            )}
+            {(s.secondary_signers as unknown[]).map((sub, i) => (
+              <SignatureFieldRow
+                key={JSON.stringify(sub)}
+                label={`Secondary signer ${i + 1}`}
+                description="Authenticator for this secondary address."
+              >
+                <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
+                  <Table size="small" sx={{tableLayout: "fixed"}}>
+                    <GeneralTableBody>
+                      <AccountSignatureRows sig={sub} />
+                    </GeneralTableBody>
+                  </Table>
+                </Paper>
+              </SignatureFieldRow>
+            ))}
+          </>
+        ) : null}
+      </>
+    );
+  } else if (typeField === "fee_payer_signature") {
+    body = (
+      <>
+        <SignatureFieldRow label="Top-level scheme">
+          {humanizeSignatureType(typeField)}
+        </SignatureFieldRow>
+        {typeof s.fee_payer_address === "string" ? (
+          <SignatureFieldRow label="Fee payer address">
+            <HashButton hash={s.fee_payer_address} type={HashType.ACCOUNT} />
+          </SignatureFieldRow>
+        ) : null}
+        <SignatureFieldRow
+          label="Sender"
+          description="Primary signer authenticator."
+        >
+          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
+            <Table size="small" sx={{tableLayout: "fixed"}}>
+              <GeneralTableBody>
+                <AccountSignatureRows sig={s.sender} />
+              </GeneralTableBody>
+            </Table>
+          </Paper>
+        </SignatureFieldRow>
+        {Array.isArray(s.secondary_signer_addresses) &&
+        Array.isArray(s.secondary_signers) ? (
+          <>
+            {(s.secondary_signer_addresses as unknown[]).map((addr, i) =>
+              typeof addr === "string" ? (
+                <SignatureFieldRow
+                  key={addr}
+                  label={`Secondary signer ${i + 1} (address)`}
+                >
+                  <HashButton hash={addr} type={HashType.ACCOUNT} />
+                </SignatureFieldRow>
+              ) : null,
+            )}
+            {(s.secondary_signers as unknown[]).map((sub, i) => (
+              <SignatureFieldRow
+                key={JSON.stringify(sub)}
+                label={`Secondary signer ${i + 1}`}
+              >
+                <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
+                  <Table size="small" sx={{tableLayout: "fixed"}}>
+                    <GeneralTableBody>
+                      <AccountSignatureRows sig={sub} />
+                    </GeneralTableBody>
+                  </Table>
+                </Paper>
+              </SignatureFieldRow>
+            ))}
+          </>
+        ) : null}
+        <SignatureFieldRow
+          label="Fee payer signer"
+          description="Authenticator used by the fee payer."
+        >
+          <Paper variant="outlined" sx={{overflow: "hidden", mt: 0.5}}>
+            <Table size="small" sx={{tableLayout: "fixed"}}>
+              <GeneralTableBody>
+                <AccountSignatureRows sig={s.fee_payer_signer} />
+              </GeneralTableBody>
+            </Table>
+          </Paper>
+        </SignatureFieldRow>
+      </>
+    );
+  } else {
+    const {type: _t, ...rest} = s;
+    const restEntries = Object.entries(rest).filter(
+      ([, v]) => v !== undefined && v !== null,
+    );
+    const simpleObject =
+      restEntries.length > 0 &&
+      restEntries.every(
+        ([, v]) =>
+          typeof v === "string" ||
+          typeof v === "number" ||
+          typeof v === "boolean",
+      );
+
+    body = (
+      <>
+        {typeField ? (
+          <SignatureFieldRow label="Type">{typeField}</SignatureFieldRow>
+        ) : null}
+        {simpleObject ? (
+          restEntries.map(([key, value]) => (
+            <SignatureFieldRow key={key} label={key.replaceAll("_", " ")}>
+              {typeof value === "string" && isHexString(value) ? (
+                <HashButton hash={value} type={HashType.OTHERS} />
+              ) : (
+                String(value)
+              )}
+            </SignatureFieldRow>
+          ))
+        ) : (
+          <SignatureFieldRow label="Raw">
+            <JsonViewCard data={signature} collapsedByDefault />
+          </SignatureFieldRow>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" sx={{overflow: "hidden"}}>
+      <Table size="small" sx={{tableLayout: "fixed"}}>
+        <GeneralTableBody>{body}</GeneralTableBody>
+      </Table>
+    </Paper>
+  );
+}

--- a/app/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/PendingTransactionOverviewTab.tsx
@@ -6,7 +6,7 @@ import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import {APTCurrencyValue} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import SignatureOverviewTable from "./Components/SignatureOverviewTable";
 import {parseExpirationTimestamp} from "../../utils";
 import {getLearnMoreTooltip} from "../helpers";
 
@@ -59,7 +59,7 @@ export default function PendingTransactionOverviewTab({
         <ContentRow
           title="Signature:"
           value={
-            <JsonViewCard data={transactionData.signature} collapsedByDefault />
+            <SignatureOverviewTable signature={transactionData.signature} />
           }
           tooltip={getLearnMoreTooltip("signature")}
         />

--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -15,7 +15,7 @@ import {APTCurrencyValue} from "../../../components/IndividualPageContent/Conten
 import GasFeeValue from "../../../components/IndividualPageContent/ContentValue/GasFeeValue";
 import GasValue from "../../../components/IndividualPageContent/ContentValue/GasValue";
 import TimestampValue from "../../../components/IndividualPageContent/ContentValue/TimestampValue";
-import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import SignatureOverviewTable from "./Components/SignatureOverviewTable";
 import {LearnMoreTooltip} from "../../../components/IndividualPageContent/LearnMoreTooltip";
 import {TransactionStatus} from "../../../components/TransactionStatus";
 import {standardizeAddress, tryStandardizeAddress} from "../../../utils";
@@ -961,7 +961,7 @@ export default function UserTransactionOverviewTab({
         <ContentRow
           title="Signature:"
           value={
-            <JsonViewCard data={transactionData.signature} collapsedByDefault />
+            <SignatureOverviewTable signature={transactionData.signature} />
           }
           tooltip={getLearnMoreTooltip("signature")}
         />

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -193,7 +193,7 @@ The app shell that wraps every page.
 | **Gas** | Gas fee, storage refund, net gas, gas unit price, max gas, VM status. |
 | **Block** | Link to parent block. |
 | **Timestamps** | Expiration and execution timestamp. |
-| **Signature** | JSON display of signature data. |
+| **Signature** | Table-style breakdown (same layout family as FeeStatement on Events); hex fields use expandable hash chips; nested or unknown shapes fall back to JSON. |
 | **Hashes** | State, event, and accumulator root hashes. |
 | **Replay protection** | Nonce display when applicable (vs sequence number). |
 
@@ -1162,6 +1162,7 @@ The app shell that wraps every page.
 | `app/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx` | Currency formatting (octa → APT) |
 | `app/components/Table/verifiedLevel.test.ts` | FEAT-COIN-003 / FEAT-UI-002 (verification level determination: native, verified, banned, recognized, unverified, disabled) |
 | `app/pages/Transaction/utils.test.ts` | FEAT-TXN-002/003 (tx amounts, counterparty, balance changes) |
+| `app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx` | FEAT-TXN-002 (signature overview table: Ed25519 rows, empty state) |
 | `app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.test.ts` | FEAT-TXN-011 (Move type display badges) |
 | `app/pages/Transaction/txnTabValues.test.ts` | FEAT-TXN-001 (tab selection by transaction type, trace tab only for user txns) |
 | `app/pages/Transaction/txnTabInvariants.test.ts` | FEAT-TXN-009 (DEX/LSD protocol coverage), TransactionTypeName enum values |

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -1162,7 +1162,7 @@ The app shell that wraps every page.
 | `app/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx` | Currency formatting (octa → APT) |
 | `app/components/Table/verifiedLevel.test.ts` | FEAT-COIN-003 / FEAT-UI-002 (verification level determination: native, verified, banned, recognized, unverified, disabled) |
 | `app/pages/Transaction/utils.test.ts` | FEAT-TXN-002/003 (tx amounts, counterparty, balance changes) |
-| `app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx` | FEAT-TXN-002 (signature overview table: Ed25519 rows, empty state) |
+| `app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx` | FEAT-TXN-002 (signature overview: Ed25519, multi-Ed25519, single_sender, multi_agent, fee_payer, fallbacks; stable keys for duplicate secondary addresses) |
 | `app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.test.ts` | FEAT-TXN-011 (Move type display badges) |
 | `app/pages/Transaction/txnTabValues.test.ts` | FEAT-TXN-001 (tab selection by transaction type, trace tab only for user txns) |
 | `app/pages/Transaction/txnTabInvariants.test.ts` | FEAT-TXN-009 (DEX/LSD protocol coverage), TransactionTypeName enum values |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Signature** section on the user transaction overview (and pending overview) now uses the same visual pattern as the **Fee Statement** event view: an outlined `Paper` with a small fixed-layout table, bold label column (~38% width), optional caption descriptions, and values in the second column.

For common shapes (`ed25519_signature`, secp256k1-style hex pairs, `multi_ed25519_signature`, `single_sender`, `multi_agent_signature`, `fee_payer_signature`), fields are broken into readable rows; hex blobs use the existing `HashButton` chips. Unknown or nested structures fall back to `JsonViewCard` inside a **Raw** row.

### Mobile (xs)

- Below the `sm` breakpoint, each field’s **label and value stack vertically** (same idea as `ContentRow`: full-width title, then value), using block-level table rows/cells instead of squeezed side-by-side columns.
- Tables use **`tableLayout: auto`** on xs and **`fixed`** from `sm+` so narrow viewports are not forced into rigid column splits.
- The signature block is wrapped in a **horizontal scroll** container (`overflow-x: auto`, `minWidth: 0`, `-webkit-overflow-scrolling: touch`) so wide hash chips or JSON still fit without clipping the page.
- Nested inner signature tables use the same scroll wrapper; `Paper` uses `maxWidth: 100%`.

### Review follow-ups (Copilot)

- Secondary authenticator list keys no longer use `JSON.stringify(sub)`; they use `secondarySignerAuthenticatorKey(addresses, i)` (`secondary-signer-{addr}-{i}` or `secondary-signer-{i}`). Duplicate secondary **address** rows use `secondary-address-{addr}-{i}` with an explicit Biome note.
- `single_sender` branch: renamed local `sig` → `signaturePayload` to avoid shadowing the `AccountSignatureRows` parameter.
- Tests: `multi_ed25519_signature`, `single_sender`, `multi_agent_signature`, `fee_payer_signature`, unknown-shape Raw fallback, nested sender JSON fallback; `HashButton` mocked for isolation; `cleanup` between cases.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run SignatureOverviewTable`

## Docs

- `docs/FEATURES_SPECIFICATION.md` (FEAT-TXN-002 signature row) and Appendix B test entry
- `CHANGELOG.md` under [Unreleased] → Improved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66b2128e-dcaa-45e6-ac10-3ba09c783c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66b2128e-dcaa-45e6-ac10-3ba09c783c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

