### PR TITLE
feat(txn): add Decibel detail tab with parsed orders, deposits, and w…

### DIFF
--- a/app/api/hooks/useGetDecibelMarketName.ts
+++ b/app/api/hooks/useGetDecibelMarketName.ts
@@ -1,0 +1,52 @@
+import {useQuery} from "@tanstack/react-query";
+import {useAptosClient, useNetworkValue} from "../../global-config";
+import {DECIBEL_CONTRACTS} from "../../utils/decibel";
+
+const PERP_MARKET_CONFIG_TYPE = "::perp_market_config::PerpMarketConfiguration";
+
+function getResourceType(networkValue: string): string | undefined {
+  // Pick the contract address matching the current network
+  for (const addr of DECIBEL_CONTRACTS) {
+    // Mainnet contract is index 0, testnet is index 1.
+    // We try the resource with each — the query will fail gracefully if wrong.
+    return `${addr}${PERP_MARKET_CONFIG_TYPE}`;
+  }
+  return undefined;
+}
+
+export function useGetDecibelMarketName(marketAddress: string): {
+  isLoading: boolean;
+  data: string | undefined;
+} {
+  const aptosClient = useAptosClient();
+  const networkValue = useNetworkValue();
+
+  const query = useQuery({
+    queryKey: ["decibelMarketName", marketAddress, networkValue],
+    queryFn: async () => {
+      // Try each contract address (mainnet and testnet) until one works
+      for (const addr of DECIBEL_CONTRACTS) {
+        try {
+          const resource = await aptosClient.getAccountResource(
+            marketAddress,
+            `${addr}${PERP_MARKET_CONFIG_TYPE}`,
+          );
+          const data = resource.data as {
+            info?: {name?: string};
+          };
+          return data?.info?.name ?? undefined;
+        } catch {
+          // Try next contract address
+        }
+      }
+      return undefined;
+    },
+    enabled: !!marketAddress,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {isLoading: query.isLoading, data: query.data ?? undefined};
+}

--- a/app/api/hooks/useGetDecibelMarketName.ts
+++ b/app/api/hooks/useGetDecibelMarketName.ts
@@ -4,16 +4,6 @@ import {DECIBEL_CONTRACTS} from "../../utils/decibel";
 
 const PERP_MARKET_CONFIG_TYPE = "::perp_market_config::PerpMarketConfiguration";
 
-function getResourceType(networkValue: string): string | undefined {
-  // Pick the contract address matching the current network
-  for (const addr of DECIBEL_CONTRACTS) {
-    // Mainnet contract is index 0, testnet is index 1.
-    // We try the resource with each — the query will fail gracefully if wrong.
-    return `${addr}${PERP_MARKET_CONFIG_TYPE}`;
-  }
-  return undefined;
-}
-
 export function useGetDecibelMarketName(marketAddress: string): {
   isLoading: boolean;
   data: string | undefined;

--- a/app/pages/Transaction/Tabs.tsx
+++ b/app/pages/Transaction/Tabs.tsx
@@ -7,6 +7,7 @@ import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import ShowChartOutlinedIcon from "@mui/icons-material/ShowChartOutlined";
 import {
   Accordion,
   AccordionDetails,
@@ -29,11 +30,13 @@ import {TransactionTypeName} from "../../components/TransactionType";
 import {useNetworkName} from "../../global-config/GlobalConfig";
 import {useNavigate} from "../../routing";
 import {assertNever} from "../../utils";
+import {isDecibelTransaction} from "../../utils/decibel";
 import {getLearnMoreTooltip} from "./helpers";
 import BalanceChangeTab from "./Tabs/BalanceChangeTab";
 import BlockEpilogueOverviewTab from "./Tabs/BlockEpilogueOverviewTab";
 import BlockMetadataOverviewTab from "./Tabs/BlockMetadataOverviewTab";
 import ChangesTab from "./Tabs/ChangesTab";
+import DecibelTab from "./Tabs/DecibelTab";
 import EventsTab from "./Tabs/EventsTab";
 import GenesisTransactionOverviewTab from "./Tabs/GenesisTransactionOverviewTab";
 import PayloadTab from "./Tabs/PayloadTab";
@@ -46,15 +49,14 @@ import ValidatorTransactionTab from "./Tabs/ValidatorTransactionTab";
 
 export function getTabValues(transaction: Types.Transaction): TabValue[] {
   switch (transaction.type) {
-    case TransactionTypeName.User:
-      return [
-        "userTxnOverview",
-        "balanceChange",
-        "events",
-        "payload",
-        "changes",
-        "trace",
-      ];
+    case TransactionTypeName.User: {
+      const tabs: TabValue[] = ["userTxnOverview"];
+      if (isDecibelTransaction(transaction)) {
+        tabs.push("decibelDetail");
+      }
+      tabs.push("balanceChange", "events", "payload", "changes", "trace");
+      return tabs;
+    }
     case TransactionTypeName.BlockMetadata:
       return ["blockMetadataOverview", "events", "changes"];
     case TransactionTypeName.StateCheckpoint:
@@ -80,6 +82,7 @@ const TabComponents = Object.freeze({
   pendingTxnOverview: PendingTransactionOverviewTab,
   genesisTxnOverview: GenesisTransactionOverviewTab,
   validatorTxnOverview: ValidatorTransactionTab,
+  decibelDetail: DecibelTab,
   balanceChange: BalanceChangeTab,
   events: EventsTab,
   payload: PayloadTab,
@@ -101,6 +104,8 @@ function getTabLabel(value: TabValue): string {
     case "validatorTxnOverview":
     case "unknown":
       return "Overview";
+    case "decibelDetail":
+      return "Decibel";
     case "balanceChange":
       return "Balance Change";
     case "events":
@@ -126,6 +131,8 @@ function getTabIcon(value: TabValue): React.JSX.Element {
     case "genesisTxnOverview":
     case "validatorTxnOverview":
       return <BarChartOutlinedIcon fontSize="small" />;
+    case "decibelDetail":
+      return <ShowChartOutlinedIcon fontSize="small" />;
     case "balanceChange":
       return <AccountBalanceWalletOutlinedIcon fontSize="small" />;
     case "events":

--- a/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
@@ -71,7 +71,6 @@ export default function DecibelEventView({
 // ---------------------------------------------------------------------------
 
 function Row({label, children}: {label: string; children: React.ReactNode}) {
-  const theme = useTheme();
   return (
     <GeneralTableRow>
       <GeneralTableCell
@@ -294,16 +293,19 @@ function PriceSizeTable({
           </TableRow>
         </TableHead>
         <TableBody>
-          {prices.map((price, i) => (
-            <GeneralTableRow key={i}>
-              <GeneralTableCell>
-                <MonoText>{price}</MonoText>
-              </GeneralTableCell>
-              <GeneralTableCell>
-                <MonoText>{sizes[i] ?? "—"}</MonoText>
-              </GeneralTableCell>
-            </GeneralTableRow>
-          ))}
+          {prices.map((price, i) => {
+            const size = sizes[i] ?? "—";
+            return (
+              <GeneralTableRow key={`${price}-${size}`}>
+                <GeneralTableCell>
+                  <MonoText>{price}</MonoText>
+                </GeneralTableCell>
+                <GeneralTableCell>
+                  <MonoText>{size}</MonoText>
+                </GeneralTableCell>
+              </GeneralTableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </Box>

--- a/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
@@ -15,6 +15,7 @@ import {
   useTheme,
 } from "@mui/material";
 import * as React from "react";
+import {useGetDecibelMarketName} from "../../../../api/hooks/useGetDecibelMarketName";
 import HashButton, {HashType} from "../../../../components/HashButton";
 import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
@@ -146,6 +147,20 @@ function ObjectValue({hash}: {hash: string}) {
   return <HashButton hash={hash} type={HashType.OBJECT} size="small" />;
 }
 
+function MarketValue({hash}: {hash: string}) {
+  const {data: name} = useGetDecibelMarketName(hash);
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      {name && (
+        <Typography variant="body2" sx={{fontWeight: 600}}>
+          {name}
+        </Typography>
+      )}
+      <HashButton hash={hash} type={HashType.OBJECT} size="small" />
+    </Stack>
+  );
+}
+
 function extractInner(val: unknown): string | undefined {
   if (typeof val === "object" && val !== null && "inner" in val) {
     return (val as {inner: string}).inner;
@@ -200,7 +215,7 @@ function OrderEventView({data}: {data: Record<string, unknown>}) {
         )}
       </Row>
       <Row label="Market">
-        <ObjectValue hash={String(data.market)} />
+        <MarketValue hash={String(data.market)} />
       </Row>
       <Row label="Price">
         <MonoText>{String(data.price)}</MonoText>
@@ -308,7 +323,7 @@ function BulkOrderPlacedEventView({data}: {data: Record<string, unknown>}) {
   return (
     <EventTable rawData={data}>
       <Row label="Market">
-        <ObjectValue hash={String(data.market)} />
+        <MarketValue hash={String(data.market)} />
       </Row>
       <Row label="Order ID">
         <MonoText>{String(data.order_id)}</MonoText>
@@ -379,7 +394,7 @@ function BulkOrderFilledEventView({data}: {data: Record<string, unknown>}) {
         <SideLabel isBid={isBid} />
       </Row>
       <Row label="Market">
-        <ObjectValue hash={String(data.market)} />
+        <MarketValue hash={String(data.market)} />
       </Row>
       <Row label="Price">
         <MonoText>{String(data.price)}</MonoText>
@@ -426,7 +441,7 @@ function TradeEventView({data}: {data: Record<string, unknown>}) {
       )}
       {market && (
         <Row label="Market">
-          <ObjectValue hash={market} />
+          <MarketValue hash={market} />
         </Row>
       )}
       <Row label="Price">
@@ -496,7 +511,7 @@ function CollateralBalanceChangeEventView({
       )}
       {balMarket && (
         <Row label="Market">
-          <ObjectValue hash={balMarket} />
+          <MarketValue hash={balMarket} />
         </Row>
       )}
     </EventTable>
@@ -517,7 +532,7 @@ function PositionUpdateEventView({data}: {data: Record<string, unknown>}) {
       </Row>
       {market && (
         <Row label="Market">
-          <ObjectValue hash={market} />
+          <MarketValue hash={market} />
         </Row>
       )}
       <Row label="Side">
@@ -547,7 +562,7 @@ function OpenInterestUpdateEventView({data}: {data: Record<string, unknown>}) {
     <EventTable rawData={data}>
       {market && (
         <Row label="Market">
-          <ObjectValue hash={market} />
+          <MarketValue hash={market} />
         </Row>
       )}
       <Row label="Current Open Interest">
@@ -600,7 +615,7 @@ function PriceUpdateEventView({data}: {data: Record<string, unknown>}) {
     <EventTable rawData={data}>
       {market && (
         <Row label="Market">
-          <ObjectValue hash={market} />
+          <MarketValue hash={market} />
         </Row>
       )}
       <Row label="Oracle Price">

--- a/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
@@ -1,15 +1,20 @@
+import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
+import TableChartOutlinedIcon from "@mui/icons-material/TableChartOutlined";
 import {
   Box,
   Chip,
+  IconButton,
   Paper,
   Stack,
   Table,
   TableBody,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
+import * as React from "react";
 import HashButton, {HashType} from "../../../../components/HashButton";
 import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
 import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
@@ -87,12 +92,37 @@ function Row({label, children}: {label: string; children: React.ReactNode}) {
   );
 }
 
-function EventTable({children}: {children: React.ReactNode}) {
+function EventTable({
+  children,
+  rawData,
+}: {
+  children: React.ReactNode;
+  rawData: Record<string, unknown>;
+}) {
+  const [showRaw, setShowRaw] = React.useState(false);
+
   return (
     <Paper variant="outlined" sx={{overflow: "hidden"}}>
-      <Table size="small" sx={{tableLayout: "fixed"}}>
-        <TableBody>{children}</TableBody>
-      </Table>
+      <Stack direction="row" justifyContent="flex-end" sx={{px: 1, pt: 0.5}}>
+        <Tooltip title={showRaw ? "Formatted view" : "Raw JSON"}>
+          <IconButton size="small" onClick={() => setShowRaw((v) => !v)}>
+            {showRaw ? (
+              <TableChartOutlinedIcon fontSize="small" />
+            ) : (
+              <CodeOutlinedIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Stack>
+      {showRaw ? (
+        <Box sx={{p: 1, pt: 0}}>
+          <JsonViewCard data={rawData} />
+        </Box>
+      ) : (
+        <Table size="small" sx={{tableLayout: "fixed"}}>
+          <TableBody>{children}</TableBody>
+        </Table>
+      )}
     </Paper>
   );
 }
@@ -162,7 +192,7 @@ function OrderEventView({data}: {data: Record<string, unknown>}) {
     | undefined;
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       <Row label="Side">
         <SideLabel isBid={isBid} />
         {data.is_taker === true && (
@@ -276,7 +306,7 @@ function BulkOrderPlacedEventView({data}: {data: Record<string, unknown>}) {
   const cancelledAskSizes = (data.cancelled_ask_sizes as string[]) ?? [];
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       <Row label="Market">
         <ObjectValue hash={String(data.market)} />
       </Row>
@@ -344,7 +374,7 @@ function BulkOrderFilledEventView({data}: {data: Record<string, unknown>}) {
   const isBid = data.is_bid === true;
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       <Row label="Side">
         <SideLabel isBid={isBid} />
       </Row>
@@ -385,7 +415,7 @@ function TradeEventView({data}: {data: Record<string, unknown>}) {
   const source = extractVariant(data.source);
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       {action && (
         <Row label="Action">
           <Chip label={action} size="small" variant="outlined" />
@@ -444,7 +474,7 @@ function CollateralBalanceChangeEventView({
   const balMarket = balanceType ? extractInner(balanceType.market) : undefined;
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       {changeType && (
         <Row label="Change Type">
           <Chip label={changeType} size="small" variant="outlined" />
@@ -481,7 +511,7 @@ function PositionUpdateEventView({data}: {data: Record<string, unknown>}) {
   const market = extractInner(data.market);
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       <Row label="User">
         <AddressValue hash={String(data.user)} />
       </Row>
@@ -514,7 +544,7 @@ function OpenInterestUpdateEventView({data}: {data: Record<string, unknown>}) {
   const market = extractInner(data.market);
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       {market && (
         <Row label="Market">
           <ObjectValue hash={market} />
@@ -531,12 +561,43 @@ function OpenInterestUpdateEventView({data}: {data: Record<string, unknown>}) {
 // PriceUpdateEvent
 // ---------------------------------------------------------------------------
 
+const FUNDING_LABELS: Record<string, string> = {
+  funding_index: "Funding Index",
+  funding_period_us: "Funding Period",
+  funding_timestamp_us: "Funding Timestamp",
+  instant_daily_funding_rate: "Daily Funding Rate",
+  outstanding_funding: "Outstanding Funding",
+  outstanding_funding_timestamp_us: "Outstanding Timestamp",
+};
+
+function FundingView({funding}: {funding: Record<string, unknown>}) {
+  const entries = Object.entries(funding).filter(
+    ([key]) => key !== "__variant__",
+  );
+  return (
+    <Stack spacing={0.5}>
+      {entries.map(([key, value]) => (
+        <Stack key={key} direction="row" spacing={1} alignItems="baseline">
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{minWidth: 140, flexShrink: 0}}
+          >
+            {FUNDING_LABELS[key] ?? key}
+          </Typography>
+          <MonoText>{String(value)}</MonoText>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
 function PriceUpdateEventView({data}: {data: Record<string, unknown>}) {
   const market =
     typeof data.market === "string" ? data.market : extractInner(data.market);
 
   return (
-    <EventTable>
+    <EventTable rawData={data}>
       {market && (
         <Row label="Market">
           <ObjectValue hash={market} />
@@ -558,11 +619,17 @@ function PriceUpdateEventView({data}: {data: Record<string, unknown>}) {
           <MonoText>{String(data.impact_ask_px)}</MonoText>
         </Row>
       )}
-      {data.funding !== undefined && (
+      {data.funding !== undefined &&
+      typeof data.funding === "object" &&
+      data.funding !== null ? (
+        <Row label="Funding">
+          <FundingView funding={data.funding as Record<string, unknown>} />
+        </Row>
+      ) : data.funding !== undefined ? (
         <Row label="Funding">
           <MonoText>{String(data.funding)}</MonoText>
         </Row>
-      )}
+      ) : null}
     </EventTable>
   );
 }

--- a/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
@@ -1,0 +1,568 @@
+import {
+  Box,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import HashButton, {HashType} from "../../../../components/HashButton";
+import JsonViewCard from "../../../../components/IndividualPageContent/JsonViewCard";
+import GeneralTableCell from "../../../../components/Table/GeneralTableCell";
+import GeneralTableHeaderCell from "../../../../components/Table/GeneralTableHeaderCell";
+import GeneralTableRow from "../../../../components/Table/GeneralTableRow";
+import {DECIBEL_CONTRACTS} from "../../../../utils/decibel";
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function isDecibelEvent(eventType: string): boolean {
+  return DECIBEL_CONTRACTS.some((addr) => eventType.startsWith(`${addr}::`));
+}
+
+const RENDERERS: Record<
+  string,
+  React.ComponentType<{data: Record<string, unknown>}>
+> = {
+  OrderEvent: OrderEventView,
+  BulkOrderPlacedEvent: BulkOrderPlacedEventView,
+  BulkOrderFilledEvent: BulkOrderFilledEventView,
+  TradeEvent: TradeEventView,
+  CollateralBalanceChangeEvent: CollateralBalanceChangeEventView,
+  PositionUpdateEvent: PositionUpdateEventView,
+  OpenInterestUpdateEvent: OpenInterestUpdateEventView,
+  PriceUpdateEvent: PriceUpdateEventView,
+};
+
+function getEventShortName(eventType: string): string {
+  return eventType.split("::").pop() ?? eventType;
+}
+
+export default function DecibelEventView({
+  eventType,
+  data,
+}: {
+  eventType: string;
+  data: Record<string, unknown>;
+}) {
+  const shortName = getEventShortName(eventType);
+  const Renderer = RENDERERS[shortName];
+
+  if (!Renderer) {
+    return <JsonViewCard data={data} />;
+  }
+
+  return <Renderer data={data} />;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function Row({label, children}: {label: string; children: React.ReactNode}) {
+  const theme = useTheme();
+  return (
+    <GeneralTableRow>
+      <GeneralTableCell
+        component="th"
+        scope="row"
+        sx={{
+          verticalAlign: "top",
+          fontWeight: 600,
+          color: "text.primary",
+          width: "38%",
+        }}
+      >
+        {label}
+      </GeneralTableCell>
+      <GeneralTableCell sx={{verticalAlign: "top"}}>
+        {children}
+      </GeneralTableCell>
+    </GeneralTableRow>
+  );
+}
+
+function EventTable({children}: {children: React.ReactNode}) {
+  return (
+    <Paper variant="outlined" sx={{overflow: "hidden"}}>
+      <Table size="small" sx={{tableLayout: "fixed"}}>
+        <TableBody>{children}</TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+function SideLabel({isBid}: {isBid: boolean}) {
+  return (
+    <Chip
+      label={isBid ? "Buy" : "Sell"}
+      size="small"
+      color={isBid ? "success" : "error"}
+      sx={{fontWeight: 600}}
+    />
+  );
+}
+
+function AddressValue({hash}: {hash: string}) {
+  return <HashButton hash={hash} type={HashType.ACCOUNT} size="small" />;
+}
+
+function ObjectValue({hash}: {hash: string}) {
+  return <HashButton hash={hash} type={HashType.OBJECT} size="small" />;
+}
+
+function extractInner(val: unknown): string | undefined {
+  if (typeof val === "object" && val !== null && "inner" in val) {
+    return (val as {inner: string}).inner;
+  }
+  return undefined;
+}
+
+function extractVariant(val: unknown): string | undefined {
+  if (typeof val === "object" && val !== null && "__variant__" in val) {
+    return (val as {__variant__: string}).__variant__;
+  }
+  return undefined;
+}
+
+function extractVecFirst(val: unknown): unknown | undefined {
+  if (typeof val === "object" && val !== null && "vec" in val) {
+    const vec = (val as {vec: unknown[]}).vec;
+    return vec.length > 0 ? vec[0] : undefined;
+  }
+  return undefined;
+}
+
+function MonoText({children}: {children: React.ReactNode}) {
+  return (
+    <Typography variant="body2" sx={{fontFamily: "monospace"}}>
+      {children}
+    </Typography>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrderEvent
+// ---------------------------------------------------------------------------
+
+function OrderEventView({data}: {data: Record<string, unknown>}) {
+  const isBid = data.is_bid === true;
+  const status = extractVariant(data.status);
+  const tif = extractVariant(data.time_in_force);
+  const cancelReason = extractVariant(
+    extractVecFirst(data.cancellation_reason),
+  );
+  const clientOrderId = extractVecFirst(data.client_order_id) as
+    | string
+    | undefined;
+
+  return (
+    <EventTable>
+      <Row label="Side">
+        <SideLabel isBid={isBid} />
+        {data.is_taker === true && (
+          <Chip label="Taker" size="small" variant="outlined" sx={{ml: 1}} />
+        )}
+      </Row>
+      <Row label="Market">
+        <ObjectValue hash={String(data.market)} />
+      </Row>
+      <Row label="Price">
+        <MonoText>{String(data.price)}</MonoText>
+      </Row>
+      <Row label="Original Size">
+        <MonoText>{String(data.orig_size)}</MonoText>
+      </Row>
+      {data.remaining_size !== undefined && (
+        <Row label="Remaining Size">
+          <MonoText>{String(data.remaining_size)}</MonoText>
+        </Row>
+      )}
+      {data.size_delta !== undefined && (
+        <Row label="Size Delta">
+          <MonoText>{String(data.size_delta)}</MonoText>
+        </Row>
+      )}
+      {status && (
+        <Row label="Status">
+          <Chip label={status} size="small" variant="outlined" />
+        </Row>
+      )}
+      {tif && <Row label="Time in Force">{tif}</Row>}
+      {cancelReason && <Row label="Cancel Reason">{cancelReason}</Row>}
+      <Row label="Order ID">
+        <MonoText>{String(data.order_id)}</MonoText>
+      </Row>
+      <Row label="User">
+        <AddressValue hash={String(data.user)} />
+      </Row>
+      {"parent" in data && data.parent ? (
+        <Row label="Parent">
+          <AddressValue hash={String(data.parent)} />
+        </Row>
+      ) : null}
+      {clientOrderId && (
+        <Row label="Client Order ID">
+          <MonoText>{clientOrderId}</MonoText>
+        </Row>
+      )}
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BulkOrderPlacedEvent
+// ---------------------------------------------------------------------------
+
+function PriceSizeTable({
+  label,
+  prices,
+  sizes,
+  color,
+}: {
+  label: string;
+  prices: string[];
+  sizes: string[];
+  color: "success" | "error";
+}) {
+  const theme = useTheme();
+  if (prices.length === 0) return null;
+
+  return (
+    <Box sx={{mb: 1}}>
+      <Typography
+        variant="subtitle2"
+        sx={{mb: 0.5, color: theme.palette[color].main}}
+      >
+        {label} ({prices.length})
+      </Typography>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <GeneralTableHeaderCell header="Price" />
+            <GeneralTableHeaderCell header="Size" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {prices.map((price, i) => (
+            <GeneralTableRow key={i}>
+              <GeneralTableCell>
+                <MonoText>{price}</MonoText>
+              </GeneralTableCell>
+              <GeneralTableCell>
+                <MonoText>{sizes[i] ?? "—"}</MonoText>
+              </GeneralTableCell>
+            </GeneralTableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+function BulkOrderPlacedEventView({data}: {data: Record<string, unknown>}) {
+  const bidPrices = (data.bid_prices as string[]) ?? [];
+  const bidSizes = (data.bid_sizes as string[]) ?? [];
+  const askPrices = (data.ask_prices as string[]) ?? [];
+  const askSizes = (data.ask_sizes as string[]) ?? [];
+  const cancelledBidPrices = (data.cancelled_bid_prices as string[]) ?? [];
+  const cancelledBidSizes = (data.cancelled_bid_sizes as string[]) ?? [];
+  const cancelledAskPrices = (data.cancelled_ask_prices as string[]) ?? [];
+  const cancelledAskSizes = (data.cancelled_ask_sizes as string[]) ?? [];
+
+  return (
+    <EventTable>
+      <Row label="Market">
+        <ObjectValue hash={String(data.market)} />
+      </Row>
+      <Row label="Order ID">
+        <MonoText>{String(data.order_id)}</MonoText>
+      </Row>
+      <Row label="User">
+        <AddressValue hash={String(data.user)} />
+      </Row>
+      <Row label="Sequence">
+        <MonoText>
+          {String(data.sequence_number)}{" "}
+          {data.previous_seq_num !== undefined && (
+            <Typography component="span" variant="body2" color="text.secondary">
+              (prev: {String(data.previous_seq_num)})
+            </Typography>
+          )}
+        </MonoText>
+      </Row>
+      <Row label="Bids">
+        <PriceSizeTable
+          label="Bids"
+          prices={bidPrices}
+          sizes={bidSizes}
+          color="success"
+        />
+      </Row>
+      <Row label="Asks">
+        <PriceSizeTable
+          label="Asks"
+          prices={askPrices}
+          sizes={askSizes}
+          color="error"
+        />
+      </Row>
+      {cancelledBidPrices.length > 0 && (
+        <Row label="Cancelled Bids">
+          <PriceSizeTable
+            label="Cancelled Bids"
+            prices={cancelledBidPrices}
+            sizes={cancelledBidSizes}
+            color="success"
+          />
+        </Row>
+      )}
+      {cancelledAskPrices.length > 0 && (
+        <Row label="Cancelled Asks">
+          <PriceSizeTable
+            label="Cancelled Asks"
+            prices={cancelledAskPrices}
+            sizes={cancelledAskSizes}
+            color="error"
+          />
+        </Row>
+      )}
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BulkOrderFilledEvent
+// ---------------------------------------------------------------------------
+
+function BulkOrderFilledEventView({data}: {data: Record<string, unknown>}) {
+  const isBid = data.is_bid === true;
+
+  return (
+    <EventTable>
+      <Row label="Side">
+        <SideLabel isBid={isBid} />
+      </Row>
+      <Row label="Market">
+        <ObjectValue hash={String(data.market)} />
+      </Row>
+      <Row label="Price">
+        <MonoText>{String(data.price)}</MonoText>
+      </Row>
+      {"orig_price" in data && data.orig_price ? (
+        <Row label="Original Price">
+          <MonoText>{String(data.orig_price)}</MonoText>
+        </Row>
+      ) : null}
+      <Row label="Filled Size">
+        <MonoText>{String(data.filled_size)}</MonoText>
+      </Row>
+      <Row label="Order ID">
+        <MonoText>{String(data.order_id)}</MonoText>
+      </Row>
+      <Row label="Fill ID">
+        <MonoText>{String(data.fill_id)}</MonoText>
+      </Row>
+      <Row label="User">
+        <AddressValue hash={String(data.user)} />
+      </Row>
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TradeEvent
+// ---------------------------------------------------------------------------
+
+function TradeEventView({data}: {data: Record<string, unknown>}) {
+  const action = extractVariant(data.action);
+  const market = extractInner(data.market);
+  const source = extractVariant(data.source);
+
+  return (
+    <EventTable>
+      {action && (
+        <Row label="Action">
+          <Chip label={action} size="small" variant="outlined" />
+          {data.is_taker === true && (
+            <Chip label="Taker" size="small" variant="outlined" sx={{ml: 1}} />
+          )}
+        </Row>
+      )}
+      {market && (
+        <Row label="Market">
+          <ObjectValue hash={market} />
+        </Row>
+      )}
+      <Row label="Price">
+        <MonoText>{String(data.price)}</MonoText>
+      </Row>
+      <Row label="Size">
+        <MonoText>{String(data.size)}</MonoText>
+      </Row>
+      <Row label="Fee">
+        <MonoText>{String(data.fee)}</MonoText>
+      </Row>
+      <Row label="Account">
+        <AddressValue hash={String(data.account)} />
+      </Row>
+      {data.realized_pnl !== undefined && String(data.realized_pnl) !== "0" && (
+        <Row label="Realized PnL">
+          <MonoText>{String(data.realized_pnl)}</MonoText>
+        </Row>
+      )}
+      {source && <Row label="Source">{source}</Row>}
+      <Row label="Fill ID">
+        <MonoText>{String(data.fill_id)}</MonoText>
+      </Row>
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CollateralBalanceChangeEvent
+// ---------------------------------------------------------------------------
+
+function CollateralBalanceChangeEventView({
+  data,
+}: {
+  data: Record<string, unknown>;
+}) {
+  const assetInner = extractInner(data.asset_type);
+  const changeType = extractVariant(data.change_type);
+  const balanceType = data.balance_type as Record<string, unknown> | undefined;
+  const balVariant = balanceType ? extractVariant(balanceType) : undefined;
+  const account =
+    balanceType && typeof balanceType.account === "string"
+      ? balanceType.account
+      : undefined;
+  const balMarket = balanceType ? extractInner(balanceType.market) : undefined;
+
+  return (
+    <EventTable>
+      {changeType && (
+        <Row label="Change Type">
+          <Chip label={changeType} size="small" variant="outlined" />
+        </Row>
+      )}
+      <Row label="Delta">
+        <MonoText>{String(data.delta)}</MonoText>
+      </Row>
+      {assetInner && (
+        <Row label="Asset">
+          <ObjectValue hash={assetInner} />
+        </Row>
+      )}
+      {balVariant && <Row label="Balance Type">{balVariant}</Row>}
+      {account && (
+        <Row label="Account">
+          <AddressValue hash={account} />
+        </Row>
+      )}
+      {balMarket && (
+        <Row label="Market">
+          <ObjectValue hash={balMarket} />
+        </Row>
+      )}
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PositionUpdateEvent
+// ---------------------------------------------------------------------------
+
+function PositionUpdateEventView({data}: {data: Record<string, unknown>}) {
+  const market = extractInner(data.market);
+
+  return (
+    <EventTable>
+      <Row label="User">
+        <AddressValue hash={String(data.user)} />
+      </Row>
+      {market && (
+        <Row label="Market">
+          <ObjectValue hash={market} />
+        </Row>
+      )}
+      <Row label="Side">
+        <SideLabel isBid={data.is_long === true} />
+        {data.is_isolated === true && (
+          <Chip label="Isolated" size="small" variant="outlined" sx={{ml: 1}} />
+        )}
+      </Row>
+      <Row label="Size">
+        <MonoText>{String(data.size)}</MonoText>
+      </Row>
+      <Row label="Leverage">
+        <MonoText>{String(data.user_leverage)}x</MonoText>
+      </Row>
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OpenInterestUpdateEvent
+// ---------------------------------------------------------------------------
+
+function OpenInterestUpdateEventView({data}: {data: Record<string, unknown>}) {
+  const market = extractInner(data.market);
+
+  return (
+    <EventTable>
+      {market && (
+        <Row label="Market">
+          <ObjectValue hash={market} />
+        </Row>
+      )}
+      <Row label="Current Open Interest">
+        <MonoText>{String(data.current_open_interest)}</MonoText>
+      </Row>
+    </EventTable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PriceUpdateEvent
+// ---------------------------------------------------------------------------
+
+function PriceUpdateEventView({data}: {data: Record<string, unknown>}) {
+  const market =
+    typeof data.market === "string" ? data.market : extractInner(data.market);
+
+  return (
+    <EventTable>
+      {market && (
+        <Row label="Market">
+          <ObjectValue hash={market} />
+        </Row>
+      )}
+      <Row label="Oracle Price">
+        <MonoText>{String(data.oracle_px)}</MonoText>
+      </Row>
+      <Row label="Mark Price">
+        <MonoText>{String(data.mark_px)}</MonoText>
+      </Row>
+      {data.impact_bid_px !== undefined && (
+        <Row label="Impact Bid">
+          <MonoText>{String(data.impact_bid_px)}</MonoText>
+        </Row>
+      )}
+      {data.impact_ask_px !== undefined && (
+        <Row label="Impact Ask">
+          <MonoText>{String(data.impact_ask_px)}</MonoText>
+        </Row>
+      )}
+      {data.funding !== undefined && (
+        <Row label="Funding">
+          <MonoText>{String(data.funding)}</MonoText>
+        </Row>
+      )}
+    </EventTable>
+  );
+}

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -8,6 +8,7 @@ import UploadOutlinedIcon from "@mui/icons-material/UploadOutlined";
 import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import {
   Box,
+  ButtonBase,
   Chip,
   Paper,
   Stack,
@@ -30,9 +31,11 @@ import {
 import {useGetDecibelMarketName} from "../../../api/hooks/useGetDecibelMarketName";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
+import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
 import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
+import {isValidAccountAddress} from "../../../utils";
 import type {
   DecibelDeposit,
   DecibelOrder,
@@ -81,12 +84,16 @@ function TruncatedCopyId({value}: {value: string}) {
 
   return (
     <Tooltip title={copied ? "Copied!" : value} arrow>
-      <Stack
-        direction="row"
-        alignItems="center"
-        spacing={0.5}
-        sx={{cursor: "pointer"}}
+      <ButtonBase
         onClick={handleCopy}
+        aria-label={`Copy ${value}`}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          borderRadius: 0.5,
+          px: 0.5,
+        }}
       >
         <Typography
           variant="body2"
@@ -96,7 +103,7 @@ function TruncatedCopyId({value}: {value: string}) {
           {truncated}
         </Typography>
         <ContentCopyIcon sx={{fontSize: 14, opacity: 0.6}} />
-      </Stack>
+      </ButtonBase>
     </Tooltip>
   );
 }
@@ -113,7 +120,7 @@ function AmountWithAsset({
   const {data: assetMetadata} = useGetAssetMetadata(asset);
   const assetCoin = findCoinData(coinData, asset);
   const decimals = assetCoin?.decimals ?? assetMetadata?.decimals ?? 0;
-  const displayAmount = Number(amount) / 10 ** decimals;
+  const displayAmount = getFormattedBalanceStr(amount, decimals);
 
   return (
     <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
@@ -141,6 +148,17 @@ function MarketValue({hash}: {hash: string}) {
       )}
       <HashButton hash={hash} type={HashType.OBJECT} size="small" />
     </Stack>
+  );
+}
+
+function SafeAccountLink({hash}: {hash: string}) {
+  if (isValidAccountAddress(hash)) {
+    return <HashButton hash={hash} type={HashType.ACCOUNT} size="small" />;
+  }
+  return (
+    <Typography variant="body2" sx={{fontFamily: "monospace"}}>
+      {hash}
+    </Typography>
   );
 }
 
@@ -180,15 +198,7 @@ function OrderRow({order}: {order: DecibelOrder}) {
       </GeneralTableCell>
       <GeneralTableCell>{order.timeInForce ?? "—"}</GeneralTableCell>
       <GeneralTableCell>
-        {order.subaccount ? (
-          <HashButton
-            hash={order.subaccount}
-            type={HashType.ACCOUNT}
-            size="small"
-          />
-        ) : (
-          "—"
-        )}
+        {order.subaccount ? <SafeAccountLink hash={order.subaccount} /> : "—"}
       </GeneralTableCell>
       <GeneralTableCell>
         {order.orderId ? <TruncatedCopyId value={order.orderId} /> : "—"}
@@ -260,6 +270,7 @@ function OrdersSection({orders}: {orders: DecibelOrder[]}) {
         Orders
       </Typography>
       {isMobile ? (
+        // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
         orders.map((order, i) => <OrderCard key={i} order={order} />)
       ) : (
         <Table>
@@ -278,6 +289,7 @@ function OrdersSection({orders}: {orders: DecibelOrder[]}) {
           </TableHead>
           <TableBody>
             {orders.map((order, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
               <OrderRow key={i} order={order} />
             ))}
           </TableBody>
@@ -308,11 +320,7 @@ function DepositRow({
         />
       </GeneralTableCell>
       <GeneralTableCell>
-        <HashButton
-          hash={deposit.subaccount}
-          type={HashType.ACCOUNT}
-          size="small"
-        />
+        <SafeAccountLink hash={deposit.subaccount} />
       </GeneralTableCell>
       <GeneralTableCell>
         {humanizeFunctionName(deposit.functionName)}
@@ -376,6 +384,7 @@ function DepositsSection({
       </Typography>
       {isMobile ? (
         deposits.map((d, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: deposits lack a unique identifier
           <DepositCard key={i} deposit={d} coinData={coinData} />
         ))
       ) : (
@@ -389,6 +398,7 @@ function DepositsSection({
           </TableHead>
           <TableBody>
             {deposits.map((d, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: deposits lack a unique identifier
               <DepositRow key={i} deposit={d} coinData={coinData} />
             ))}
           </TableBody>
@@ -419,11 +429,7 @@ function WithdrawRow({
         />
       </GeneralTableCell>
       <GeneralTableCell>
-        <HashButton
-          hash={withdraw.subaccount}
-          type={HashType.ACCOUNT}
-          size="small"
-        />
+        <SafeAccountLink hash={withdraw.subaccount} />
       </GeneralTableCell>
       <GeneralTableCell>
         {humanizeFunctionName(withdraw.functionName)}
@@ -487,6 +493,7 @@ function WithdrawalsSection({
       </Typography>
       {isMobile ? (
         withdrawals.map((w, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: withdrawals lack a unique identifier
           <WithdrawCard key={i} withdraw={w} coinData={coinData} />
         ))
       ) : (
@@ -500,6 +507,7 @@ function WithdrawalsSection({
           </TableHead>
           <TableBody>
             {withdrawals.map((w, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: withdrawals lack a unique identifier
               <WithdrawRow key={i} withdraw={w} coinData={coinData} />
             ))}
           </TableBody>

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -27,6 +27,7 @@ import {
   type CoinDescription,
   useGetCoinList,
 } from "../../../api/hooks/useGetCoinList";
+import {useGetDecibelMarketName} from "../../../api/hooks/useGetDecibelMarketName";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import GeneralTableCell from "../../../components/Table/GeneralTableCell";
@@ -129,6 +130,20 @@ function AmountWithAsset({
   );
 }
 
+function MarketValue({hash}: {hash: string}) {
+  const {data: name} = useGetDecibelMarketName(hash);
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      {name && (
+        <Typography variant="body2" sx={{fontWeight: 600}}>
+          {name}
+        </Typography>
+      )}
+      <HashButton hash={hash} type={HashType.OBJECT} size="small" />
+    </Stack>
+  );
+}
+
 function humanizeFunctionName(fnName: string): string {
   return fnName.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
@@ -150,7 +165,7 @@ function OrderRow({order}: {order: DecibelOrder}) {
         <SideChip side={order.side} />
       </GeneralTableCell>
       <GeneralTableCell>
-        <HashButton hash={order.market} type={HashType.OBJECT} size="small" />
+        <MarketValue hash={order.market} />
       </GeneralTableCell>
       <GeneralTableCell>{order.size ?? "—"}</GeneralTableCell>
       <GeneralTableCell>
@@ -200,7 +215,7 @@ function OrderCard({order}: {order: DecibelOrder}) {
           <SideChip side={order.side} />
         </Stack>
         <KeyValue label="Market">
-          <HashButton hash={order.market} type={HashType.OBJECT} size="small" />
+          <MarketValue hash={order.market} />
         </KeyValue>
         {order.size && <KeyValue label="Size">{order.size}</KeyValue>}
         <KeyValue label="Price">

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -45,11 +45,8 @@ function SideChip({side}: {side: "buy" | "sell" | undefined}) {
     <Chip
       label={side === "buy" ? "Buy" : "Sell"}
       size="small"
-      sx={{
-        fontWeight: 600,
-        color: "#fff",
-        backgroundColor: side === "buy" ? "success.main" : "error.main",
-      }}
+      color={side === "buy" ? "success" : "error"}
+      sx={{fontWeight: 600}}
     />
   );
 }

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -1,4 +1,11 @@
+import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
+import FlashOnOutlinedIcon from "@mui/icons-material/FlashOnOutlined";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
+import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
+import UploadOutlinedIcon from "@mui/icons-material/UploadOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import {
   Box,
   Chip,
@@ -31,11 +38,18 @@ import type {
   DecibelWithdraw,
 } from "../../../utils/decibel";
 import {
-  ORDER_TYPE_EMOJIS,
   ORDER_TYPE_LABELS,
   parseDecibelTransaction,
 } from "../../../utils/decibel";
 import {findCoinData} from "../utils";
+
+const ORDER_TYPE_ICONS: Record<string, React.ReactElement> = {
+  limit: <ListAltOutlinedIcon fontSize="small" />,
+  market: <FlashOnOutlinedIcon fontSize="small" />,
+  cancel: <CancelOutlinedIcon fontSize="small" />,
+  bulk: <ViewInArOutlinedIcon fontSize="small" />,
+  twap: <ScheduleOutlinedIcon fontSize="small" />,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -124,13 +138,13 @@ function humanizeFunctionName(fnName: string): string {
 // ---------------------------------------------------------------------------
 
 function OrderRow({order}: {order: DecibelOrder}) {
-  const emoji = ORDER_TYPE_EMOJIS[order.orderType] ?? "";
+  const icon = ORDER_TYPE_ICONS[order.orderType] ?? null;
   const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
 
   return (
     <GeneralTableRow>
       <GeneralTableCell>
-        {emoji} {label}
+        {icon} {label}
       </GeneralTableCell>
       <GeneralTableCell>
         <SideChip side={order.side} />
@@ -169,7 +183,7 @@ function OrderRow({order}: {order: DecibelOrder}) {
 }
 
 function OrderCard({order}: {order: DecibelOrder}) {
-  const emoji = ORDER_TYPE_EMOJIS[order.orderType] ?? "";
+  const icon = ORDER_TYPE_ICONS[order.orderType] ?? null;
   const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
 
   return (
@@ -181,7 +195,7 @@ function OrderCard({order}: {order: DecibelOrder}) {
           alignItems="center"
         >
           <Typography variant="subtitle2">
-            {emoji} {label}
+            {icon} {label}
           </Typography>
           <SideChip side={order.side} />
         </Stack>
@@ -302,7 +316,10 @@ function DepositCard({
   return (
     <Paper sx={{p: 2, mb: 1.5}}>
       <Stack spacing={1}>
-        <Typography variant="subtitle2">📥 Deposit</Typography>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <DownloadOutlinedIcon fontSize="small" />
+          <Typography variant="subtitle2">Deposit</Typography>
+        </Stack>
         <KeyValue label="Amount">
           <AmountWithAsset
             asset={deposit.asset}
@@ -410,7 +427,10 @@ function WithdrawCard({
   return (
     <Paper sx={{p: 2, mb: 1.5}}>
       <Stack spacing={1}>
-        <Typography variant="subtitle2">📤 Withdraw</Typography>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <UploadOutlinedIcon fontSize="small" />
+          <Typography variant="subtitle2">Withdraw</Typography>
+        </Stack>
         <KeyValue label="Amount">
           <AmountWithAsset
             asset={withdraw.asset}

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -118,6 +118,35 @@ function OrderRow({order}: {order: DecibelOrder}) {
         )}
       </GeneralTableCell>
       <GeneralTableCell>{order.timeInForce ?? "—"}</GeneralTableCell>
+      <GeneralTableCell>
+        {order.subaccount ? (
+          <HashButton
+            hash={order.subaccount}
+            type={HashType.ACCOUNT}
+            size="small"
+          />
+        ) : (
+          "—"
+        )}
+      </GeneralTableCell>
+      <GeneralTableCell>
+        {order.orderId ? (
+          <Typography
+            variant="body2"
+            sx={{
+              maxWidth: 150,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            title={order.orderId}
+          >
+            {order.orderId}
+          </Typography>
+        ) : (
+          "—"
+        )}
+      </GeneralTableCell>
     </GeneralTableRow>
   );
 }
@@ -154,6 +183,22 @@ function OrderCard({order}: {order: DecibelOrder}) {
         {order.timeInForce && (
           <KeyValue label="Time in Force">{order.timeInForce}</KeyValue>
         )}
+        {order.subaccount && (
+          <KeyValue label="Subaccount">
+            <HashButton
+              hash={order.subaccount}
+              type={HashType.ACCOUNT}
+              size="small"
+            />
+          </KeyValue>
+        )}
+        {order.orderId && (
+          <KeyValue label="Order ID">
+            <Typography variant="body2" sx={{wordBreak: "break-all"}}>
+              {order.orderId}
+            </Typography>
+          </KeyValue>
+        )}
       </Stack>
     </Paper>
   );
@@ -183,6 +228,8 @@ function OrdersSection({orders}: {orders: DecibelOrder[]}) {
               <GeneralTableHeaderCell header="Price" />
               <GeneralTableHeaderCell header="Status" />
               <GeneralTableHeaderCell header="Time in Force" />
+              <GeneralTableHeaderCell header="Subaccount" />
+              <GeneralTableHeaderCell header="Order ID" />
             </TableRow>
           </TableHead>
           <TableBody>

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -1,3 +1,4 @@
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {
   Box,
   Chip,
@@ -7,11 +8,12 @@ import {
   TableBody,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import type * as React from "react";
+import * as React from "react";
 import type {Types} from "~/types/aptos";
 import {useGetAssetMetadata} from "../../../api/hooks/useGetAssetMetadata";
 import {
@@ -48,6 +50,39 @@ function SideChip({side}: {side: "buy" | "sell" | undefined}) {
       color={side === "buy" ? "success" : "error"}
       sx={{fontWeight: 600}}
     />
+  );
+}
+
+function TruncatedCopyId({value}: {value: string}) {
+  const [copied, setCopied] = React.useState(false);
+  const truncated =
+    value.length > 8 ? `${value.slice(0, 4)}…${value.slice(-4)}` : value;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Tooltip title={copied ? "Copied!" : value} arrow>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={0.5}
+        sx={{cursor: "pointer"}}
+        onClick={handleCopy}
+      >
+        <Typography
+          variant="body2"
+          component="span"
+          sx={{fontFamily: "monospace"}}
+        >
+          {truncated}
+        </Typography>
+        <ContentCopyIcon sx={{fontSize: 14, opacity: 0.6}} />
+      </Stack>
+    </Tooltip>
   );
 }
 
@@ -127,22 +162,7 @@ function OrderRow({order}: {order: DecibelOrder}) {
         )}
       </GeneralTableCell>
       <GeneralTableCell>
-        {order.orderId ? (
-          <Typography
-            variant="body2"
-            sx={{
-              maxWidth: 150,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-            title={order.orderId}
-          >
-            {order.orderId}
-          </Typography>
-        ) : (
-          "—"
-        )}
+        {order.orderId ? <TruncatedCopyId value={order.orderId} /> : "—"}
       </GeneralTableCell>
     </GeneralTableRow>
   );
@@ -191,9 +211,7 @@ function OrderCard({order}: {order: DecibelOrder}) {
         )}
         {order.orderId && (
           <KeyValue label="Order ID">
-            <Typography variant="body2" sx={{wordBreak: "break-all"}}>
-              {order.orderId}
-            </Typography>
+            <TruncatedCopyId value={order.orderId} />
           </KeyValue>
         )}
       </Stack>

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -1,0 +1,482 @@
+import {
+  Box,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import type * as React from "react";
+import type {Types} from "~/types/aptos";
+import {useGetAssetMetadata} from "../../../api/hooks/useGetAssetMetadata";
+import {
+  type CoinDescription,
+  useGetCoinList,
+} from "../../../api/hooks/useGetCoinList";
+import HashButton, {HashType} from "../../../components/HashButton";
+import ContentBox from "../../../components/IndividualPageContent/ContentBox";
+import GeneralTableCell from "../../../components/Table/GeneralTableCell";
+import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeaderCell";
+import GeneralTableRow from "../../../components/Table/GeneralTableRow";
+import type {
+  DecibelDeposit,
+  DecibelOrder,
+  DecibelWithdraw,
+} from "../../../utils/decibel";
+import {
+  ORDER_TYPE_EMOJIS,
+  ORDER_TYPE_LABELS,
+  parseDecibelTransaction,
+} from "../../../utils/decibel";
+import {findCoinData} from "../utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SideChip({side}: {side: "buy" | "sell" | undefined}) {
+  if (!side) return null;
+  return (
+    <Chip
+      label={side === "buy" ? "Buy" : "Sell"}
+      size="small"
+      sx={{
+        fontWeight: 600,
+        color: "#fff",
+        backgroundColor: side === "buy" ? "success.main" : "error.main",
+      }}
+    />
+  );
+}
+
+function AmountWithAsset({
+  asset,
+  amount,
+  coinData,
+}: {
+  asset: string;
+  amount: string;
+  coinData: CoinDescription[] | undefined;
+}) {
+  const {data: assetMetadata} = useGetAssetMetadata(asset);
+  const assetCoin = findCoinData(coinData, asset);
+  const decimals = assetCoin?.decimals ?? assetMetadata?.decimals ?? 0;
+  const displayAmount = Number(amount) / 10 ** decimals;
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
+      <Typography variant="body2" component="span">
+        {displayAmount}
+      </Typography>
+      <HashButton
+        hash={asset}
+        type={asset.includes("::") ? HashType.COIN : HashType.FUNGIBLE_ASSET}
+        img={assetCoin?.logoUrl}
+        size="small"
+      />
+    </Stack>
+  );
+}
+
+function humanizeFunctionName(fnName: string): string {
+  return fnName.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// Orders Section
+// ---------------------------------------------------------------------------
+
+function OrderRow({order}: {order: DecibelOrder}) {
+  const emoji = ORDER_TYPE_EMOJIS[order.orderType] ?? "";
+  const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
+
+  return (
+    <GeneralTableRow>
+      <GeneralTableCell>
+        {emoji} {label}
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <SideChip side={order.side} />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <HashButton hash={order.market} type={HashType.OBJECT} size="small" />
+      </GeneralTableCell>
+      <GeneralTableCell>{order.size ?? "—"}</GeneralTableCell>
+      <GeneralTableCell>
+        {order.price ?? (order.orderType === "market" ? "Market" : "—")}
+      </GeneralTableCell>
+      <GeneralTableCell>
+        {order.status ? (
+          <Chip label={order.status} size="small" variant="outlined" />
+        ) : (
+          "—"
+        )}
+      </GeneralTableCell>
+      <GeneralTableCell>{order.timeInForce ?? "—"}</GeneralTableCell>
+    </GeneralTableRow>
+  );
+}
+
+function OrderCard({order}: {order: DecibelOrder}) {
+  const emoji = ORDER_TYPE_EMOJIS[order.orderType] ?? "";
+  const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
+
+  return (
+    <Paper sx={{p: 2, mb: 1.5}}>
+      <Stack spacing={1}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Typography variant="subtitle2">
+            {emoji} {label}
+          </Typography>
+          <SideChip side={order.side} />
+        </Stack>
+        <KeyValue label="Market">
+          <HashButton hash={order.market} type={HashType.OBJECT} size="small" />
+        </KeyValue>
+        {order.size && <KeyValue label="Size">{order.size}</KeyValue>}
+        <KeyValue label="Price">
+          {order.price ?? (order.orderType === "market" ? "Market" : "—")}
+        </KeyValue>
+        {order.status && (
+          <KeyValue label="Status">
+            <Chip label={order.status} size="small" variant="outlined" />
+          </KeyValue>
+        )}
+        {order.timeInForce && (
+          <KeyValue label="Time in Force">{order.timeInForce}</KeyValue>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+function OrdersSection({orders}: {orders: DecibelOrder[]}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  if (orders.length === 0) return null;
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Orders
+      </Typography>
+      {isMobile ? (
+        orders.map((order, i) => <OrderCard key={i} order={order} />)
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <GeneralTableHeaderCell header="Type" />
+              <GeneralTableHeaderCell header="Side" />
+              <GeneralTableHeaderCell header="Market" />
+              <GeneralTableHeaderCell header="Size" />
+              <GeneralTableHeaderCell header="Price" />
+              <GeneralTableHeaderCell header="Status" />
+              <GeneralTableHeaderCell header="Time in Force" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {orders.map((order, i) => (
+              <OrderRow key={i} order={order} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Deposits Section
+// ---------------------------------------------------------------------------
+
+function DepositRow({
+  deposit,
+  coinData,
+}: {
+  deposit: DecibelDeposit;
+  coinData: CoinDescription[] | undefined;
+}) {
+  return (
+    <GeneralTableRow>
+      <GeneralTableCell>
+        <AmountWithAsset
+          asset={deposit.asset}
+          amount={deposit.amount}
+          coinData={coinData}
+        />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <HashButton
+          hash={deposit.subaccount}
+          type={HashType.ACCOUNT}
+          size="small"
+        />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        {humanizeFunctionName(deposit.functionName)}
+      </GeneralTableCell>
+    </GeneralTableRow>
+  );
+}
+
+function DepositCard({
+  deposit,
+  coinData,
+}: {
+  deposit: DecibelDeposit;
+  coinData: CoinDescription[] | undefined;
+}) {
+  return (
+    <Paper sx={{p: 2, mb: 1.5}}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">📥 Deposit</Typography>
+        <KeyValue label="Amount">
+          <AmountWithAsset
+            asset={deposit.asset}
+            amount={deposit.amount}
+            coinData={coinData}
+          />
+        </KeyValue>
+        <KeyValue label="Subaccount">
+          <HashButton
+            hash={deposit.subaccount}
+            type={HashType.ACCOUNT}
+            size="small"
+          />
+        </KeyValue>
+        <KeyValue label="Function">
+          {humanizeFunctionName(deposit.functionName)}
+        </KeyValue>
+      </Stack>
+    </Paper>
+  );
+}
+
+function DepositsSection({
+  deposits,
+  coinData,
+}: {
+  deposits: DecibelDeposit[];
+  coinData: CoinDescription[] | undefined;
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  if (deposits.length === 0) return null;
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Deposits
+      </Typography>
+      {isMobile ? (
+        deposits.map((d, i) => (
+          <DepositCard key={i} deposit={d} coinData={coinData} />
+        ))
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <GeneralTableHeaderCell header="Asset & Amount" />
+              <GeneralTableHeaderCell header="Subaccount" />
+              <GeneralTableHeaderCell header="Function" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {deposits.map((d, i) => (
+              <DepositRow key={i} deposit={d} coinData={coinData} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawals Section
+// ---------------------------------------------------------------------------
+
+function WithdrawRow({
+  withdraw,
+  coinData,
+}: {
+  withdraw: DecibelWithdraw;
+  coinData: CoinDescription[] | undefined;
+}) {
+  return (
+    <GeneralTableRow>
+      <GeneralTableCell>
+        <AmountWithAsset
+          asset={withdraw.asset}
+          amount={withdraw.amount}
+          coinData={coinData}
+        />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <HashButton
+          hash={withdraw.subaccount}
+          type={HashType.ACCOUNT}
+          size="small"
+        />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        {humanizeFunctionName(withdraw.functionName)}
+      </GeneralTableCell>
+    </GeneralTableRow>
+  );
+}
+
+function WithdrawCard({
+  withdraw,
+  coinData,
+}: {
+  withdraw: DecibelWithdraw;
+  coinData: CoinDescription[] | undefined;
+}) {
+  return (
+    <Paper sx={{p: 2, mb: 1.5}}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">📤 Withdraw</Typography>
+        <KeyValue label="Amount">
+          <AmountWithAsset
+            asset={withdraw.asset}
+            amount={withdraw.amount}
+            coinData={coinData}
+          />
+        </KeyValue>
+        <KeyValue label="Subaccount">
+          <HashButton
+            hash={withdraw.subaccount}
+            type={HashType.ACCOUNT}
+            size="small"
+          />
+        </KeyValue>
+        <KeyValue label="Function">
+          {humanizeFunctionName(withdraw.functionName)}
+        </KeyValue>
+      </Stack>
+    </Paper>
+  );
+}
+
+function WithdrawalsSection({
+  withdrawals,
+  coinData,
+}: {
+  withdrawals: DecibelWithdraw[];
+  coinData: CoinDescription[] | undefined;
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  if (withdrawals.length === 0) return null;
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Withdrawals
+      </Typography>
+      {isMobile ? (
+        withdrawals.map((w, i) => (
+          <WithdrawCard key={i} withdraw={w} coinData={coinData} />
+        ))
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <GeneralTableHeaderCell header="Asset & Amount" />
+              <GeneralTableHeaderCell header="Subaccount" />
+              <GeneralTableHeaderCell header="Function" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {withdrawals.map((w, i) => (
+              <WithdrawRow key={i} withdraw={w} coinData={coinData} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+function KeyValue({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{minWidth: 100, flexShrink: 0}}
+      >
+        {label}
+      </Typography>
+      <Box sx={{flex: 1, minWidth: 0}}>{children}</Box>
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Tab
+// ---------------------------------------------------------------------------
+
+export default function DecibelTab({
+  transaction,
+}: {
+  transaction: Types.Transaction;
+}) {
+  const {data: coinData} = useGetCoinList();
+  const summary = parseDecibelTransaction(transaction);
+
+  const hasContent =
+    summary.orders.length > 0 ||
+    summary.deposits.length > 0 ||
+    summary.withdrawals.length > 0;
+
+  if (!hasContent) {
+    return (
+      <ContentBox>
+        <Typography color="text.secondary">
+          No Decibel activity found in this transaction.
+        </Typography>
+      </ContentBox>
+    );
+  }
+
+  return (
+    <ContentBox>
+      <Stack spacing={3}>
+        <OrdersSection orders={summary.orders} />
+        <DepositsSection
+          deposits={summary.deposits}
+          coinData={coinData?.data}
+        />
+        <WithdrawalsSection
+          withdrawals={summary.withdrawals}
+          coinData={coinData?.data}
+        />
+      </Stack>
+    </ContentBox>
+  );
+}

--- a/app/pages/Transaction/Tabs/EventsTab.tsx
+++ b/app/pages/Transaction/Tabs/EventsTab.tsx
@@ -6,6 +6,7 @@ import CollapsibleCards from "../../../components/IndividualPageContent/Collapsi
 import ContentRow from "../../../components/IndividualPageContent/ContentRow";
 import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
 import JsonViewCard from "../../../components/IndividualPageContent/JsonViewCard";
+import DecibelEventView, {isDecibelEvent} from "./Components/DecibelEventView";
 import FeeStatementEventView, {
   FEE_STATEMENT_EVENT_TYPE,
   shouldRenderFeeStatementTable,
@@ -103,6 +104,11 @@ export default function EventsTab({transaction}: EventsTabProps) {
                   <FeeStatementEventView
                     data={feeStatementData}
                     gasUnitPrice={gasUnitPrice}
+                  />
+                ) : isDecibelEvent(event.type) && eventDataObject ? (
+                  <DecibelEventView
+                    eventType={event.type}
+                    data={eventDataObject}
                   />
                 ) : (
                   <JsonViewCard

--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -2959,6 +2959,12 @@ function parseDecibelPerpFromPayload(
 
   const fnName = fn.split("::").pop() ?? "";
 
+  // NOTE: The Aptos API strips the `&signer` argument from entry function
+  // payloads, so all arg indices are offset by -1 from the Move function
+  // signature.
+
+  // deposit_to_subaccount_at(owner, subaccount, metadata, amount)
+  // API args: [subaccount(0), metadata(1), amount(2)]
   if (fnName === "deposit_to_subaccount_at") {
     if (args.length < 3) return undefined;
     return {
@@ -2970,35 +2976,55 @@ function parseDecibelPerpFromPayload(
     };
   }
 
+  // deposit_to_isolated_position_collateral(owner, subaccount, market, metadata, amount)
+  // API args: [subaccount(0), market(1), metadata(2), amount(3)]
   if (fnName === "deposit_to_isolated_position_collateral") {
-    if (args.length < 5) return undefined;
+    if (args.length < 4) return undefined;
     return {
       actionType: "perp deposit",
       dex: DECIBEL_CONTRACT,
-      subaccount: extractObjectInner(args[1]),
-      asset: extractObjectInner(args[3]),
-      amount: String(args[4]),
-    };
-  }
-
-  if (
-    fnName === "withdraw_from_subaccount" ||
-    fnName === "withdraw_from_cross_collateral" ||
-    fnName === "withdraw_from_non_collateral" ||
-    fnName === "withdraw_from_isolated_position_collateral"
-  ) {
-    if (args.length < 4) return undefined;
-    return {
-      actionType: "perp withdraw",
-      dex: DECIBEL_CONTRACT,
-      subaccount: extractObjectInner(args[1]),
+      subaccount: extractObjectInner(args[0]),
       asset: extractObjectInner(args[2]),
       amount: String(args[3]),
     };
   }
 
-  if (fnName === "place_bulk_orders_to_subaccount") {
+  // withdraw_from_subaccount(owner, subaccount, metadata, amount)
+  // withdraw_from_cross_collateral(owner, subaccount, metadata, amount)
+  // withdraw_from_non_collateral(owner, subaccount, metadata, amount)
+  // API args: [subaccount(0), metadata(1), amount(2)]
+  if (
+    fnName === "withdraw_from_subaccount" ||
+    fnName === "withdraw_from_cross_collateral" ||
+    fnName === "withdraw_from_non_collateral"
+  ) {
     if (args.length < 3) return undefined;
+    return {
+      actionType: "perp withdraw",
+      dex: DECIBEL_CONTRACT,
+      subaccount: extractObjectInner(args[0]),
+      asset: extractObjectInner(args[1]),
+      amount: String(args[2]),
+    };
+  }
+
+  // withdraw_from_isolated_position_collateral(owner, subaccount, market, metadata, amount)
+  // API args: [subaccount(0), market(1), metadata(2), amount(3)]
+  if (fnName === "withdraw_from_isolated_position_collateral") {
+    if (args.length < 4) return undefined;
+    return {
+      actionType: "perp withdraw",
+      dex: DECIBEL_CONTRACT,
+      subaccount: extractObjectInner(args[0]),
+      asset: extractObjectInner(args[2]),
+      amount: String(args[3]),
+    };
+  }
+
+  // place_bulk_orders_to_subaccount(auth, subaccount, market, ...)
+  // API args: [subaccount(0), market(1), ...]
+  if (fnName === "place_bulk_orders_to_subaccount") {
+    if (args.length < 2) return undefined;
     return {
       actionType: "perp order",
       dex: DECIBEL_CONTRACT,
@@ -3010,44 +3036,59 @@ function parseDecibelPerpFromPayload(
     };
   }
 
+  // place_twap_order_to_subaccount(auth, subaccount, market, size, is_buy, ...)
+  // API args: [subaccount(0), market(1), size(2), is_buy(3), ...]
   if (
     fnName === "place_twap_order_to_subaccount" ||
     fnName === "place_twap_order_to_subaccount_v2"
   ) {
-    if (args.length < 5) return undefined;
+    if (args.length < 4) return undefined;
     return {
       actionType: "perp order",
       dex: DECIBEL_CONTRACT,
       orderType: "twap",
-      side: args[4] === true || args[4] === "true" ? "buy" : "sell",
+      side: args[3] === true || args[3] === "true" ? "buy" : "sell",
       market: extractObjectInner(args[1]),
       size: String(args[2]),
       price: undefined,
     };
   }
 
+  // cancel_order_to_subaccount(auth, subaccount, order_id, market)
+  // cancel_client_order_to_subaccount(auth, subaccount, client_order_id, market)
+  // API args: [subaccount(0), order_id(1), market(2)]
   if (
     fnName === "cancel_order_to_subaccount" ||
-    fnName === "cancel_client_order_to_subaccount" ||
-    fnName === "cancel_bulk_order_to_subaccount" ||
-    fnName === "cancel_twap_orders_to_subaccount" ||
-    fnName === "cancel_tp_sl_order_for_position"
+    fnName === "cancel_client_order_to_subaccount"
   ) {
     if (args.length < 3) return undefined;
-    const market =
-      fnName === "cancel_bulk_order_to_subaccount"
-        ? extractObjectInner(args[2])
-        : fnName === "cancel_order_to_subaccount"
-          ? extractObjectInner(args[3])
-          : fnName === "cancel_client_order_to_subaccount"
-            ? extractObjectInner(args[3])
-            : extractObjectInner(args[2]);
     return {
       actionType: "perp order",
       dex: DECIBEL_CONTRACT,
       orderType: "cancel",
       side: undefined,
-      market,
+      market: extractObjectInner(args[2]),
+      size: undefined,
+      price: undefined,
+    };
+  }
+
+  // cancel_bulk_order_to_subaccount(auth, subaccount, market)
+  // cancel_twap_orders_to_subaccount(auth, subaccount, market, order_id)
+  // cancel_tp_sl_order_for_position(auth, subaccount, market, order_id)
+  // API args: [subaccount(0), market(1), ...]
+  if (
+    fnName === "cancel_bulk_order_to_subaccount" ||
+    fnName === "cancel_twap_orders_to_subaccount" ||
+    fnName === "cancel_tp_sl_order_for_position"
+  ) {
+    if (args.length < 2) return undefined;
+    return {
+      actionType: "perp order",
+      dex: DECIBEL_CONTRACT,
+      orderType: "cancel",
+      side: undefined,
+      market: extractObjectInner(args[1]),
       size: undefined,
       price: undefined,
     };

--- a/app/pages/Transaction/transactionTabMeta.ts
+++ b/app/pages/Transaction/transactionTabMeta.ts
@@ -3,6 +3,8 @@
  */
 export function getTransactionTabHeadLabel(tab: string | undefined): string {
   switch (tab) {
+    case "decibelDetail":
+      return "Decibel";
     case "balanceChange":
       return "Balance Change";
     case "events":

--- a/app/pages/Transaction/txnTabValues.test.ts
+++ b/app/pages/Transaction/txnTabValues.test.ts
@@ -20,6 +20,26 @@ describe("FEAT-TXN-001 — getTabValues", () => {
     ]);
   });
 
+  it("includes decibelDetail tab for Decibel user transactions", () => {
+    const decibelTxn = {
+      type: TransactionTypeName.User,
+      events: [
+        {
+          type: "0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06::market_types::OrderEvent",
+          data: {},
+        },
+      ],
+    } as Parameters<typeof getTabValues>[0];
+    const tabs = getTabValues(decibelTxn);
+    expect(tabs).toContain("decibelDetail");
+    expect(tabs.indexOf("decibelDetail")).toBe(1); // after overview
+  });
+
+  it("excludes decibelDetail tab for non-Decibel user transactions", () => {
+    const tabs = getTabValues(makeTxn(TransactionTypeName.User));
+    expect(tabs).not.toContain("decibelDetail");
+  });
+
   it("returns overview, events, changes for block metadata", () => {
     const tabs = getTabValues(makeTxn(TransactionTypeName.BlockMetadata));
     expect(tabs).toEqual(["blockMetadataOverview", "events", "changes"]);

--- a/app/pages/Transaction/txnTabValues.test.ts
+++ b/app/pages/Transaction/txnTabValues.test.ts
@@ -1,6 +1,7 @@
 // Covers FEAT-TXN-001 — Transaction tab selection by type
 import {describe, expect, it} from "vitest";
 import {TransactionTypeName} from "../../components/TransactionType";
+import {DECIBEL_CONTRACTS} from "../../utils/decibel";
 import {getTabValues} from "./Tabs";
 
 function makeTxn(type: string) {
@@ -25,7 +26,7 @@ describe("FEAT-TXN-001 — getTabValues", () => {
       type: TransactionTypeName.User,
       events: [
         {
-          type: "0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06::market_types::OrderEvent",
+          type: `${DECIBEL_CONTRACTS[0]}::market_types::OrderEvent`,
           data: {},
         },
       ],

--- a/app/utils/decibel/constants.ts
+++ b/app/utils/decibel/constants.ts
@@ -1,0 +1,20 @@
+export const DECIBEL_CONTRACTS = [
+  "0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06", // mainnet
+  "0xe7da2794b1d8af76532ed95f38bfdf1136abfd8ea3a240189971988a83101b7f", // testnet
+] as const;
+
+export const ORDER_TYPE_LABELS: Record<string, string> = {
+  limit: "Limit Order",
+  market: "Market Order",
+  cancel: "Cancel Order",
+  bulk: "Bulk Orders",
+  twap: "TWAP Order",
+};
+
+export const ORDER_TYPE_EMOJIS: Record<string, string> = {
+  limit: "📋",
+  market: "⚡",
+  cancel: "❌",
+  bulk: "📦",
+  twap: "⏱️",
+};

--- a/app/utils/decibel/constants.ts
+++ b/app/utils/decibel/constants.ts
@@ -10,11 +10,3 @@ export const ORDER_TYPE_LABELS: Record<string, string> = {
   bulk: "Bulk Orders",
   twap: "TWAP Order",
 };
-
-export const ORDER_TYPE_EMOJIS: Record<string, string> = {
-  limit: "📋",
-  market: "⚡",
-  cancel: "❌",
-  bulk: "📦",
-  twap: "⏱️",
-};

--- a/app/utils/decibel/index.ts
+++ b/app/utils/decibel/index.ts
@@ -1,0 +1,12 @@
+export {
+  DECIBEL_CONTRACTS,
+  ORDER_TYPE_EMOJIS,
+  ORDER_TYPE_LABELS,
+} from "./constants";
+export {isDecibelTransaction, parseDecibelTransaction} from "./parser";
+export type {
+  DecibelDeposit,
+  DecibelOrder,
+  DecibelTransactionSummary,
+  DecibelWithdraw,
+} from "./types";

--- a/app/utils/decibel/index.ts
+++ b/app/utils/decibel/index.ts
@@ -1,8 +1,4 @@
-export {
-  DECIBEL_CONTRACTS,
-  ORDER_TYPE_EMOJIS,
-  ORDER_TYPE_LABELS,
-} from "./constants";
+export {DECIBEL_CONTRACTS, ORDER_TYPE_LABELS} from "./constants";
 export {isDecibelTransaction, parseDecibelTransaction} from "./parser";
 export type {
   DecibelDeposit,

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -1,0 +1,297 @@
+import {describe, expect, it} from "vitest";
+import type {Types} from "~/types/aptos";
+import {DECIBEL_CONTRACTS} from "./constants";
+import {isDecibelTransaction, parseDecibelTransaction} from "./parser";
+
+const MAINNET_CONTRACT = DECIBEL_CONTRACTS[0];
+const TESTNET_CONTRACT = DECIBEL_CONTRACTS[1];
+
+function makeUserTxn(
+  overrides: Partial<{
+    events: Types.Event[];
+    payload: Record<string, unknown>;
+    success: boolean;
+  }> = {},
+): Types.Transaction {
+  return {
+    type: "user_transaction",
+    success: true,
+    events: [],
+    payload: {type: "entry_function_payload", function: "", arguments: []},
+    ...overrides,
+  } as unknown as Types.Transaction;
+}
+
+describe("isDecibelTransaction", () => {
+  it("returns true when events contain a Decibel event type (mainnet)", () => {
+    const txn = makeUserTxn({
+      events: [
+        {
+          type: `${MAINNET_CONTRACT}::market_types::OrderEvent`,
+          data: {},
+        } as unknown as Types.Event,
+      ],
+    });
+    expect(isDecibelTransaction(txn)).toBe(true);
+  });
+
+  it("returns true when events contain a Decibel event type (testnet)", () => {
+    const txn = makeUserTxn({
+      events: [
+        {
+          type: `${TESTNET_CONTRACT}::market_types::OrderEvent`,
+          data: {},
+        } as unknown as Types.Event,
+      ],
+    });
+    expect(isDecibelTransaction(txn)).toBe(true);
+  });
+
+  it("returns true when payload function targets Decibel", () => {
+    const txn = makeUserTxn({
+      payload: {
+        type: "entry_function_payload",
+        function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_subaccount_at`,
+        arguments: [],
+      },
+    });
+    expect(isDecibelTransaction(txn)).toBe(true);
+  });
+
+  it("returns false for non-Decibel transactions", () => {
+    const txn = makeUserTxn({
+      events: [
+        {
+          type: "0xabc::some_module::SomeEvent",
+          data: {},
+        } as unknown as Types.Event,
+      ],
+      payload: {
+        type: "entry_function_payload",
+        function: "0xabc::some_module::some_function",
+        arguments: [],
+      },
+    });
+    expect(isDecibelTransaction(txn)).toBe(false);
+  });
+
+  it("returns false for transactions without events or payload", () => {
+    const txn = {type: "state_checkpoint_transaction"} as Types.Transaction;
+    expect(isDecibelTransaction(txn)).toBe(false);
+  });
+});
+
+describe("parseDecibelTransaction", () => {
+  describe("orders", () => {
+    it("parses a limit order from OrderEvent", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::OrderEvent`,
+            data: {
+              is_bid: true,
+              market: "0xmarket1",
+              orig_size: "1000",
+              price: "5000",
+              status: {__variant__: "FILLED"},
+              time_in_force: {__variant__: "GTC"},
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(1);
+      expect(summary.orders[0]).toEqual({
+        orderType: "limit",
+        side: "buy",
+        market: "0xmarket1",
+        size: "1000",
+        price: "5000",
+        status: "FILLED",
+        timeInForce: "GTC",
+      });
+    });
+
+    it("parses a market order (IOC time-in-force)", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::OrderEvent`,
+            data: {
+              is_bid: false,
+              market: "0xmarket2",
+              orig_size: "500",
+              price: "3000",
+              status: {__variant__: "FILLED"},
+              time_in_force: {__variant__: "IOC"},
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders[0].orderType).toBe("market");
+      expect(summary.orders[0].side).toBe("sell");
+      expect(summary.orders[0].price).toBeUndefined();
+    });
+
+    it("parses a cancelled order", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::OrderEvent`,
+            data: {
+              is_bid: true,
+              market: "0xmarket1",
+              orig_size: "100",
+              price: "2000",
+              status: {__variant__: "CANCELLED"},
+              time_in_force: {__variant__: "GTC"},
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders[0].orderType).toBe("cancel");
+      expect(summary.orders[0].price).toBeUndefined();
+    });
+
+    it("parses bulk order from payload", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: ["sub1", {inner: "0xmarket1"}, "data"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(1);
+      expect(summary.orders[0].orderType).toBe("bulk");
+      expect(summary.orders[0].market).toBe("0xmarket1");
+    });
+
+    it("parses twap order from payload", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_twap_order_to_subaccount`,
+          arguments: ["sub1", {inner: "0xmarket1"}, "500", "data", "true"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders[0].orderType).toBe("twap");
+      expect(summary.orders[0].side).toBe("buy");
+      expect(summary.orders[0].size).toBe("500");
+    });
+  });
+
+  describe("deposits", () => {
+    it("parses deposit_to_subaccount_at", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_subaccount_at`,
+          arguments: ["sub1", {inner: "0xasset1"}, "1000000"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.deposits).toHaveLength(1);
+      expect(summary.deposits[0]).toEqual({
+        asset: "0xasset1",
+        amount: "1000000",
+        subaccount: "sub1",
+        functionName: "deposit_to_subaccount_at",
+      });
+    });
+
+    it("parses deposit_to_isolated_position_collateral", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_isolated_position_collateral`,
+          arguments: [
+            "signer",
+            {inner: "sub1"},
+            "pos",
+            {inner: "0xasset1"},
+            "2000000",
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.deposits).toHaveLength(1);
+      expect(summary.deposits[0].subaccount).toBe("sub1");
+      expect(summary.deposits[0].asset).toBe("0xasset1");
+      expect(summary.deposits[0].amount).toBe("2000000");
+    });
+  });
+
+  describe("withdrawals", () => {
+    it("parses withdraw_from_subaccount", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::withdraw_from_subaccount`,
+          arguments: ["signer", {inner: "sub1"}, {inner: "0xasset1"}, "500000"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.withdrawals).toHaveLength(1);
+      expect(summary.withdrawals[0]).toEqual({
+        asset: "0xasset1",
+        amount: "500000",
+        subaccount: "sub1",
+        functionName: "withdraw_from_subaccount",
+      });
+    });
+
+    it("parses withdraw_from_cross_collateral", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::withdraw_from_cross_collateral`,
+          arguments: ["signer", {inner: "sub1"}, {inner: "0xasset2"}, "300000"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.withdrawals).toHaveLength(1);
+      expect(summary.withdrawals[0].functionName).toBe(
+        "withdraw_from_cross_collateral",
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty summary for non-Decibel transaction", () => {
+      const txn = makeUserTxn({
+        events: [
+          {type: "0xabc::module::Event", data: {}} as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(0);
+      expect(summary.deposits).toHaveLength(0);
+      expect(summary.withdrawals).toHaveLength(0);
+    });
+
+    it("skips payload parsing for failed transactions", () => {
+      const txn = makeUserTxn({
+        success: false,
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_subaccount_at`,
+          arguments: ["sub1", {inner: "0xasset1"}, "1000000"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.deposits).toHaveLength(0);
+    });
+
+    it("handles transaction with no events array", () => {
+      const txn = {type: "user_transaction"} as Types.Transaction;
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(0);
+      expect(summary.deposits).toHaveLength(0);
+      expect(summary.withdrawals).toHaveLength(0);
+    });
+  });
+});

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -219,6 +219,61 @@ describe("parseDecibelTransaction", () => {
       expect(summary.orders[0].market).toBe(
         "0xd62d10d1ef0cbe2103b5bd479691ac38222a85140fcbe7c2dc66ed23bdef58ae",
       );
+      expect(summary.orders[0].orderId).toBe(
+        "170141599249866109911302405644884115456",
+      );
+      expect(summary.orders[0].subaccount).toBe(
+        "0x418abee2561e6eae64b826b152eccbd1b0781693b5d9a7ef12c96f2ce03fe607",
+      );
+    });
+
+    it("merges event and payload data for cancel orders", () => {
+      // Real scenario: event has side/size/status, payload has orderId/subaccount
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::OrderEvent`,
+            data: {
+              is_bid: true,
+              market:
+                "0xd62d10d1ef0cbe2103b5bd479691ac38222a85140fcbe7c2dc66ed23bdef58ae",
+              orig_size: "2000000",
+              price: "89850",
+              status: {__variant__: "CANCELLED"},
+              time_in_force: {__variant__: "GTC"},
+            },
+          } as unknown as Types.Event,
+        ],
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::cancel_order_to_subaccount`,
+          arguments: [
+            {
+              inner:
+                "0x418abee2561e6eae64b826b152eccbd1b0781693b5d9a7ef12c96f2ce03fe607",
+            },
+            "170141599249866109911302405644884115456",
+            {
+              inner:
+                "0xd62d10d1ef0cbe2103b5bd479691ac38222a85140fcbe7c2dc66ed23bdef58ae",
+            },
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      // Should produce ONE merged order, not two
+      expect(summary.orders).toHaveLength(1);
+      const order = summary.orders[0];
+      // From event
+      expect(order.side).toBe("buy");
+      expect(order.size).toBe("2000000");
+      expect(order.status).toBe("CANCELLED");
+      expect(order.timeInForce).toBe("GTC");
+      // From payload (merged in)
+      expect(order.orderId).toBe("170141599249866109911302405644884115456");
+      expect(order.subaccount).toBe(
+        "0x418abee2561e6eae64b826b152eccbd1b0781693b5d9a7ef12c96f2ce03fe607",
+      );
     });
   });
 

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -170,17 +170,55 @@ describe("parseDecibelTransaction", () => {
     });
 
     it("parses twap order from payload", () => {
+      // API args (signer stripped): [subaccount, market, size, is_buy, ...]
       const txn = makeUserTxn({
         payload: {
           type: "entry_function_payload",
           function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_twap_order_to_subaccount`,
-          arguments: ["sub1", {inner: "0xmarket1"}, "500", "data", "true"],
+          arguments: [
+            {inner: "sub1"},
+            {inner: "0xmarket1"},
+            "500",
+            "true",
+            "false",
+            "60",
+            "3600",
+            "0x0",
+            "0",
+          ],
         },
       });
       const summary = parseDecibelTransaction(txn);
       expect(summary.orders[0].orderType).toBe("twap");
       expect(summary.orders[0].side).toBe("buy");
       expect(summary.orders[0].size).toBe("500");
+    });
+
+    it("parses cancel_order_to_subaccount from payload", () => {
+      // API args (signer stripped): [subaccount, order_id, market]
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::cancel_order_to_subaccount`,
+          arguments: [
+            {
+              inner:
+                "0x418abee2561e6eae64b826b152eccbd1b0781693b5d9a7ef12c96f2ce03fe607",
+            },
+            "170141599249866109911302405644884115456",
+            {
+              inner:
+                "0xd62d10d1ef0cbe2103b5bd479691ac38222a85140fcbe7c2dc66ed23bdef58ae",
+            },
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(1);
+      expect(summary.orders[0].orderType).toBe("cancel");
+      expect(summary.orders[0].market).toBe(
+        "0xd62d10d1ef0cbe2103b5bd479691ac38222a85140fcbe7c2dc66ed23bdef58ae",
+      );
     });
   });
 
@@ -204,14 +242,14 @@ describe("parseDecibelTransaction", () => {
     });
 
     it("parses deposit_to_isolated_position_collateral", () => {
+      // API args (signer stripped): [subaccount, market, metadata, amount]
       const txn = makeUserTxn({
         payload: {
           type: "entry_function_payload",
           function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_isolated_position_collateral`,
           arguments: [
-            "signer",
             {inner: "sub1"},
-            "pos",
+            {inner: "0xmarket1"},
             {inner: "0xasset1"},
             "2000000",
           ],
@@ -227,11 +265,12 @@ describe("parseDecibelTransaction", () => {
 
   describe("withdrawals", () => {
     it("parses withdraw_from_subaccount", () => {
+      // API args (signer stripped): [subaccount, metadata, amount]
       const txn = makeUserTxn({
         payload: {
           type: "entry_function_payload",
           function: `${MAINNET_CONTRACT}::dex_accounts_entry::withdraw_from_subaccount`,
-          arguments: ["signer", {inner: "sub1"}, {inner: "0xasset1"}, "500000"],
+          arguments: [{inner: "sub1"}, {inner: "0xasset1"}, "500000"],
         },
       });
       const summary = parseDecibelTransaction(txn);
@@ -245,11 +284,12 @@ describe("parseDecibelTransaction", () => {
     });
 
     it("parses withdraw_from_cross_collateral", () => {
+      // API args (signer stripped): [subaccount, metadata, amount]
       const txn = makeUserTxn({
         payload: {
           type: "entry_function_payload",
           function: `${MAINNET_CONTRACT}::dex_accounts_entry::withdraw_from_cross_collateral`,
-          arguments: ["signer", {inner: "sub1"}, {inner: "0xasset2"}, "300000"],
+          arguments: [{inner: "sub1"}, {inner: "0xasset2"}, "300000"],
         },
       });
       const summary = parseDecibelTransaction(txn);

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -101,7 +101,7 @@ describe("parseDecibelTransaction", () => {
       });
       const summary = parseDecibelTransaction(txn);
       expect(summary.orders).toHaveLength(1);
-      expect(summary.orders[0]).toEqual({
+      expect(summary.orders[0]).toMatchObject({
         orderType: "limit",
         side: "buy",
         market: "0xmarket1",
@@ -379,6 +379,18 @@ describe("parseDecibelTransaction", () => {
       });
       const summary = parseDecibelTransaction(txn);
       expect(summary.deposits).toHaveLength(0);
+    });
+
+    it("returns empty for cancel with insufficient args", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::cancel_order_to_subaccount`,
+          arguments: [{inner: "sub1"}],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.orders).toHaveLength(0);
     });
 
     it("handles transaction with no events array", () => {

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -1,0 +1,227 @@
+import type {Types} from "~/types/aptos";
+import {DECIBEL_CONTRACTS} from "./constants";
+import type {
+  DecibelDeposit,
+  DecibelOrder,
+  DecibelTransactionSummary,
+  DecibelWithdraw,
+} from "./types";
+
+function extractObjectInner(arg: unknown): string {
+  if (typeof arg === "object" && arg !== null && "inner" in arg) {
+    return (arg as {inner: string}).inner;
+  }
+  return String(arg);
+}
+
+function isDecibelContract(value: string): boolean {
+  return DECIBEL_CONTRACTS.some((addr) => value.startsWith(`${addr}::`));
+}
+
+export function isDecibelTransaction(transaction: Types.Transaction): boolean {
+  if ("events" in transaction && Array.isArray(transaction.events)) {
+    for (const event of transaction.events) {
+      if (isDecibelContract(event.type)) return true;
+    }
+  }
+
+  if (
+    "payload" in transaction &&
+    transaction.payload.type === "entry_function_payload" &&
+    "function" in transaction.payload
+  ) {
+    const payload =
+      transaction.payload as Types.TransactionPayload_EntryFunctionPayload;
+    if (isDecibelContract(payload.function)) return true;
+  }
+
+  return false;
+}
+
+function parseOrderEvent(event: Types.Event): DecibelOrder | undefined {
+  const isOrderEvent = DECIBEL_CONTRACTS.some(
+    (addr) => event.type === `${addr}::market_types::OrderEvent`,
+  );
+  if (!isOrderEvent) return undefined;
+
+  const data: {
+    is_bid: boolean;
+    market: string;
+    orig_size: string;
+    price: string;
+    status: {__variant__: string};
+    time_in_force: {__variant__: string};
+  } = event.data;
+
+  const statusVariant = data.status?.__variant__ ?? "";
+  const tif = data.time_in_force?.__variant__ ?? "";
+  const isCancelled =
+    statusVariant === "CANCELLED" || statusVariant === "CANCELED";
+  const isMarket = tif === "IOC" || tif === "FOK";
+
+  return {
+    orderType: isCancelled ? "cancel" : isMarket ? "market" : "limit",
+    side: data.is_bid ? "buy" : "sell",
+    market: data.market,
+    size: data.orig_size,
+    price: isCancelled || isMarket ? undefined : data.price,
+    status: statusVariant || undefined,
+    timeInForce: tif || undefined,
+  };
+}
+
+function parsePayloadAction(
+  transaction: Types.Transaction,
+): DecibelOrder | DecibelDeposit | DecibelWithdraw | undefined {
+  if (
+    !("payload" in transaction) ||
+    !("success" in transaction) ||
+    !transaction.success
+  ) {
+    return undefined;
+  }
+
+  const payload = transaction.payload;
+  if (
+    payload.type !== "entry_function_payload" ||
+    !("function" in payload) ||
+    !("arguments" in payload)
+  ) {
+    return undefined;
+  }
+
+  const typedPayload = payload as Types.TransactionPayload_EntryFunctionPayload;
+  const fn = typedPayload.function;
+  const args = typedPayload.arguments;
+
+  const matchesDecibel = DECIBEL_CONTRACTS.some((addr) =>
+    fn.startsWith(`${addr}::dex_accounts_entry::`),
+  );
+  if (!matchesDecibel) return undefined;
+
+  const fnName = fn.split("::").pop() ?? "";
+
+  if (fnName === "deposit_to_subaccount_at") {
+    if (args.length < 3) return undefined;
+    return {
+      asset: extractObjectInner(args[1]),
+      amount: String(args[2]),
+      subaccount: String(args[0]),
+      functionName: fnName,
+    } satisfies DecibelDeposit;
+  }
+
+  if (fnName === "deposit_to_isolated_position_collateral") {
+    if (args.length < 5) return undefined;
+    return {
+      asset: extractObjectInner(args[3]),
+      amount: String(args[4]),
+      subaccount: extractObjectInner(args[1]),
+      functionName: fnName,
+    } satisfies DecibelDeposit;
+  }
+
+  if (
+    fnName === "withdraw_from_subaccount" ||
+    fnName === "withdraw_from_cross_collateral" ||
+    fnName === "withdraw_from_non_collateral" ||
+    fnName === "withdraw_from_isolated_position_collateral"
+  ) {
+    if (args.length < 4) return undefined;
+    return {
+      asset: extractObjectInner(args[2]),
+      amount: String(args[3]),
+      subaccount: extractObjectInner(args[1]),
+      functionName: fnName,
+    } satisfies DecibelWithdraw;
+  }
+
+  if (fnName === "place_bulk_orders_to_subaccount") {
+    if (args.length < 3) return undefined;
+    return {
+      orderType: "bulk",
+      side: undefined,
+      market: extractObjectInner(args[1]),
+      size: undefined,
+      price: undefined,
+      status: undefined,
+      timeInForce: undefined,
+    } satisfies DecibelOrder;
+  }
+
+  if (
+    fnName === "place_twap_order_to_subaccount" ||
+    fnName === "place_twap_order_to_subaccount_v2"
+  ) {
+    if (args.length < 5) return undefined;
+    return {
+      orderType: "twap",
+      side: args[4] === true || args[4] === "true" ? "buy" : "sell",
+      market: extractObjectInner(args[1]),
+      size: String(args[2]),
+      price: undefined,
+      status: undefined,
+      timeInForce: undefined,
+    } satisfies DecibelOrder;
+  }
+
+  if (
+    fnName === "cancel_order_to_subaccount" ||
+    fnName === "cancel_client_order_to_subaccount" ||
+    fnName === "cancel_bulk_order_to_subaccount" ||
+    fnName === "cancel_twap_orders_to_subaccount" ||
+    fnName === "cancel_tp_sl_order_for_position"
+  ) {
+    if (args.length < 3) return undefined;
+    const market =
+      fnName === "cancel_bulk_order_to_subaccount"
+        ? extractObjectInner(args[2])
+        : fnName === "cancel_order_to_subaccount" ||
+            fnName === "cancel_client_order_to_subaccount"
+          ? extractObjectInner(args[3])
+          : extractObjectInner(args[2]);
+    return {
+      orderType: "cancel",
+      side: undefined,
+      market,
+      size: undefined,
+      price: undefined,
+      status: undefined,
+      timeInForce: undefined,
+    } satisfies DecibelOrder;
+  }
+
+  return undefined;
+}
+
+export function parseDecibelTransaction(
+  transaction: Types.Transaction,
+): DecibelTransactionSummary {
+  const orders: DecibelOrder[] = [];
+  const deposits: DecibelDeposit[] = [];
+  const withdrawals: DecibelWithdraw[] = [];
+
+  // Parse events for order data
+  if ("events" in transaction && Array.isArray(transaction.events)) {
+    for (const event of transaction.events) {
+      const order = parseOrderEvent(event);
+      if (order) orders.push(order);
+    }
+  }
+
+  // Parse payload for deposit/withdraw/order actions
+  const payloadAction = parsePayloadAction(transaction);
+  if (payloadAction) {
+    if ("orderType" in payloadAction) {
+      orders.push(payloadAction);
+    } else if ("functionName" in payloadAction) {
+      if (payloadAction.functionName.startsWith("deposit")) {
+        deposits.push(payloadAction as DecibelDeposit);
+      } else {
+        withdrawals.push(payloadAction as DecibelWithdraw);
+      }
+    }
+  }
+
+  return {orders, deposits, withdrawals};
+}

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -67,6 +67,8 @@ function parseOrderEvent(event: Types.Event): DecibelOrder | undefined {
     price: isCancelled || isMarket ? undefined : data.price,
     status: statusVariant || undefined,
     timeInForce: tif || undefined,
+    orderId: undefined,
+    subaccount: undefined,
   };
 }
 
@@ -170,6 +172,8 @@ function parsePayloadAction(
       price: undefined,
       status: undefined,
       timeInForce: undefined,
+      orderId: undefined,
+      subaccount: extractObjectInner(args[0]),
     } satisfies DecibelOrder;
   }
 
@@ -188,10 +192,13 @@ function parsePayloadAction(
       price: undefined,
       status: undefined,
       timeInForce: undefined,
+      orderId: undefined,
+      subaccount: extractObjectInner(args[0]),
     } satisfies DecibelOrder;
   }
 
   // cancel_order_to_subaccount(auth, subaccount, order_id, market)
+  // cancel_client_order_to_subaccount(auth, subaccount, client_order_id, market)
   // API args: [subaccount(0), order_id(1), market(2)]
   if (
     fnName === "cancel_order_to_subaccount" ||
@@ -206,6 +213,8 @@ function parsePayloadAction(
       price: undefined,
       status: undefined,
       timeInForce: undefined,
+      orderId: String(args[1]),
+      subaccount: extractObjectInner(args[0]),
     } satisfies DecibelOrder;
   }
 
@@ -227,6 +236,8 @@ function parsePayloadAction(
       price: undefined,
       status: undefined,
       timeInForce: undefined,
+      orderId: args.length >= 3 ? String(args[2]) : undefined,
+      subaccount: extractObjectInner(args[0]),
     } satisfies DecibelOrder;
   }
 
@@ -252,7 +263,20 @@ export function parseDecibelTransaction(
   const payloadAction = parsePayloadAction(transaction);
   if (payloadAction) {
     if ("orderType" in payloadAction) {
-      orders.push(payloadAction);
+      // Merge payload data (orderId, subaccount) into event-parsed orders
+      // rather than creating a duplicate entry
+      if (orders.length > 0) {
+        for (const order of orders) {
+          if (!order.orderId && payloadAction.orderId) {
+            order.orderId = payloadAction.orderId;
+          }
+          if (!order.subaccount && payloadAction.subaccount) {
+            order.subaccount = payloadAction.subaccount;
+          }
+        }
+      } else {
+        orders.push(payloadAction);
+      }
     } else if ("functionName" in payloadAction) {
       if (payloadAction.functionName.startsWith("deposit")) {
         deposits.push(payloadAction as DecibelDeposit);

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -51,6 +51,8 @@ function parseOrderEvent(event: Types.Event): DecibelOrder | undefined {
     price: string;
     status: {__variant__: string};
     time_in_force: {__variant__: string};
+    order_id?: string;
+    user?: string;
   } = event.data;
 
   const statusVariant = data.status?.__variant__ ?? "";
@@ -67,8 +69,8 @@ function parseOrderEvent(event: Types.Event): DecibelOrder | undefined {
     price: isCancelled || isMarket ? undefined : data.price,
     status: statusVariant || undefined,
     timeInForce: tif || undefined,
-    orderId: undefined,
-    subaccount: undefined,
+    orderId: typeof data.order_id === "string" ? data.order_id : undefined,
+    subaccount: typeof data.user === "string" ? data.user : undefined,
   };
 }
 
@@ -115,7 +117,7 @@ function parsePayloadAction(
     return {
       asset: extractObjectInner(args[1]),
       amount: String(args[2]),
-      subaccount: String(args[0]),
+      subaccount: extractObjectInner(args[0]),
       functionName: fnName,
     } satisfies DecibelDeposit;
   }

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -101,6 +101,13 @@ function parsePayloadAction(
 
   const fnName = fn.split("::").pop() ?? "";
 
+  // NOTE: The Aptos API strips the `&signer` argument from entry function
+  // payloads, so all arg indices are offset by -1 from the Move function
+  // signature (and from the functionArgumentNameOverrides file which
+  // includes the signer as arg0).
+
+  // deposit_to_subaccount_at(owner, subaccount, metadata, amount)
+  // API args: [subaccount(0), metadata(1), amount(2)]
   if (fnName === "deposit_to_subaccount_at") {
     if (args.length < 3) return undefined;
     return {
@@ -111,33 +118,50 @@ function parsePayloadAction(
     } satisfies DecibelDeposit;
   }
 
+  // deposit_to_isolated_position_collateral(owner, subaccount, market, metadata, amount)
+  // API args: [subaccount(0), market(1), metadata(2), amount(3)]
   if (fnName === "deposit_to_isolated_position_collateral") {
-    if (args.length < 5) return undefined;
-    return {
-      asset: extractObjectInner(args[3]),
-      amount: String(args[4]),
-      subaccount: extractObjectInner(args[1]),
-      functionName: fnName,
-    } satisfies DecibelDeposit;
-  }
-
-  if (
-    fnName === "withdraw_from_subaccount" ||
-    fnName === "withdraw_from_cross_collateral" ||
-    fnName === "withdraw_from_non_collateral" ||
-    fnName === "withdraw_from_isolated_position_collateral"
-  ) {
     if (args.length < 4) return undefined;
     return {
       asset: extractObjectInner(args[2]),
       amount: String(args[3]),
-      subaccount: extractObjectInner(args[1]),
+      subaccount: extractObjectInner(args[0]),
+      functionName: fnName,
+    } satisfies DecibelDeposit;
+  }
+
+  // withdraw_from_subaccount(owner, subaccount, metadata, amount)
+  // API args: [subaccount(0), metadata(1), amount(2)]
+  if (
+    fnName === "withdraw_from_subaccount" ||
+    fnName === "withdraw_from_cross_collateral" ||
+    fnName === "withdraw_from_non_collateral"
+  ) {
+    if (args.length < 3) return undefined;
+    return {
+      asset: extractObjectInner(args[1]),
+      amount: String(args[2]),
+      subaccount: extractObjectInner(args[0]),
       functionName: fnName,
     } satisfies DecibelWithdraw;
   }
 
+  // withdraw_from_isolated_position_collateral(owner, subaccount, market, metadata, amount)
+  // API args: [subaccount(0), market(1), metadata(2), amount(3)]
+  if (fnName === "withdraw_from_isolated_position_collateral") {
+    if (args.length < 4) return undefined;
+    return {
+      asset: extractObjectInner(args[2]),
+      amount: String(args[3]),
+      subaccount: extractObjectInner(args[0]),
+      functionName: fnName,
+    } satisfies DecibelWithdraw;
+  }
+
+  // place_bulk_orders_to_subaccount(auth, subaccount, market, ...)
+  // API args: [subaccount(0), market(1), ...]
   if (fnName === "place_bulk_orders_to_subaccount") {
-    if (args.length < 3) return undefined;
+    if (args.length < 2) return undefined;
     return {
       orderType: "bulk",
       side: undefined,
@@ -149,14 +173,16 @@ function parsePayloadAction(
     } satisfies DecibelOrder;
   }
 
+  // place_twap_order_to_subaccount(auth, subaccount, market, size, is_buy, ...)
+  // API args: [subaccount(0), market(1), size(2), is_buy(3), ...]
   if (
     fnName === "place_twap_order_to_subaccount" ||
     fnName === "place_twap_order_to_subaccount_v2"
   ) {
-    if (args.length < 5) return undefined;
+    if (args.length < 4) return undefined;
     return {
       orderType: "twap",
-      side: args[4] === true || args[4] === "true" ? "buy" : "sell",
+      side: args[3] === true || args[3] === "true" ? "buy" : "sell",
       market: extractObjectInner(args[1]),
       size: String(args[2]),
       price: undefined,
@@ -165,25 +191,38 @@ function parsePayloadAction(
     } satisfies DecibelOrder;
   }
 
+  // cancel_order_to_subaccount(auth, subaccount, order_id, market)
+  // API args: [subaccount(0), order_id(1), market(2)]
   if (
     fnName === "cancel_order_to_subaccount" ||
-    fnName === "cancel_client_order_to_subaccount" ||
+    fnName === "cancel_client_order_to_subaccount"
+  ) {
+    if (args.length < 3) return undefined;
+    return {
+      orderType: "cancel",
+      side: undefined,
+      market: extractObjectInner(args[2]),
+      size: undefined,
+      price: undefined,
+      status: undefined,
+      timeInForce: undefined,
+    } satisfies DecibelOrder;
+  }
+
+  // cancel_bulk_order_to_subaccount(auth, subaccount, market)
+  // cancel_twap_orders_to_subaccount(auth, subaccount, market, order_id)
+  // cancel_tp_sl_order_for_position(auth, subaccount, market, order_id)
+  // API args: [subaccount(0), market(1), ...]
+  if (
     fnName === "cancel_bulk_order_to_subaccount" ||
     fnName === "cancel_twap_orders_to_subaccount" ||
     fnName === "cancel_tp_sl_order_for_position"
   ) {
-    if (args.length < 3) return undefined;
-    const market =
-      fnName === "cancel_bulk_order_to_subaccount"
-        ? extractObjectInner(args[2])
-        : fnName === "cancel_order_to_subaccount" ||
-            fnName === "cancel_client_order_to_subaccount"
-          ? extractObjectInner(args[3])
-          : extractObjectInner(args[2]);
+    if (args.length < 2) return undefined;
     return {
       orderType: "cancel",
       side: undefined,
-      market,
+      market: extractObjectInner(args[1]),
       size: undefined,
       price: undefined,
       status: undefined,

--- a/app/utils/decibel/types.ts
+++ b/app/utils/decibel/types.ts
@@ -6,6 +6,8 @@ export type DecibelOrder = {
   price: string | undefined;
   status: string | undefined;
   timeInForce: string | undefined;
+  orderId: string | undefined;
+  subaccount: string | undefined;
 };
 
 export type DecibelDeposit = {

--- a/app/utils/decibel/types.ts
+++ b/app/utils/decibel/types.ts
@@ -1,0 +1,29 @@
+export type DecibelOrder = {
+  orderType: "limit" | "market" | "cancel" | "bulk" | "twap";
+  side: "buy" | "sell" | undefined;
+  market: string;
+  size: string | undefined;
+  price: string | undefined;
+  status: string | undefined;
+  timeInForce: string | undefined;
+};
+
+export type DecibelDeposit = {
+  asset: string;
+  amount: string;
+  subaccount: string;
+  functionName: string;
+};
+
+export type DecibelWithdraw = {
+  asset: string;
+  amount: string;
+  subaccount: string;
+  functionName: string;
+};
+
+export type DecibelTransactionSummary = {
+  orders: DecibelOrder[];
+  deposits: DecibelDeposit[];
+  withdrawals: DecibelWithdraw[];
+};


### PR DESCRIPTION
…ithdrawals

Add a dedicated "Decibel" tab to the transaction detail page that only appears for transactions involving Decibel contracts. Parses OrderEvent data and entry function payloads into friendly, mobile-responsive tables covering perpetual orders, deposits, and withdrawals.

- New parsing module at app/utils/decibel/ with detection and parsing
- Responsive tab: MUI tables on desktop, card layout on mobile
- Supports both mainnet and testnet Decibel contract addresses
- 15 new tests covering parser, detection, and tab visibility

### Description

<!-- Please describe your change and its motivation. -->

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
