### PR TITLE
fix(blocks): align blocks list with REST block data

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -54,7 +54,7 @@ Used by route loaders **and** components. When a route loader pre-fetches data, 
 | `useGetBlockByHeight` | `useGetBlock.ts` | 30 s | 10 min | 20 min | — | Confirmed blocks |
 | `useGetBlockByVersion` | `useGetBlock.ts` | 1 h | 24 h | — | — | Immutable |
 | `useGetMostRecentBlocks` (ledger) | `useGetMostRecentBlocks.ts` | 60 s | 5 min | — | `refetchOnWindowFocus: false` | Ledger info for block height |
-| `useGetMostRecentBlocks` (blocks) | `useGetMostRecentBlocks.ts` | 60 s | 10 min | — | `refetchOnWindowFocus: false` | Indexer-based recent blocks |
+| `useGetMostRecentBlocks` (blocks) | `useGetMostRecentBlocks.ts` | 60 s | 10 min | — | `refetchOnWindowFocus: false` | REST `getBlockByHeight` batch for recent blocks |
 
 ### Transactions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Blocks list** (`/blocks`): recent rows now use the same REST block API as block detail pages, so block hash, timestamps, and transaction version ranges match what you see after opening a block (previously the indexer `block_metadata_transactions` row was mislabeled as the block hash and version bounds could disagree with the node).
 - **Coins page** (`/coins`): changing verification filters or the Emojicoins toggle no longer freezes the tab when thousands of assets match — the table virtualizes rows via an on-demand `renderRow` path and scrolls inside a bounded-height container instead of allocating every row up front
 - **Dev mode**: `useFeatureName()` now reads from a `feature_name` cookie or the `VITE_FEATURE_NAME` env var instead of always returning `"prod"` — the Development Mode banner, Early Development Mode banner, and dev-only UI (e.g. Aptos Names banner) are functional again
 - **SSR dev server**: removed duplicate `tanstackRouter()` plugin from `vite.config.ts` — it conflicted with the code-splitting plugins already bundled inside `tanstackStart()`, causing `ReferenceError: TSRSplitComponent is not defined` on every SSR request during `pnpm dev`

--- a/app/api/hooks/useGetMostRecentBlocks.ts
+++ b/app/api/hooks/useGetMostRecentBlocks.ts
@@ -6,29 +6,12 @@ import {
   useSdkV2Client,
 } from "../../global-config";
 import {getLedgerInfo} from "..";
+import {getRecentBlocks} from "../v2";
 
-const RECENT_BLOCKS_QUERY = `
-  query RecentBlocks($maxBlockHeight: bigint!, $limit: Int!) {
-    block_metadata_transactions(
-      where: {block_height: {_lte: $maxBlockHeight}}
-      order_by: {block_height: desc}
-      limit: $limit
-    ) {
-      block_height
-      id
-      timestamp
-      version
-    }
-  }
-`;
-
-type BlockMetadataTransactionSummary = {
-  block_height: number | string;
-  id: string;
-  timestamp: string;
-  version: number | string;
-};
-
+/**
+ * Recent blocks for `/blocks`. Uses the same REST `getBlockByHeight` data as block
+ * detail pages so hash, timestamps, and version ranges stay consistent with the API.
+ */
 export function useGetMostRecentBlocks(
   start: string | undefined,
   count: number,
@@ -51,66 +34,31 @@ export function useGetMostRecentBlocks(
   );
 
   const {isLoading, data: blocks} = useQuery<Types.Block[]>({
-    queryKey: ["recentBlocksIndexer", currentBlockHeight, count, networkValue],
+    queryKey: ["recentBlocksRest", currentBlockHeight, count, networkValue],
     queryFn: async () => {
-      if (!Number.isFinite(currentBlockHeight) || !ledgerData?.ledger_version) {
+      if (!Number.isFinite(currentBlockHeight)) {
         return [];
       }
-      const upperBound = currentBlockHeight + 1;
-      const response = await sdkV2Client.queryIndexer<{
-        block_metadata_transactions: BlockMetadataTransactionSummary[];
-      }>({
-        query: {
-          query: RECENT_BLOCKS_QUERY,
-          variables: {
-            maxBlockHeight: upperBound,
-            limit: count + 1,
-          },
-        },
-      });
-
-      const rows = response.block_metadata_transactions ?? [];
-      const sentinel =
-        rows.length > 0 && Number(rows[0].block_height) > currentBlockHeight
-          ? rows[0]
-          : undefined;
-      const recentRows = sentinel
-        ? rows.slice(1, count + 1)
-        : rows.slice(0, count);
-
-      return recentRows.map((row, index) => {
-        const nextFirstVersion =
-          index === 0
-            ? sentinel
-              ? BigInt(String(sentinel.version))
-              : BigInt(ledgerData.ledger_version) + 1n
-            : BigInt(String(recentRows[index - 1].version));
-
-        // Hasura returns timestamps without timezone suffix (e.g. "2024-03-19T17:40:00").
-        // Without an explicit timezone, new Date() treats the string as *local* time, which
-        // shifts the value by the user's UTC offset. Append "Z" when no timezone is present
-        // so the string is always interpreted as UTC.
-        const rawTs = row.timestamp as string;
-        const utcTs = /Z$|[+-]\d{2}:\d{2}$/.test(rawTs) ? rawTs : `${rawTs}Z`;
-
-        return {
-          block_height: row.block_height.toString(),
-          block_hash: row.id,
-          block_timestamp: new Date(utcTs).getTime().toString(),
-          first_version: row.version.toString(),
-          last_version: (nextFirstVersion - 1n).toString(),
-        };
-      });
+      const restBlocks = await getRecentBlocks(
+        currentBlockHeight,
+        count,
+        sdkV2Client,
+      );
+      return restBlocks.map((b) => ({
+        block_height: b.block_height,
+        block_hash: b.block_hash,
+        block_timestamp: b.block_timestamp,
+        first_version: b.first_version,
+        last_version: b.last_version,
+      }));
     },
-    enabled:
-      Number.isFinite(currentBlockHeight) && !!ledgerData?.ledger_version,
+    enabled: Number.isFinite(currentBlockHeight),
     staleTime: 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
   });
 
-  // Calculate recentBlocks during render instead of using useEffect
   const recentBlocks =
     currentBlockHeight !== undefined &&
     !isLoadingLedgerData &&

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -279,7 +279,7 @@ The app shell that wraps every page.
 
 | Aspect | Detail |
 |--------|--------|
-| **Data** | Ledger info + indexer `block_metadata_transactions`. |
+| **Data** | Ledger info (cursor height) + REST `getBlockByHeight` for each row (same source as block detail). |
 | **Pagination** | `?start=` cursor. |
 | **Columns** | Block height (linked), proposer, timestamp, transaction count. |
 | **Virtualization** | Uses `VirtualizedTableBody` for large result sets. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/blocks` table was built from indexer `block_metadata_transactions`, mapping the row `id` (block metadata **transaction** id, typically the txn hash) to `block_hash`, and inferring `last_version` from the next row or ledger tip. That could disagree with block detail pages, which use REST `getBlockByHeight`.

## Changes

- `useGetMostRecentBlocks` now loads each row via `getRecentBlocks` → parallel REST `getBlockByHeight` (with `withTransactions: false`), matching the block detail API for hash, timestamp, and version range.
- Updated `docs/FEATURES_SPECIFICATION.md` (FEAT-BLOCKS-001), `CHANGELOG.md`, and `CACHING.md`.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86b09ef-8027-4e2a-a560-e551a83465b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86b09ef-8027-4e2a-a560-e551a83465b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

