### PR TITLE
fix(wallet): allow custom + loopback RPC when explorer is local (non-Petra)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wallet transactions on localnet**: non-Petra wallets that report a **custom** network name but use a **loopback** REST URL (for example `http://127.0.0.1:8080/v1`) are no longer blocked when the explorer is on the **local** network; submission still requires a real loopback endpoint match.
 - **Blocks list** (`/blocks`): recent rows now use the same REST block API as block detail pages, so block hash, timestamps, and transaction version ranges match what you see after opening a block (previously the indexer `block_metadata_transactions` row was mislabeled as the block hash and version bounds could disagree with the node).
 - **Coins page** (`/coins`): changing verification filters or the Emojicoins toggle no longer freezes the tab when thousands of assets match — the table virtualizes rows via an on-demand `renderRow` path and scrolls inside a bounded-height container instead of allocating every row up front
 - **Dev mode**: `useFeatureName()` now reads from a `feature_name` cookie or the `VITE_FEATURE_NAME` env var instead of always returning `"prod"` — the Development Mode banner, Early Development Mode banner, and dev-only UI (e.g. Aptos Names banner) are functional again

--- a/app/api/hooks/useSubmitTransaction.ts
+++ b/app/api/hooks/useSubmitTransaction.ts
@@ -34,8 +34,8 @@ const useSubmitTransaction = () => {
   const {signAndSubmitTransaction, wallet, network} = useWallet();
 
   async function submitTransaction(transaction: InputTransactionData) {
-    const walletNet = network?.name.toLocaleLowerCase();
-    const explorerNet = networkName.toLocaleLowerCase();
+    const walletNet = network?.name.toLowerCase();
+    const explorerNet = networkName.toLowerCase();
     const customLocalOk = allowsCustomNetworkForLocalExplorer(
       wallet?.name,
       walletNet,

--- a/app/api/hooks/useSubmitTransaction.ts
+++ b/app/api/hooks/useSubmitTransaction.ts
@@ -5,6 +5,7 @@ import {
 import {useState} from "react";
 import {FailedTransactionError} from "~/types/aptos";
 import {useAptosClient, useNetworkName} from "../../global-config";
+import {allowsCustomNetworkForLocalExplorer} from "../../utils/walletNetwork";
 
 export type TransactionResponse =
   | TransactionResponseOnSubmission
@@ -33,8 +34,17 @@ const useSubmitTransaction = () => {
   const {signAndSubmitTransaction, wallet, network} = useWallet();
 
   async function submitTransaction(transaction: InputTransactionData) {
+    const walletNet = network?.name.toLocaleLowerCase();
+    const explorerNet = networkName.toLocaleLowerCase();
+    const customLocalOk = allowsCustomNetworkForLocalExplorer(
+      wallet?.name,
+      walletNet,
+      network?.url,
+      explorerNet,
+    );
     if (
-      network?.name.toLocaleLowerCase() !== networkName &&
+      walletNet !== explorerNet &&
+      !customLocalOk &&
       // TODO: This is a hack to get around network being cached
       wallet?.name !== "Google (AptosConnect)"
     ) {

--- a/app/utils/routeRedirects.test.ts
+++ b/app/utils/routeRedirects.test.ts
@@ -287,6 +287,9 @@ describe("FEAT-WALLET-002 — shouldBlockWalletSubmission", () => {
     expect(shouldBlockWalletSubmission("Mainnet", "mainnet", "Petra")).toBe(
       false,
     );
+    expect(shouldBlockWalletSubmission("mainnet", "Mainnet", "Petra")).toBe(
+      false,
+    );
   });
 
   it("never blocks Google AptosConnect", () => {

--- a/app/utils/routeRedirects.test.ts
+++ b/app/utils/routeRedirects.test.ts
@@ -304,6 +304,39 @@ describe("FEAT-WALLET-002 — shouldBlockWalletSubmission", () => {
       true,
     );
   });
+
+  it("allows non-Petra custom + loopback URL when explorer is local", () => {
+    expect(
+      shouldBlockWalletSubmission(
+        "custom",
+        "local",
+        "Nightly",
+        "http://127.0.0.1:8080/v1",
+      ),
+    ).toBe(false);
+  });
+
+  it("still blocks Petra custom even with loopback URL", () => {
+    expect(
+      shouldBlockWalletSubmission(
+        "custom",
+        "local",
+        "Petra",
+        "http://127.0.0.1:8080/v1",
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks non-Petra custom when URL is not loopback", () => {
+    expect(
+      shouldBlockWalletSubmission(
+        "custom",
+        "local",
+        "Nightly",
+        "https://api.testnet.staging.aptoslabs.com/v1",
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("FEAT-ACCOUNT-002 — getPortfolioUrl", () => {

--- a/app/utils/routeRedirects.ts
+++ b/app/utils/routeRedirects.ts
@@ -131,7 +131,7 @@ export function shouldBlockWalletSubmission(
   ) {
     return false;
   }
-  return walletNetworkName?.toLocaleLowerCase() !== explorerNetworkName;
+  return walletNetworkName?.toLowerCase() !== explorerNetworkName.toLowerCase();
 }
 
 export type PortfolioProvider = "lightscan" | "yieldai";

--- a/app/utils/routeRedirects.ts
+++ b/app/utils/routeRedirects.ts
@@ -5,6 +5,8 @@
  * unit tested without mounting the TanStack Router.
  */
 
+import {allowsCustomNetworkForLocalExplorer} from "./walletNetwork";
+
 export type EntityRedirectResult =
   | {kind: "tab"; tab: string; search: Record<string, string>}
   | {kind: "modules"; search: Record<string, string>}
@@ -114,8 +116,19 @@ export function shouldBlockWalletSubmission(
   walletNetworkName: string | undefined,
   explorerNetworkName: string,
   walletName: string | undefined,
+  walletRpcUrl?: string,
 ): boolean {
   if (walletName === "Google (AptosConnect)") {
+    return false;
+  }
+  if (
+    allowsCustomNetworkForLocalExplorer(
+      walletName,
+      walletNetworkName,
+      walletRpcUrl,
+      explorerNetworkName,
+    )
+  ) {
     return false;
   }
   return walletNetworkName?.toLocaleLowerCase() !== explorerNetworkName;

--- a/app/utils/walletNetwork.test.ts
+++ b/app/utils/walletNetwork.test.ts
@@ -1,0 +1,88 @@
+// Covers FEAT-WALLET-002 (custom + loopback alignment for non-Petra wallets)
+import {describe, expect, it} from "vitest";
+import {
+  allowsCustomNetworkForLocalExplorer,
+  isLoopbackHostname,
+  isLoopbackRpcUrl,
+} from "./walletNetwork";
+
+describe("isLoopbackHostname", () => {
+  it("accepts localhost", () => {
+    expect(isLoopbackHostname("localhost")).toBe(true);
+    expect(isLoopbackHostname("LOCALHOST")).toBe(true);
+  });
+
+  it("accepts 127.0.0.1 and other 127.x", () => {
+    expect(isLoopbackHostname("127.0.0.1")).toBe(true);
+    expect(isLoopbackHostname("127.255.255.255")).toBe(true);
+  });
+
+  it("rejects non-loopback IPv4", () => {
+    expect(isLoopbackHostname("128.0.0.1")).toBe(false);
+    expect(isLoopbackHostname("10.0.0.1")).toBe(false);
+  });
+
+  it("accepts IPv6 loopback textual forms", () => {
+    expect(isLoopbackHostname("::1")).toBe(true);
+    expect(isLoopbackHostname("0:0:0:0:0:0:0:1")).toBe(true);
+  });
+});
+
+describe("isLoopbackRpcUrl", () => {
+  it("parses http URLs", () => {
+    expect(isLoopbackRpcUrl("http://127.0.0.1:8080/v1")).toBe(true);
+    expect(isLoopbackRpcUrl("http://localhost:8080/v1")).toBe(true);
+  });
+
+  it("returns false for empty or invalid", () => {
+    expect(isLoopbackRpcUrl(undefined)).toBe(false);
+    expect(isLoopbackRpcUrl("")).toBe(false);
+    expect(isLoopbackRpcUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("allowsCustomNetworkForLocalExplorer", () => {
+  it("allows custom + loopback for non-Petra when explorer is local", () => {
+    expect(
+      allowsCustomNetworkForLocalExplorer(
+        "Nightly",
+        "custom",
+        "http://127.0.0.1:8080/v1",
+        "local",
+      ),
+    ).toBe(true);
+  });
+
+  it("disallows for Petra", () => {
+    expect(
+      allowsCustomNetworkForLocalExplorer(
+        "Petra",
+        "custom",
+        "http://127.0.0.1:8080/v1",
+        "local",
+      ),
+    ).toBe(false);
+  });
+
+  it("disallows when explorer is not local", () => {
+    expect(
+      allowsCustomNetworkForLocalExplorer(
+        "Nightly",
+        "custom",
+        "http://127.0.0.1:8080/v1",
+        "mainnet",
+      ),
+    ).toBe(false);
+  });
+
+  it("disallows when wallet URL is not loopback", () => {
+    expect(
+      allowsCustomNetworkForLocalExplorer(
+        "Nightly",
+        "custom",
+        "https://api.testnet.staging.aptoslabs.com/v1",
+        "local",
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/utils/walletNetwork.test.ts
+++ b/app/utils/walletNetwork.test.ts
@@ -34,6 +34,11 @@ describe("isLoopbackRpcUrl", () => {
     expect(isLoopbackRpcUrl("http://localhost:8080/v1")).toBe(true);
   });
 
+  it("rejects non-http(s) schemes even when hostname is loopback", () => {
+    expect(isLoopbackRpcUrl("file://localhost/etc/passwd")).toBe(false);
+    expect(isLoopbackRpcUrl("ws://127.0.0.1:8080/v1")).toBe(false);
+  });
+
   it("returns false for empty or invalid", () => {
     expect(isLoopbackRpcUrl(undefined)).toBe(false);
     expect(isLoopbackRpcUrl("")).toBe(false);

--- a/app/utils/walletNetwork.ts
+++ b/app/utils/walletNetwork.ts
@@ -1,0 +1,51 @@
+/**
+ * Wallet ↔ explorer network alignment helpers.
+ *
+ * Non-Petra wallets often report SDK `Network.CUSTOM` while the explorer uses
+ * `local` for loopback development; treat them as compatible when the wallet
+ * RPC URL targets localhost / loopback.
+ */
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost") return true;
+  if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h)) {
+    const parts = h.split(".").map(Number);
+    if (
+      parts.length === 4 &&
+      parts[0] === 127 &&
+      parts.every((n) => n >= 0 && n <= 255)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isLoopbackRpcUrl(url: string | undefined): boolean {
+  if (!url?.trim()) return false;
+  try {
+    return isLoopbackHostname(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * When the explorer is on `local`, allow a wallet-reported `custom` network
+ * for non-Petra wallets if the wallet's REST URL points at loopback.
+ */
+export function allowsCustomNetworkForLocalExplorer(
+  walletName: string | undefined,
+  walletNetworkName: string | undefined,
+  walletRpcUrl: string | undefined,
+  explorerNetworkName: string,
+): boolean {
+  if (walletName === "Petra") return false;
+  if (explorerNetworkName.toLowerCase() !== "local") return false;
+  if (walletNetworkName?.toLowerCase() !== "custom") return false;
+  return isLoopbackRpcUrl(walletRpcUrl);
+}

--- a/app/utils/walletNetwork.ts
+++ b/app/utils/walletNetwork.ts
@@ -28,7 +28,11 @@ export function isLoopbackHostname(hostname: string): boolean {
 export function isLoopbackRpcUrl(url: string | undefined): boolean {
   if (!url?.trim()) return false;
   try {
-    return isLoopbackHostname(new URL(url).hostname);
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    return isLoopbackHostname(parsed.hostname);
   } catch {
     return false;
   }

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -787,7 +787,7 @@ The app shell that wraps every page.
 | Aspect | Detail |
 |--------|--------|
 | **Hook** | `useSubmitTransaction`. |
-| **Validation** | Enforces wallet network matches explorer network (exception for Google Aptos Connect). |
+| **Validation** | Enforces wallet network matches explorer network (exceptions: Google Aptos Connect; for **non-Petra** wallets, wallet `custom` with a **loopback** REST URL is treated as compatible with explorer **local**). |
 | **Flow** | Signs via wallet adapter, confirms via explorer's Aptos client polling. |
 
 ### FEAT-WALLET-003 — Account Navigation
@@ -1199,6 +1199,7 @@ The app shell that wraps every page.
 | `app/lib/graphqlSupport.test.ts` | FEAT-FLAGS-001 (GraphQL URI per network), FEAT-COIN-001/FEAT-FA-001 (tab gating logic) |
 | `app/lib/validators.test.ts` | FEAT-NETWORK-001 (network name validation), FEAT-FLAGS-003 (feature name validation), well-known constants |
 | `app/utils/routeRedirects.test.ts` | FEAT-ACCOUNT-012 (entity default tab redirects for all route types), FEAT-TOKEN-004 (legacy numeric redirect), FEAT-VALIDATORS-006 (validators/validators-enhanced redirects), FEAT-SEARCH-001 (header search navigation), FEAT-WALLET-002 (wallet network mismatch), FEAT-ACCOUNT-002 (DeFi portfolio URLs) |
+| `app/utils/walletNetwork.test.ts` | FEAT-WALLET-002 (loopback RPC + `custom` vs explorer `local` for non-Petra) |
 | `app/utils/rateLimiter.test.ts` | FEAT-RATELIMIT-002 (rate limit error detection, URL endpoint extraction) |
 | `app/utils/utilsCoverage.test.ts` | FEAT-ROUTING-003 (isValidStruct), FEAT-TXN-002 (sortTransactions), FEAT-WALLET-001 (sortPetraFirst), FEAT-MODULES-004 (bytecode size), FEAT-MODULES-001 (param names, function line numbers), isValidUrl, assertNever |
 | `app/data/bannedCollections.test.ts` | FEAT-ACCOUNT-008 (scam collection detection: registry shape, hex keys, reason strings) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Non-Petra wallets often report Aptos SDK `Network.CUSTOM` while the explorer uses the `local` network for development. The transaction hook previously compared names only and blocked submission.

## Changes

- Added `app/utils/walletNetwork.ts` with loopback hostname/URL detection and `allowsCustomNetworkForLocalExplorer` (non-Petra only: wallet `custom` + loopback REST URL + explorer `local` → treat as aligned).
- `useSubmitTransaction` uses the same rule before showing the network mismatch error.
- Extended `shouldBlockWalletSubmission` with an optional `walletRpcUrl` parameter for consistency and tests.
- Tests in `walletNetwork.test.ts` and `routeRedirects.test.ts`; spec and changelog updated.

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run app/utils/walletNetwork.test.ts app/utils/routeRedirects.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed014caa-cbaa-48aa-912a-ff506b9af933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed014caa-cbaa-48aa-912a-ff506b9af933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

