### PR TITLE
feat(decibel): enrich bulk order visualization with full bid/ask ladders and event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Decibel bulk order detail**: the Decibel tab on transaction pages now displays full bid/ask price-size ladders parsed from `place_bulk_orders_to_subaccount` payload arguments, structured `BulkOrderPlacedEvent` data (including cancelled orders), and `BulkOrderFilledEvent` fill tables — previously only the market name and subaccount were shown for bulk orders
 - **Settings page** (`/settings`): dedicated full-page settings replacing the old header popup dialog. Includes API key overrides (per network) and a new Move Bytecode Decompilation opt-in toggle
 - **Decompilation opt-in**: decompiled and disassembly code views now require explicit user opt-in at `/settings`. Users must acknowledge a disclaimer that decompiled output may not match original source before the feature is enabled
 - **Settings**: optional geomi.dev API key override can be set **per network** (instead of one key for all networks). Existing saved single keys are migrated to all networks on load until you save again.

--- a/app/api/hooks/useGetDecibelMarketName.ts
+++ b/app/api/hooks/useGetDecibelMarketName.ts
@@ -4,10 +4,22 @@ import {DECIBEL_CONTRACTS} from "../../utils/decibel";
 
 const PERP_MARKET_CONFIG_TYPE = "::perp_market_config::PerpMarketConfiguration";
 
+const PRICE_DECIMALS = 6;
+
 export type DecibelMarketConfig = {
   name: string | undefined;
-  szDecimals: number | undefined;
-  tickerSize: number | undefined;
+  baseAsset: string | undefined;
+  quoteAsset: string | undefined;
+  szDecimals: number;
+  priceDecimals: number;
+};
+
+type PerpMarketConfigResource = {
+  info?: {name?: string};
+  precision?: {
+    sz_precision?: {decimals?: number};
+    ticker_size?: string;
+  };
 };
 
 function fetchMarketConfig(
@@ -21,21 +33,30 @@ function fetchMarketConfig(
           marketAddress,
           `${addr}${PERP_MARKET_CONFIG_TYPE}`,
         );
-        const data = resource.data as {
-          info?: {name?: string; sz_decimals?: string; ticker_size?: string};
-        };
-        const szDec = data?.info?.sz_decimals;
-        const ticker = data?.info?.ticker_size;
+        const data = resource.data as PerpMarketConfigResource;
+        const name = data?.info?.name ?? undefined;
+        const szDec = data?.precision?.sz_precision?.decimals;
+        const [baseAsset, quoteAsset] = name?.includes("/")
+          ? name.split("/", 2)
+          : [undefined, undefined];
         return {
-          name: data?.info?.name ?? undefined,
-          szDecimals: szDec !== undefined ? Number(szDec) : undefined,
-          tickerSize: ticker !== undefined ? Number(ticker) : undefined,
+          name,
+          baseAsset,
+          quoteAsset,
+          szDecimals: szDec ?? 0,
+          priceDecimals: PRICE_DECIMALS,
         };
       } catch {
         // Try next contract address
       }
     }
-    return {name: undefined, szDecimals: undefined, tickerSize: undefined};
+    return {
+      name: undefined,
+      baseAsset: undefined,
+      quoteAsset: undefined,
+      szDecimals: 0,
+      priceDecimals: PRICE_DECIMALS,
+    };
   };
 }
 

--- a/app/api/hooks/useGetDecibelMarketName.ts
+++ b/app/api/hooks/useGetDecibelMarketName.ts
@@ -4,33 +4,59 @@ import {DECIBEL_CONTRACTS} from "../../utils/decibel";
 
 const PERP_MARKET_CONFIG_TYPE = "::perp_market_config::PerpMarketConfiguration";
 
+export type DecibelMarketConfig = {
+  name: string | undefined;
+  szDecimals: number | undefined;
+  tickerSize: number | undefined;
+};
+
+function fetchMarketConfig(
+  aptosClient: ReturnType<typeof useAptosClient>,
+  marketAddress: string,
+): () => Promise<DecibelMarketConfig> {
+  return async () => {
+    for (const addr of DECIBEL_CONTRACTS) {
+      try {
+        const resource = await aptosClient.getAccountResource(
+          marketAddress,
+          `${addr}${PERP_MARKET_CONFIG_TYPE}`,
+        );
+        const data = resource.data as {
+          info?: {name?: string; sz_decimals?: string; ticker_size?: string};
+        };
+        const szDec = data?.info?.sz_decimals;
+        const ticker = data?.info?.ticker_size;
+        return {
+          name: data?.info?.name ?? undefined,
+          szDecimals: szDec !== undefined ? Number(szDec) : undefined,
+          tickerSize: ticker !== undefined ? Number(ticker) : undefined,
+        };
+      } catch {
+        // Try next contract address
+      }
+    }
+    return {name: undefined, szDecimals: undefined, tickerSize: undefined};
+  };
+}
+
 export function useGetDecibelMarketName(marketAddress: string): {
   isLoading: boolean;
   data: string | undefined;
+} {
+  const config = useGetDecibelMarketConfig(marketAddress);
+  return {isLoading: config.isLoading, data: config.data?.name};
+}
+
+export function useGetDecibelMarketConfig(marketAddress: string): {
+  isLoading: boolean;
+  data: DecibelMarketConfig | undefined;
 } {
   const aptosClient = useAptosClient();
   const networkValue = useNetworkValue();
 
   const query = useQuery({
-    queryKey: ["decibelMarketName", marketAddress, networkValue],
-    queryFn: async () => {
-      // Try each contract address (mainnet and testnet) until one works
-      for (const addr of DECIBEL_CONTRACTS) {
-        try {
-          const resource = await aptosClient.getAccountResource(
-            marketAddress,
-            `${addr}${PERP_MARKET_CONFIG_TYPE}`,
-          );
-          const data = resource.data as {
-            info?: {name?: string};
-          };
-          return data?.info?.name ?? undefined;
-        } catch {
-          // Try next contract address
-        }
-      }
-      return undefined;
-    },
+    queryKey: ["decibelMarketConfig", marketAddress, networkValue],
+    queryFn: fetchMarketConfig(aptosClient, marketAddress),
     enabled: !!marketAddress,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: 24 * 60 * 60 * 1000,

--- a/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
+++ b/app/pages/Transaction/Tabs/Components/DecibelEventView.tsx
@@ -381,14 +381,7 @@ function BulkOrderPlacedEventView({data}: {data: Record<string, unknown>}) {
         <AddressValue hash={String(data.user)} />
       </Row>
       <Row label="Sequence">
-        <MonoText>
-          {String(data.sequence_number)}{" "}
-          {data.previous_seq_num !== undefined && (
-            <Typography component="span" variant="body2" color="text.secondary">
-              (prev: {String(data.previous_seq_num)})
-            </Typography>
-          )}
-        </MonoText>
+        <MonoText>{String(data.sequence_number)}</MonoText>
       </Row>
       <Row label="Bids">
         <PriceSizeTable

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -68,8 +68,6 @@ const ORDER_TYPE_ICONS: Record<string, React.ReactElement> = {
   twap: <ScheduleOutlinedIcon fontSize="small" />,
 };
 
-const PRICE_DECIMALS = 5;
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -185,14 +183,23 @@ function formatDecibelPrice(
   raw: string,
   config: DecibelMarketConfig | undefined,
 ): string {
-  return getFormattedBalanceStr(raw, config?.szDecimals ?? PRICE_DECIMALS);
+  const decimals = config?.priceDecimals ?? 6;
+  const formatted = getFormattedBalanceStr(raw, decimals);
+  const quote = config?.quoteAsset;
+  if (quote === "USD" || quote === "USDC") return `$${formatted}`;
+  if (quote) return `${formatted} ${quote}`;
+  return formatted;
 }
 
 function formatDecibelSize(
   raw: string,
   config: DecibelMarketConfig | undefined,
 ): string {
-  return getFormattedBalanceStr(raw, config?.szDecimals ?? PRICE_DECIMALS);
+  const decimals = config?.szDecimals ?? 0;
+  const formatted = getFormattedBalanceStr(raw, decimals);
+  const base = config?.baseAsset;
+  if (base) return `${formatted} ${base}`;
+  return formatted;
 }
 
 function MonoText({children}: {children: React.ReactNode}) {
@@ -311,8 +318,20 @@ function LegTable({
         <TableHead>
           <TableRow>
             <GeneralTableHeaderCell header="#" />
-            <GeneralTableHeaderCell header="Price" />
-            <GeneralTableHeaderCell header="Size" />
+            <GeneralTableHeaderCell
+              header={
+                marketConfig?.quoteAsset
+                  ? `Price (${marketConfig.quoteAsset})`
+                  : "Price"
+              }
+            />
+            <GeneralTableHeaderCell
+              header={
+                marketConfig?.baseAsset
+                  ? `Size (${marketConfig.baseAsset})`
+                  : "Size"
+              }
+            />
           </TableRow>
         </TableHead>
         <TableBody>

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -378,12 +378,16 @@ function BulkOrderInlineDetail({
   const hasPlaced = placedEvents.length > 0;
   const hasFills = filledEvents.length > 0;
 
+  const [expanded, setExpanded] = React.useState(false);
+
   if (!hasDetail && !hasPlaced && !hasFills) return null;
 
   return (
     <Accordion
       disableGutters
       elevation={0}
+      expanded={expanded}
+      onChange={() => setExpanded((prev) => !prev)}
       sx={{
         "&::before": {display: "none"},
         backgroundColor: "transparent",
@@ -391,6 +395,9 @@ function BulkOrderInlineDetail({
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
+        aria-label={
+          expanded ? "Hide bulk order details" : "Show bulk order details"
+        }
         sx={{
           minHeight: 36,
           px: 0,
@@ -398,7 +405,7 @@ function BulkOrderInlineDetail({
         }}
       >
         <Typography variant="body2" color="primary" sx={{fontWeight: 600}}>
-          More Details
+          {expanded ? "Hide details" : "Show details"}
         </Typography>
       </AccordionSummary>
       <AccordionDetails sx={{px: 0, pt: 0}}>

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -1,12 +1,16 @@
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FlashOnOutlinedIcon from "@mui/icons-material/FlashOnOutlined";
 import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
 import UploadOutlinedIcon from "@mui/icons-material/UploadOutlined";
 import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   ButtonBase,
   Chip,
@@ -28,7 +32,11 @@ import {
   type CoinDescription,
   useGetCoinList,
 } from "../../../api/hooks/useGetCoinList";
-import {useGetDecibelMarketName} from "../../../api/hooks/useGetDecibelMarketName";
+import {
+  type DecibelMarketConfig,
+  useGetDecibelMarketConfig,
+  useGetDecibelMarketName,
+} from "../../../api/hooks/useGetDecibelMarketName";
 import HashButton, {HashType} from "../../../components/HashButton";
 import ContentBox from "../../../components/IndividualPageContent/ContentBox";
 import {getFormattedBalanceStr} from "../../../components/IndividualPageContent/ContentValue/CurrencyValue";
@@ -43,6 +51,7 @@ import type {
   DecibelBulkOrderPlacedEvent,
   DecibelDeposit,
   DecibelOrder,
+  DecibelTransactionSummary,
   DecibelWithdraw,
 } from "../../../utils/decibel";
 import {
@@ -58,6 +67,8 @@ const ORDER_TYPE_ICONS: Record<string, React.ReactElement> = {
   bulk: <ViewInArOutlinedIcon fontSize="small" />,
   twap: <ScheduleOutlinedIcon fontSize="small" />,
 };
+
+const PRICE_DECIMALS = 5;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -170,13 +181,497 @@ function humanizeFunctionName(fnName: string): string {
   return fnName.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function formatDecibelPrice(
+  raw: string,
+  config: DecibelMarketConfig | undefined,
+): string {
+  return getFormattedBalanceStr(raw, config?.szDecimals ?? PRICE_DECIMALS);
+}
+
+function formatDecibelSize(
+  raw: string,
+  config: DecibelMarketConfig | undefined,
+): string {
+  return getFormattedBalanceStr(raw, config?.szDecimals ?? PRICE_DECIMALS);
+}
+
+function MonoText({children}: {children: React.ReactNode}) {
+  return (
+    <Typography variant="body2" sx={{fontFamily: "monospace"}}>
+      {children}
+    </Typography>
+  );
+}
+
+function KeyValue({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{minWidth: 100, flexShrink: 0}}
+      >
+        {label}
+      </Typography>
+      <Box sx={{flex: 1, minWidth: 0}}>{children}</Box>
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk Order Ladder Table
+// ---------------------------------------------------------------------------
+
+function LegTable({
+  legs,
+  label,
+  color,
+  isMobile,
+  marketConfig,
+}: {
+  legs: BulkOrderLeg[];
+  label: string;
+  color: "success" | "error";
+  isMobile: boolean;
+  marketConfig: DecibelMarketConfig | undefined;
+}) {
+  const theme = useTheme();
+  if (legs.length === 0) return null;
+
+  const formattedLegs = legs.map((leg) => ({
+    price: formatDecibelPrice(leg.price, marketConfig),
+    size: formatDecibelSize(leg.size, marketConfig),
+    rawSize: Number(leg.size) || 0,
+  }));
+
+  const totalRawSize = formattedLegs.reduce((acc, leg) => acc + leg.rawSize, 0);
+  const totalSize =
+    totalRawSize > 0
+      ? formatDecibelSize(String(totalRawSize), marketConfig)
+      : undefined;
+
+  if (isMobile) {
+    return (
+      <Box sx={{mb: 1}}>
+        <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 1}}>
+          <Typography
+            variant="subtitle2"
+            sx={{color: theme.palette[color].main}}
+          >
+            {label} ({legs.length})
+          </Typography>
+          {totalSize && (
+            <Typography variant="caption" color="text.secondary">
+              Total: {totalSize}
+            </Typography>
+          )}
+        </Stack>
+        <Stack spacing={0.5}>
+          {formattedLegs.map((leg, i) => (
+            <Stack
+              // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
+              key={`${leg.price}-${leg.size}-${i}`}
+              direction="row"
+              justifyContent="space-between"
+              alignItems="baseline"
+              sx={{
+                py: 0.5,
+                borderBottom: `1px solid ${theme.palette.divider}`,
+                "&:last-of-type": {borderBottom: "none"},
+              }}
+            >
+              <MonoText>{leg.price}</MonoText>
+              <MonoText>{leg.size}</MonoText>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{mb: 1}}>
+      <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 0.5}}>
+        <Typography variant="subtitle2" sx={{color: theme.palette[color].main}}>
+          {label} ({legs.length})
+        </Typography>
+        {totalSize && (
+          <Typography variant="caption" color="text.secondary">
+            Total size: {totalSize}
+          </Typography>
+        )}
+      </Stack>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <GeneralTableHeaderCell header="#" />
+            <GeneralTableHeaderCell header="Price" />
+            <GeneralTableHeaderCell header="Size" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {formattedLegs.map((leg, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
+            <GeneralTableRow key={`${leg.price}-${leg.size}-${i}`}>
+              <GeneralTableCell>
+                <Typography variant="body2" color="text.secondary">
+                  {i + 1}
+                </Typography>
+              </GeneralTableCell>
+              <GeneralTableCell>
+                <MonoText>{leg.price}</MonoText>
+              </GeneralTableCell>
+              <GeneralTableCell>
+                <MonoText>{leg.size}</MonoText>
+              </GeneralTableCell>
+            </GeneralTableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline Bulk Order Detail (expandable under bulk order row)
+// ---------------------------------------------------------------------------
+
+function BulkOrderInlineDetail({
+  detail,
+  placedEvents,
+  filledEvents,
+  marketConfig,
+}: {
+  detail: DecibelBulkOrderDetail | undefined;
+  placedEvents: DecibelBulkOrderPlacedEvent[];
+  filledEvents: DecibelBulkOrderFilledEvent[];
+  marketConfig: DecibelMarketConfig | undefined;
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const hasDetail = detail !== undefined;
+  const hasPlaced = placedEvents.length > 0;
+  const hasFills = filledEvents.length > 0;
+
+  if (!hasDetail && !hasPlaced && !hasFills) return null;
+
+  return (
+    <Accordion
+      disableGutters
+      elevation={0}
+      sx={{
+        "&::before": {display: "none"},
+        backgroundColor: "transparent",
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          minHeight: 36,
+          px: 0,
+          "& .MuiAccordionSummary-content": {my: 0.5},
+        }}
+      >
+        <Typography variant="body2" color="primary" sx={{fontWeight: 600}}>
+          More Details
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{px: 0, pt: 0}}>
+        <Stack spacing={2.5}>
+          {/* Payload-level detail */}
+          {detail && (
+            <Box>
+              <Typography variant="subtitle2" sx={{mb: 1}}>
+                Submitted Order
+              </Typography>
+              <Paper variant="outlined" sx={{p: 2}}>
+                <Stack spacing={1.5}>
+                  {detail.sequenceNumber && (
+                    <KeyValue label="Sequence #">
+                      <MonoText>{detail.sequenceNumber}</MonoText>
+                    </KeyValue>
+                  )}
+                  {detail.builderAddress && (
+                    <KeyValue label="Builder">
+                      <SafeAccountLink hash={detail.builderAddress} />
+                    </KeyValue>
+                  )}
+                  {detail.builderFees && (
+                    <KeyValue label="Builder Fee">
+                      <MonoText>{detail.builderFees}</MonoText>
+                    </KeyValue>
+                  )}
+                  <Stack
+                    direction={isMobile ? "column" : "row"}
+                    spacing={2}
+                    sx={{mt: 1}}
+                  >
+                    <Box sx={{flex: 1}}>
+                      <LegTable
+                        legs={detail.bids}
+                        label="Bids"
+                        color="success"
+                        isMobile={isMobile}
+                        marketConfig={marketConfig}
+                      />
+                    </Box>
+                    <Box sx={{flex: 1}}>
+                      <LegTable
+                        legs={detail.asks}
+                        label="Asks"
+                        color="error"
+                        isMobile={isMobile}
+                        marketConfig={marketConfig}
+                      />
+                    </Box>
+                  </Stack>
+                </Stack>
+              </Paper>
+            </Box>
+          )}
+
+          {/* Placed events */}
+          {hasPlaced && (
+            <Box>
+              <Typography variant="subtitle2" sx={{mb: 1}}>
+                Placed{" "}
+                {placedEvents.length > 1 ? `(${placedEvents.length})` : ""}
+              </Typography>
+              <Stack spacing={1.5}>
+                {placedEvents.map((evt, idx) => (
+                  <Paper
+                    // biome-ignore lint/suspicious/noArrayIndexKey: events lack a guaranteed unique identifier
+                    key={`placed-${evt.orderId}-${idx}`}
+                    variant="outlined"
+                    sx={{p: 2}}
+                  >
+                    <Stack spacing={1.5}>
+                      <KeyValue label="Order ID">
+                        <TruncatedCopyId value={evt.orderId} />
+                      </KeyValue>
+                      <KeyValue label="User">
+                        <SafeAccountLink hash={evt.user} />
+                      </KeyValue>
+                      <KeyValue label="Sequence #">
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          alignItems="baseline"
+                        >
+                          <MonoText>{evt.sequenceNumber}</MonoText>
+                          {evt.previousSeqNum !== undefined && (
+                            <Typography
+                              variant="body2"
+                              color="text.secondary"
+                              component="span"
+                            >
+                              (prev: {evt.previousSeqNum})
+                            </Typography>
+                          )}
+                        </Stack>
+                      </KeyValue>
+                      <Stack
+                        direction={isMobile ? "column" : "row"}
+                        spacing={2}
+                        sx={{mt: 1}}
+                      >
+                        <Box sx={{flex: 1}}>
+                          <LegTable
+                            legs={evt.bids}
+                            label="Bids"
+                            color="success"
+                            isMobile={isMobile}
+                            marketConfig={marketConfig}
+                          />
+                        </Box>
+                        <Box sx={{flex: 1}}>
+                          <LegTable
+                            legs={evt.asks}
+                            label="Asks"
+                            color="error"
+                            isMobile={isMobile}
+                            marketConfig={marketConfig}
+                          />
+                        </Box>
+                      </Stack>
+                      {(evt.cancelledBids.length > 0 ||
+                        evt.cancelledAsks.length > 0) && (
+                        <Box>
+                          <Typography
+                            variant="subtitle2"
+                            color="text.secondary"
+                            sx={{mb: 1}}
+                          >
+                            Cancelled Orders
+                          </Typography>
+                          <Stack
+                            direction={isMobile ? "column" : "row"}
+                            spacing={2}
+                          >
+                            <Box sx={{flex: 1}}>
+                              <LegTable
+                                legs={evt.cancelledBids}
+                                label="Cancelled Bids"
+                                color="success"
+                                isMobile={isMobile}
+                                marketConfig={marketConfig}
+                              />
+                            </Box>
+                            <Box sx={{flex: 1}}>
+                              <LegTable
+                                legs={evt.cancelledAsks}
+                                label="Cancelled Asks"
+                                color="error"
+                                isMobile={isMobile}
+                                marketConfig={marketConfig}
+                              />
+                            </Box>
+                          </Stack>
+                        </Box>
+                      )}
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          {/* Filled events */}
+          {hasFills && (
+            <Box>
+              <Typography variant="subtitle2" sx={{mb: 1}}>
+                Fills ({filledEvents.length})
+              </Typography>
+              {isMobile ? (
+                <Stack spacing={1}>
+                  {filledEvents.map((fill, i) => (
+                    <Paper
+                      // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
+                      key={`fill-${fill.fillId}-${i}`}
+                      variant="outlined"
+                      sx={{p: 1.5}}
+                    >
+                      <Stack spacing={0.75}>
+                        <Stack
+                          direction="row"
+                          justifyContent="space-between"
+                          alignItems="center"
+                        >
+                          <Typography variant="body2" fontWeight={600}>
+                            Fill
+                          </Typography>
+                          <SideChip side={fill.side} />
+                        </Stack>
+                        <KeyValue label="Price">
+                          <MonoText>
+                            {formatDecibelPrice(fill.price, marketConfig)}
+                          </MonoText>
+                        </KeyValue>
+                        <KeyValue label="Size">
+                          <MonoText>
+                            {formatDecibelSize(fill.filledSize, marketConfig)}
+                          </MonoText>
+                        </KeyValue>
+                        {fill.origPrice && (
+                          <KeyValue label="Orig Price">
+                            <MonoText>
+                              {formatDecibelPrice(fill.origPrice, marketConfig)}
+                            </MonoText>
+                          </KeyValue>
+                        )}
+                        <KeyValue label="Order ID">
+                          <TruncatedCopyId value={fill.orderId} />
+                        </KeyValue>
+                        <KeyValue label="Fill ID">
+                          <TruncatedCopyId value={fill.fillId} />
+                        </KeyValue>
+                        <KeyValue label="User">
+                          <SafeAccountLink hash={fill.user} />
+                        </KeyValue>
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              ) : (
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <GeneralTableHeaderCell header="Side" />
+                      <GeneralTableHeaderCell header="Price" />
+                      <GeneralTableHeaderCell header="Filled Size" />
+                      <GeneralTableHeaderCell header="Order ID" />
+                      <GeneralTableHeaderCell header="Fill ID" />
+                      <GeneralTableHeaderCell header="User" />
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {filledEvents.map((fill, i) => (
+                      <GeneralTableRow
+                        // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
+                        key={`fill-${fill.fillId}-${i}`}
+                      >
+                        <GeneralTableCell>
+                          <SideChip side={fill.side} />
+                        </GeneralTableCell>
+                        <GeneralTableCell>
+                          <MonoText>
+                            {formatDecibelPrice(fill.price, marketConfig)}
+                          </MonoText>
+                        </GeneralTableCell>
+                        <GeneralTableCell>
+                          <MonoText>
+                            {formatDecibelSize(fill.filledSize, marketConfig)}
+                          </MonoText>
+                        </GeneralTableCell>
+                        <GeneralTableCell>
+                          <TruncatedCopyId value={fill.orderId} />
+                        </GeneralTableCell>
+                        <GeneralTableCell>
+                          <TruncatedCopyId value={fill.fillId} />
+                        </GeneralTableCell>
+                        <GeneralTableCell>
+                          <SafeAccountLink hash={fill.user} />
+                        </GeneralTableCell>
+                      </GeneralTableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </Box>
+          )}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Orders Section
 // ---------------------------------------------------------------------------
 
-function OrderRow({order}: {order: DecibelOrder}) {
+function OrderRow({
+  order,
+  marketConfig,
+}: {
+  order: DecibelOrder;
+  marketConfig: DecibelMarketConfig | undefined;
+}) {
   const icon = ORDER_TYPE_ICONS[order.orderType] ?? null;
   const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
+  const formattedSize = order.size
+    ? formatDecibelSize(order.size, marketConfig)
+    : "—";
+  const formattedPrice = order.price
+    ? formatDecibelPrice(order.price, marketConfig)
+    : order.orderType === "market"
+      ? "Market"
+      : "—";
 
   return (
     <GeneralTableRow>
@@ -189,10 +684,8 @@ function OrderRow({order}: {order: DecibelOrder}) {
       <GeneralTableCell>
         <MarketValue hash={order.market} />
       </GeneralTableCell>
-      <GeneralTableCell>{order.size ?? "—"}</GeneralTableCell>
-      <GeneralTableCell>
-        {order.price ?? (order.orderType === "market" ? "Market" : "—")}
-      </GeneralTableCell>
+      <GeneralTableCell>{formattedSize}</GeneralTableCell>
+      <GeneralTableCell>{formattedPrice}</GeneralTableCell>
       <GeneralTableCell>
         {order.status ? (
           <Chip label={order.status} size="small" variant="outlined" />
@@ -211,9 +704,25 @@ function OrderRow({order}: {order: DecibelOrder}) {
   );
 }
 
-function OrderCard({order}: {order: DecibelOrder}) {
+function OrderCard({
+  order,
+  marketConfig,
+  children,
+}: {
+  order: DecibelOrder;
+  marketConfig: DecibelMarketConfig | undefined;
+  children?: React.ReactNode;
+}) {
   const icon = ORDER_TYPE_ICONS[order.orderType] ?? null;
   const label = ORDER_TYPE_LABELS[order.orderType] ?? order.orderType;
+  const formattedSize = order.size
+    ? formatDecibelSize(order.size, marketConfig)
+    : undefined;
+  const formattedPrice = order.price
+    ? formatDecibelPrice(order.price, marketConfig)
+    : order.orderType === "market"
+      ? "Market"
+      : "—";
 
   return (
     <Paper sx={{p: 2, mb: 1.5}}>
@@ -231,10 +740,8 @@ function OrderCard({order}: {order: DecibelOrder}) {
         <KeyValue label="Market">
           <MarketValue hash={order.market} />
         </KeyValue>
-        {order.size && <KeyValue label="Size">{order.size}</KeyValue>}
-        <KeyValue label="Price">
-          {order.price ?? (order.orderType === "market" ? "Market" : "—")}
-        </KeyValue>
+        {formattedSize && <KeyValue label="Size">{formattedSize}</KeyValue>}
+        <KeyValue label="Price">{formattedPrice}</KeyValue>
         {order.status && (
           <KeyValue label="Status">
             <Chip label={order.status} size="small" variant="outlined" />
@@ -257,14 +764,24 @@ function OrderCard({order}: {order: DecibelOrder}) {
             <TruncatedCopyId value={order.orderId} />
           </KeyValue>
         )}
+        {children}
       </Stack>
     </Paper>
   );
 }
 
-function OrdersSection({orders}: {orders: DecibelOrder[]}) {
+function OrdersSection({
+  orders,
+  summary,
+}: {
+  orders: DecibelOrder[];
+  summary: DecibelTransactionSummary;
+}) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const bulkMarket =
+    summary.bulkOrderDetail?.market ?? orders.find((o) => o.market)?.market;
+  const {data: marketConfig} = useGetDecibelMarketConfig(bulkMarket ?? "");
 
   if (orders.length === 0) return null;
 
@@ -274,30 +791,57 @@ function OrdersSection({orders}: {orders: DecibelOrder[]}) {
         Orders
       </Typography>
       {isMobile ? (
-        // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
-        orders.map((order, i) => <OrderCard key={i} order={order} />)
+        orders.map((order, i) => (
+          <OrderCard
+            // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
+            key={i}
+            order={order}
+            marketConfig={marketConfig}
+          >
+            {order.orderType === "bulk" && (
+              <BulkOrderInlineDetail
+                detail={summary.bulkOrderDetail}
+                placedEvents={summary.bulkOrderPlacedEvents}
+                filledEvents={summary.bulkOrderFilledEvents}
+                marketConfig={marketConfig}
+              />
+            )}
+          </OrderCard>
+        ))
       ) : (
-        <Table>
-          <TableHead>
-            <TableRow>
-              <GeneralTableHeaderCell header="Type" />
-              <GeneralTableHeaderCell header="Side" />
-              <GeneralTableHeaderCell header="Market" />
-              <GeneralTableHeaderCell header="Size" />
-              <GeneralTableHeaderCell header="Price" />
-              <GeneralTableHeaderCell header="Status" />
-              <GeneralTableHeaderCell header="Time in Force" />
-              <GeneralTableHeaderCell header="Subaccount" />
-              <GeneralTableHeaderCell header="Order ID" />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {orders.map((order, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
-              <OrderRow key={i} order={order} />
-            ))}
-          </TableBody>
-        </Table>
+        <Stack spacing={0}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <GeneralTableHeaderCell header="Type" />
+                <GeneralTableHeaderCell header="Side" />
+                <GeneralTableHeaderCell header="Market" />
+                <GeneralTableHeaderCell header="Size" />
+                <GeneralTableHeaderCell header="Price" />
+                <GeneralTableHeaderCell header="Status" />
+                <GeneralTableHeaderCell header="Time in Force" />
+                <GeneralTableHeaderCell header="Subaccount" />
+                <GeneralTableHeaderCell header="Order ID" />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {orders.map((order, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: orders lack a guaranteed unique identifier
+                <OrderRow key={i} order={order} marketConfig={marketConfig} />
+              ))}
+            </TableBody>
+          </Table>
+          {orders.some((o) => o.orderType === "bulk") && (
+            <Box sx={{mt: 1, px: 1}}>
+              <BulkOrderInlineDetail
+                detail={summary.bulkOrderDetail}
+                placedEvents={summary.bulkOrderPlacedEvents}
+                filledEvents={summary.bulkOrderFilledEvents}
+                marketConfig={marketConfig}
+              />
+            </Box>
+          )}
+        </Stack>
       )}
     </Box>
   );
@@ -522,445 +1066,6 @@ function WithdrawalsSection({
 }
 
 // ---------------------------------------------------------------------------
-// Shared
-// ---------------------------------------------------------------------------
-
-function KeyValue({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-      <Typography
-        variant="body2"
-        color="text.secondary"
-        sx={{minWidth: 100, flexShrink: 0}}
-      >
-        {label}
-      </Typography>
-      <Box sx={{flex: 1, minWidth: 0}}>{children}</Box>
-    </Stack>
-  );
-}
-
-function MonoText({children}: {children: React.ReactNode}) {
-  return (
-    <Typography variant="body2" sx={{fontFamily: "monospace"}}>
-      {children}
-    </Typography>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Bulk Order Ladder Table
-// ---------------------------------------------------------------------------
-
-function LegTable({
-  legs,
-  label,
-  color,
-  isMobile,
-}: {
-  legs: BulkOrderLeg[];
-  label: string;
-  color: "success" | "error";
-  isMobile: boolean;
-}) {
-  const theme = useTheme();
-  if (legs.length === 0) return null;
-
-  const totalSize = legs.reduce((acc, leg) => acc + (Number(leg.size) || 0), 0);
-
-  if (isMobile) {
-    return (
-      <Box sx={{mb: 1}}>
-        <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 1}}>
-          <Typography
-            variant="subtitle2"
-            sx={{color: theme.palette[color].main}}
-          >
-            {label} ({legs.length})
-          </Typography>
-          {totalSize > 0 && (
-            <Typography variant="caption" color="text.secondary">
-              Total: {totalSize}
-            </Typography>
-          )}
-        </Stack>
-        <Stack spacing={0.5}>
-          {legs.map((leg, i) => (
-            <Stack
-              // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
-              key={`${leg.price}-${leg.size}-${i}`}
-              direction="row"
-              justifyContent="space-between"
-              alignItems="baseline"
-              sx={{
-                py: 0.5,
-                borderBottom: `1px solid ${theme.palette.divider}`,
-                "&:last-of-type": {borderBottom: "none"},
-              }}
-            >
-              <MonoText>{leg.price}</MonoText>
-              <MonoText>{leg.size}</MonoText>
-            </Stack>
-          ))}
-        </Stack>
-      </Box>
-    );
-  }
-
-  return (
-    <Box sx={{mb: 1}}>
-      <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 0.5}}>
-        <Typography variant="subtitle2" sx={{color: theme.palette[color].main}}>
-          {label} ({legs.length})
-        </Typography>
-        {totalSize > 0 && (
-          <Typography variant="caption" color="text.secondary">
-            Total size: {totalSize}
-          </Typography>
-        )}
-      </Stack>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <GeneralTableHeaderCell header="#" />
-            <GeneralTableHeaderCell header="Price" />
-            <GeneralTableHeaderCell header="Size" />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {legs.map((leg, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
-            <GeneralTableRow key={`${leg.price}-${leg.size}-${i}`}>
-              <GeneralTableCell>
-                <Typography variant="body2" color="text.secondary">
-                  {i + 1}
-                </Typography>
-              </GeneralTableCell>
-              <GeneralTableCell>
-                <MonoText>{leg.price}</MonoText>
-              </GeneralTableCell>
-              <GeneralTableCell>
-                <MonoText>{leg.size}</MonoText>
-              </GeneralTableCell>
-            </GeneralTableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Box>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Bulk Order Detail (from payload arguments)
-// ---------------------------------------------------------------------------
-
-function BulkOrderDetailSection({detail}: {detail: DecibelBulkOrderDetail}) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-
-  return (
-    <Box>
-      <Typography variant="h6" sx={{mb: 1.5}}>
-        Bulk Order Detail
-      </Typography>
-      <Paper variant="outlined" sx={{p: 2}}>
-        <Stack spacing={2}>
-          <KeyValue label="Market">
-            <MarketValue hash={detail.market} />
-          </KeyValue>
-          {detail.subaccount && (
-            <KeyValue label="Subaccount">
-              <SafeAccountLink hash={detail.subaccount} />
-            </KeyValue>
-          )}
-          {detail.sequenceNumber && (
-            <KeyValue label="Sequence #">
-              <MonoText>{detail.sequenceNumber}</MonoText>
-            </KeyValue>
-          )}
-          {detail.builderAddress && (
-            <KeyValue label="Builder">
-              <SafeAccountLink hash={detail.builderAddress} />
-            </KeyValue>
-          )}
-          {detail.builderFees && (
-            <KeyValue label="Builder Fee">
-              <MonoText>{detail.builderFees}</MonoText>
-            </KeyValue>
-          )}
-          <Stack
-            direction={isMobile ? "column" : "row"}
-            spacing={2}
-            sx={{mt: 1}}
-          >
-            <Box sx={{flex: 1}}>
-              <LegTable
-                legs={detail.bids}
-                label="Bids"
-                color="success"
-                isMobile={isMobile}
-              />
-            </Box>
-            <Box sx={{flex: 1}}>
-              <LegTable
-                legs={detail.asks}
-                label="Asks"
-                color="error"
-                isMobile={isMobile}
-              />
-            </Box>
-          </Stack>
-        </Stack>
-      </Paper>
-    </Box>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Bulk Order Placed Events
-// ---------------------------------------------------------------------------
-
-function BulkOrderPlacedSection({
-  events,
-}: {
-  events: DecibelBulkOrderPlacedEvent[];
-}) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-
-  if (events.length === 0) return null;
-
-  return (
-    <Box>
-      <Typography variant="h6" sx={{mb: 1.5}}>
-        Bulk Order Placed {events.length > 1 ? `(${events.length})` : ""}
-      </Typography>
-      <Stack spacing={2}>
-        {events.map((evt, idx) => (
-          <Paper
-            // biome-ignore lint/suspicious/noArrayIndexKey: events lack a guaranteed unique identifier
-            key={`placed-${evt.orderId}-${idx}`}
-            variant="outlined"
-            sx={{p: 2}}
-          >
-            <Stack spacing={1.5}>
-              <KeyValue label="Market">
-                <MarketValue hash={evt.market} />
-              </KeyValue>
-              <KeyValue label="Order ID">
-                <TruncatedCopyId value={evt.orderId} />
-              </KeyValue>
-              <KeyValue label="User">
-                <SafeAccountLink hash={evt.user} />
-              </KeyValue>
-              <KeyValue label="Sequence #">
-                <Stack direction="row" spacing={1} alignItems="baseline">
-                  <MonoText>{evt.sequenceNumber}</MonoText>
-                  {evt.previousSeqNum !== undefined && (
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      component="span"
-                    >
-                      (prev: {evt.previousSeqNum})
-                    </Typography>
-                  )}
-                </Stack>
-              </KeyValue>
-              <Stack
-                direction={isMobile ? "column" : "row"}
-                spacing={2}
-                sx={{mt: 1}}
-              >
-                <Box sx={{flex: 1}}>
-                  <LegTable
-                    legs={evt.bids}
-                    label="Bids"
-                    color="success"
-                    isMobile={isMobile}
-                  />
-                </Box>
-                <Box sx={{flex: 1}}>
-                  <LegTable
-                    legs={evt.asks}
-                    label="Asks"
-                    color="error"
-                    isMobile={isMobile}
-                  />
-                </Box>
-              </Stack>
-              {(evt.cancelledBids.length > 0 ||
-                evt.cancelledAsks.length > 0) && (
-                <Box>
-                  <Typography
-                    variant="subtitle2"
-                    color="text.secondary"
-                    sx={{mb: 1}}
-                  >
-                    Cancelled Orders
-                  </Typography>
-                  <Stack direction={isMobile ? "column" : "row"} spacing={2}>
-                    <Box sx={{flex: 1}}>
-                      <LegTable
-                        legs={evt.cancelledBids}
-                        label="Cancelled Bids"
-                        color="success"
-                        isMobile={isMobile}
-                      />
-                    </Box>
-                    <Box sx={{flex: 1}}>
-                      <LegTable
-                        legs={evt.cancelledAsks}
-                        label="Cancelled Asks"
-                        color="error"
-                        isMobile={isMobile}
-                      />
-                    </Box>
-                  </Stack>
-                </Box>
-              )}
-            </Stack>
-          </Paper>
-        ))}
-      </Stack>
-    </Box>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Bulk Order Filled Events
-// ---------------------------------------------------------------------------
-
-function BulkOrderFilledRow({fill}: {fill: DecibelBulkOrderFilledEvent}) {
-  return (
-    <GeneralTableRow>
-      <GeneralTableCell>
-        <SideChip side={fill.side} />
-      </GeneralTableCell>
-      <GeneralTableCell>
-        <MarketValue hash={fill.market} />
-      </GeneralTableCell>
-      <GeneralTableCell>
-        <MonoText>{fill.price}</MonoText>
-      </GeneralTableCell>
-      <GeneralTableCell>
-        <MonoText>{fill.filledSize}</MonoText>
-      </GeneralTableCell>
-      {fill.origPrice && (
-        <GeneralTableCell>
-          <MonoText>{fill.origPrice}</MonoText>
-        </GeneralTableCell>
-      )}
-      <GeneralTableCell>
-        <TruncatedCopyId value={fill.orderId} />
-      </GeneralTableCell>
-      <GeneralTableCell>
-        <TruncatedCopyId value={fill.fillId} />
-      </GeneralTableCell>
-      <GeneralTableCell>
-        <SafeAccountLink hash={fill.user} />
-      </GeneralTableCell>
-    </GeneralTableRow>
-  );
-}
-
-function BulkOrderFilledCard({fill}: {fill: DecibelBulkOrderFilledEvent}) {
-  return (
-    <Paper sx={{p: 2, mb: 1.5}}>
-      <Stack spacing={1}>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          <Typography variant="subtitle2">Fill</Typography>
-          <SideChip side={fill.side} />
-        </Stack>
-        <KeyValue label="Market">
-          <MarketValue hash={fill.market} />
-        </KeyValue>
-        <KeyValue label="Price">
-          <MonoText>{fill.price}</MonoText>
-        </KeyValue>
-        <KeyValue label="Filled Size">
-          <MonoText>{fill.filledSize}</MonoText>
-        </KeyValue>
-        {fill.origPrice && (
-          <KeyValue label="Orig Price">
-            <MonoText>{fill.origPrice}</MonoText>
-          </KeyValue>
-        )}
-        <KeyValue label="Order ID">
-          <TruncatedCopyId value={fill.orderId} />
-        </KeyValue>
-        <KeyValue label="Fill ID">
-          <TruncatedCopyId value={fill.fillId} />
-        </KeyValue>
-        <KeyValue label="User">
-          <SafeAccountLink hash={fill.user} />
-        </KeyValue>
-      </Stack>
-    </Paper>
-  );
-}
-
-function BulkOrderFilledSection({
-  fills,
-}: {
-  fills: DecibelBulkOrderFilledEvent[];
-}) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const hasOrigPrice = fills.some((f) => f.origPrice);
-
-  if (fills.length === 0) return null;
-
-  return (
-    <Box>
-      <Typography variant="h6" sx={{mb: 1.5}}>
-        Bulk Order Fills ({fills.length})
-      </Typography>
-      {isMobile ? (
-        fills.map((fill, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
-          <BulkOrderFilledCard key={`fill-${fill.fillId}-${i}`} fill={fill} />
-        ))
-      ) : (
-        <Table>
-          <TableHead>
-            <TableRow>
-              <GeneralTableHeaderCell header="Side" />
-              <GeneralTableHeaderCell header="Market" />
-              <GeneralTableHeaderCell header="Price" />
-              <GeneralTableHeaderCell header="Filled Size" />
-              {hasOrigPrice && <GeneralTableHeaderCell header="Orig Price" />}
-              <GeneralTableHeaderCell header="Order ID" />
-              <GeneralTableHeaderCell header="Fill ID" />
-              <GeneralTableHeaderCell header="User" />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {fills.map((fill, i) => (
-              <BulkOrderFilledRow
-                // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
-                key={`fill-${fill.fillId}-${i}`}
-                fill={fill}
-              />
-            ))}
-          </TableBody>
-        </Table>
-      )}
-    </Box>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main Tab
 // ---------------------------------------------------------------------------
 
@@ -993,12 +1098,7 @@ export default function DecibelTab({
   return (
     <ContentBox>
       <Stack spacing={3}>
-        <OrdersSection orders={summary.orders} />
-        {summary.bulkOrderDetail && (
-          <BulkOrderDetailSection detail={summary.bulkOrderDetail} />
-        )}
-        <BulkOrderPlacedSection events={summary.bulkOrderPlacedEvents} />
-        <BulkOrderFilledSection fills={summary.bulkOrderFilledEvents} />
+        <OrdersSection orders={summary.orders} summary={summary} />
         <DepositsSection
           deposits={summary.deposits}
           coinData={coinData?.data}

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -478,22 +478,7 @@ function BulkOrderInlineDetail({
                         <SafeAccountLink hash={evt.user} />
                       </KeyValue>
                       <KeyValue label="Sequence #">
-                        <Stack
-                          direction="row"
-                          spacing={1}
-                          alignItems="baseline"
-                        >
-                          <MonoText>{evt.sequenceNumber}</MonoText>
-                          {evt.previousSeqNum !== undefined && (
-                            <Typography
-                              variant="body2"
-                              color="text.secondary"
-                              component="span"
-                            >
-                              (prev: {evt.previousSeqNum})
-                            </Typography>
-                          )}
-                        </Stack>
+                        <MonoText>{evt.sequenceNumber}</MonoText>
                       </KeyValue>
                       <Stack
                         direction={isMobile ? "column" : "row"}

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -254,12 +254,18 @@ function LegTable({
   const formattedLegs = legs.map((leg) => ({
     price: formatDecibelPrice(leg.price, marketConfig),
     size: formatDecibelSize(leg.size, marketConfig),
-    rawSize: Number(leg.size) || 0,
   }));
 
-  const totalRawSize = formattedLegs.reduce((acc, leg) => acc + leg.rawSize, 0);
+  let totalRawSize = BigInt(0);
+  try {
+    for (const leg of legs) {
+      totalRawSize += BigInt(leg.size);
+    }
+  } catch {
+    totalRawSize = BigInt(0);
+  }
   const totalSize =
-    totalRawSize > 0
+    totalRawSize > BigInt(0)
       ? formatDecibelSize(String(totalRawSize), marketConfig)
       : undefined;
 
@@ -360,6 +366,73 @@ function LegTable({
 // ---------------------------------------------------------------------------
 // Inline Bulk Order Detail (expandable under bulk order row)
 // ---------------------------------------------------------------------------
+
+function FillsDesktopTable({
+  fills,
+  marketConfig,
+}: {
+  fills: DecibelBulkOrderFilledEvent[];
+  marketConfig: DecibelMarketConfig | undefined;
+}) {
+  const hasOrigPrice = fills.some((f) => f.origPrice != null);
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <GeneralTableHeaderCell header="Side" />
+          <GeneralTableHeaderCell header="Price" />
+          <GeneralTableHeaderCell header="Filled Size" />
+          {hasOrigPrice && <GeneralTableHeaderCell header="Orig Price" />}
+          <GeneralTableHeaderCell header="Order ID" />
+          <GeneralTableHeaderCell header="Fill ID" />
+          <GeneralTableHeaderCell header="User" />
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {fills.map((fill, i) => (
+          <GeneralTableRow
+            // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
+            key={`fill-${fill.fillId}-${i}`}
+          >
+            <GeneralTableCell>
+              <SideChip side={fill.side} />
+            </GeneralTableCell>
+            <GeneralTableCell>
+              <MonoText>
+                {formatDecibelPrice(fill.price, marketConfig)}
+              </MonoText>
+            </GeneralTableCell>
+            <GeneralTableCell>
+              <MonoText>
+                {formatDecibelSize(fill.filledSize, marketConfig)}
+              </MonoText>
+            </GeneralTableCell>
+            {hasOrigPrice && (
+              <GeneralTableCell>
+                {fill.origPrice ? (
+                  <MonoText>
+                    {formatDecibelPrice(fill.origPrice, marketConfig)}
+                  </MonoText>
+                ) : (
+                  "—"
+                )}
+              </GeneralTableCell>
+            )}
+            <GeneralTableCell>
+              <TruncatedCopyId value={fill.orderId} />
+            </GeneralTableCell>
+            <GeneralTableCell>
+              <TruncatedCopyId value={fill.fillId} />
+            </GeneralTableCell>
+            <GeneralTableCell>
+              <SafeAccountLink hash={fill.user} />
+            </GeneralTableCell>
+          </GeneralTableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
 
 function BulkOrderInlineDetail({
   detail,
@@ -589,7 +662,7 @@ function BulkOrderInlineDetail({
                             {formatDecibelSize(fill.filledSize, marketConfig)}
                           </MonoText>
                         </KeyValue>
-                        {fill.origPrice && (
+                        {fill.origPrice != null && (
                           <KeyValue label="Orig Price">
                             <MonoText>
                               {formatDecibelPrice(fill.origPrice, marketConfig)}
@@ -610,49 +683,10 @@ function BulkOrderInlineDetail({
                   ))}
                 </Stack>
               ) : (
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <GeneralTableHeaderCell header="Side" />
-                      <GeneralTableHeaderCell header="Price" />
-                      <GeneralTableHeaderCell header="Filled Size" />
-                      <GeneralTableHeaderCell header="Order ID" />
-                      <GeneralTableHeaderCell header="Fill ID" />
-                      <GeneralTableHeaderCell header="User" />
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {filledEvents.map((fill, i) => (
-                      <GeneralTableRow
-                        // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
-                        key={`fill-${fill.fillId}-${i}`}
-                      >
-                        <GeneralTableCell>
-                          <SideChip side={fill.side} />
-                        </GeneralTableCell>
-                        <GeneralTableCell>
-                          <MonoText>
-                            {formatDecibelPrice(fill.price, marketConfig)}
-                          </MonoText>
-                        </GeneralTableCell>
-                        <GeneralTableCell>
-                          <MonoText>
-                            {formatDecibelSize(fill.filledSize, marketConfig)}
-                          </MonoText>
-                        </GeneralTableCell>
-                        <GeneralTableCell>
-                          <TruncatedCopyId value={fill.orderId} />
-                        </GeneralTableCell>
-                        <GeneralTableCell>
-                          <TruncatedCopyId value={fill.fillId} />
-                        </GeneralTableCell>
-                        <GeneralTableCell>
-                          <SafeAccountLink hash={fill.user} />
-                        </GeneralTableCell>
-                      </GeneralTableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                <FillsDesktopTable
+                  fills={filledEvents}
+                  marketConfig={marketConfig}
+                />
               )}
             </Box>
           )}

--- a/app/pages/Transaction/Tabs/DecibelTab.tsx
+++ b/app/pages/Transaction/Tabs/DecibelTab.tsx
@@ -37,6 +37,10 @@ import GeneralTableHeaderCell from "../../../components/Table/GeneralTableHeader
 import GeneralTableRow from "../../../components/Table/GeneralTableRow";
 import {isValidAccountAddress} from "../../../utils";
 import type {
+  BulkOrderLeg,
+  DecibelBulkOrderDetail,
+  DecibelBulkOrderFilledEvent,
+  DecibelBulkOrderPlacedEvent,
   DecibelDeposit,
   DecibelOrder,
   DecibelWithdraw,
@@ -542,6 +546,420 @@ function KeyValue({
   );
 }
 
+function MonoText({children}: {children: React.ReactNode}) {
+  return (
+    <Typography variant="body2" sx={{fontFamily: "monospace"}}>
+      {children}
+    </Typography>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk Order Ladder Table
+// ---------------------------------------------------------------------------
+
+function LegTable({
+  legs,
+  label,
+  color,
+  isMobile,
+}: {
+  legs: BulkOrderLeg[];
+  label: string;
+  color: "success" | "error";
+  isMobile: boolean;
+}) {
+  const theme = useTheme();
+  if (legs.length === 0) return null;
+
+  const totalSize = legs.reduce((acc, leg) => acc + (Number(leg.size) || 0), 0);
+
+  if (isMobile) {
+    return (
+      <Box sx={{mb: 1}}>
+        <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 1}}>
+          <Typography
+            variant="subtitle2"
+            sx={{color: theme.palette[color].main}}
+          >
+            {label} ({legs.length})
+          </Typography>
+          {totalSize > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              Total: {totalSize}
+            </Typography>
+          )}
+        </Stack>
+        <Stack spacing={0.5}>
+          {legs.map((leg, i) => (
+            <Stack
+              // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
+              key={`${leg.price}-${leg.size}-${i}`}
+              direction="row"
+              justifyContent="space-between"
+              alignItems="baseline"
+              sx={{
+                py: 0.5,
+                borderBottom: `1px solid ${theme.palette.divider}`,
+                "&:last-of-type": {borderBottom: "none"},
+              }}
+            >
+              <MonoText>{leg.price}</MonoText>
+              <MonoText>{leg.size}</MonoText>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{mb: 1}}>
+      <Stack direction="row" alignItems="baseline" spacing={1} sx={{mb: 0.5}}>
+        <Typography variant="subtitle2" sx={{color: theme.palette[color].main}}>
+          {label} ({legs.length})
+        </Typography>
+        {totalSize > 0 && (
+          <Typography variant="caption" color="text.secondary">
+            Total size: {totalSize}
+          </Typography>
+        )}
+      </Stack>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <GeneralTableHeaderCell header="#" />
+            <GeneralTableHeaderCell header="Price" />
+            <GeneralTableHeaderCell header="Size" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {legs.map((leg, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: legs may share identical price-size pairs
+            <GeneralTableRow key={`${leg.price}-${leg.size}-${i}`}>
+              <GeneralTableCell>
+                <Typography variant="body2" color="text.secondary">
+                  {i + 1}
+                </Typography>
+              </GeneralTableCell>
+              <GeneralTableCell>
+                <MonoText>{leg.price}</MonoText>
+              </GeneralTableCell>
+              <GeneralTableCell>
+                <MonoText>{leg.size}</MonoText>
+              </GeneralTableCell>
+            </GeneralTableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk Order Detail (from payload arguments)
+// ---------------------------------------------------------------------------
+
+function BulkOrderDetailSection({detail}: {detail: DecibelBulkOrderDetail}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Bulk Order Detail
+      </Typography>
+      <Paper variant="outlined" sx={{p: 2}}>
+        <Stack spacing={2}>
+          <KeyValue label="Market">
+            <MarketValue hash={detail.market} />
+          </KeyValue>
+          {detail.subaccount && (
+            <KeyValue label="Subaccount">
+              <SafeAccountLink hash={detail.subaccount} />
+            </KeyValue>
+          )}
+          {detail.sequenceNumber && (
+            <KeyValue label="Sequence #">
+              <MonoText>{detail.sequenceNumber}</MonoText>
+            </KeyValue>
+          )}
+          {detail.builderAddress && (
+            <KeyValue label="Builder">
+              <SafeAccountLink hash={detail.builderAddress} />
+            </KeyValue>
+          )}
+          {detail.builderFees && (
+            <KeyValue label="Builder Fee">
+              <MonoText>{detail.builderFees}</MonoText>
+            </KeyValue>
+          )}
+          <Stack
+            direction={isMobile ? "column" : "row"}
+            spacing={2}
+            sx={{mt: 1}}
+          >
+            <Box sx={{flex: 1}}>
+              <LegTable
+                legs={detail.bids}
+                label="Bids"
+                color="success"
+                isMobile={isMobile}
+              />
+            </Box>
+            <Box sx={{flex: 1}}>
+              <LegTable
+                legs={detail.asks}
+                label="Asks"
+                color="error"
+                isMobile={isMobile}
+              />
+            </Box>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk Order Placed Events
+// ---------------------------------------------------------------------------
+
+function BulkOrderPlacedSection({
+  events,
+}: {
+  events: DecibelBulkOrderPlacedEvent[];
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  if (events.length === 0) return null;
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Bulk Order Placed {events.length > 1 ? `(${events.length})` : ""}
+      </Typography>
+      <Stack spacing={2}>
+        {events.map((evt, idx) => (
+          <Paper
+            // biome-ignore lint/suspicious/noArrayIndexKey: events lack a guaranteed unique identifier
+            key={`placed-${evt.orderId}-${idx}`}
+            variant="outlined"
+            sx={{p: 2}}
+          >
+            <Stack spacing={1.5}>
+              <KeyValue label="Market">
+                <MarketValue hash={evt.market} />
+              </KeyValue>
+              <KeyValue label="Order ID">
+                <TruncatedCopyId value={evt.orderId} />
+              </KeyValue>
+              <KeyValue label="User">
+                <SafeAccountLink hash={evt.user} />
+              </KeyValue>
+              <KeyValue label="Sequence #">
+                <Stack direction="row" spacing={1} alignItems="baseline">
+                  <MonoText>{evt.sequenceNumber}</MonoText>
+                  {evt.previousSeqNum !== undefined && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      component="span"
+                    >
+                      (prev: {evt.previousSeqNum})
+                    </Typography>
+                  )}
+                </Stack>
+              </KeyValue>
+              <Stack
+                direction={isMobile ? "column" : "row"}
+                spacing={2}
+                sx={{mt: 1}}
+              >
+                <Box sx={{flex: 1}}>
+                  <LegTable
+                    legs={evt.bids}
+                    label="Bids"
+                    color="success"
+                    isMobile={isMobile}
+                  />
+                </Box>
+                <Box sx={{flex: 1}}>
+                  <LegTable
+                    legs={evt.asks}
+                    label="Asks"
+                    color="error"
+                    isMobile={isMobile}
+                  />
+                </Box>
+              </Stack>
+              {(evt.cancelledBids.length > 0 ||
+                evt.cancelledAsks.length > 0) && (
+                <Box>
+                  <Typography
+                    variant="subtitle2"
+                    color="text.secondary"
+                    sx={{mb: 1}}
+                  >
+                    Cancelled Orders
+                  </Typography>
+                  <Stack direction={isMobile ? "column" : "row"} spacing={2}>
+                    <Box sx={{flex: 1}}>
+                      <LegTable
+                        legs={evt.cancelledBids}
+                        label="Cancelled Bids"
+                        color="success"
+                        isMobile={isMobile}
+                      />
+                    </Box>
+                    <Box sx={{flex: 1}}>
+                      <LegTable
+                        legs={evt.cancelledAsks}
+                        label="Cancelled Asks"
+                        color="error"
+                        isMobile={isMobile}
+                      />
+                    </Box>
+                  </Stack>
+                </Box>
+              )}
+            </Stack>
+          </Paper>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk Order Filled Events
+// ---------------------------------------------------------------------------
+
+function BulkOrderFilledRow({fill}: {fill: DecibelBulkOrderFilledEvent}) {
+  return (
+    <GeneralTableRow>
+      <GeneralTableCell>
+        <SideChip side={fill.side} />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <MarketValue hash={fill.market} />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <MonoText>{fill.price}</MonoText>
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <MonoText>{fill.filledSize}</MonoText>
+      </GeneralTableCell>
+      {fill.origPrice && (
+        <GeneralTableCell>
+          <MonoText>{fill.origPrice}</MonoText>
+        </GeneralTableCell>
+      )}
+      <GeneralTableCell>
+        <TruncatedCopyId value={fill.orderId} />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <TruncatedCopyId value={fill.fillId} />
+      </GeneralTableCell>
+      <GeneralTableCell>
+        <SafeAccountLink hash={fill.user} />
+      </GeneralTableCell>
+    </GeneralTableRow>
+  );
+}
+
+function BulkOrderFilledCard({fill}: {fill: DecibelBulkOrderFilledEvent}) {
+  return (
+    <Paper sx={{p: 2, mb: 1.5}}>
+      <Stack spacing={1}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Typography variant="subtitle2">Fill</Typography>
+          <SideChip side={fill.side} />
+        </Stack>
+        <KeyValue label="Market">
+          <MarketValue hash={fill.market} />
+        </KeyValue>
+        <KeyValue label="Price">
+          <MonoText>{fill.price}</MonoText>
+        </KeyValue>
+        <KeyValue label="Filled Size">
+          <MonoText>{fill.filledSize}</MonoText>
+        </KeyValue>
+        {fill.origPrice && (
+          <KeyValue label="Orig Price">
+            <MonoText>{fill.origPrice}</MonoText>
+          </KeyValue>
+        )}
+        <KeyValue label="Order ID">
+          <TruncatedCopyId value={fill.orderId} />
+        </KeyValue>
+        <KeyValue label="Fill ID">
+          <TruncatedCopyId value={fill.fillId} />
+        </KeyValue>
+        <KeyValue label="User">
+          <SafeAccountLink hash={fill.user} />
+        </KeyValue>
+      </Stack>
+    </Paper>
+  );
+}
+
+function BulkOrderFilledSection({
+  fills,
+}: {
+  fills: DecibelBulkOrderFilledEvent[];
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const hasOrigPrice = fills.some((f) => f.origPrice);
+
+  if (fills.length === 0) return null;
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{mb: 1.5}}>
+        Bulk Order Fills ({fills.length})
+      </Typography>
+      {isMobile ? (
+        fills.map((fill, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
+          <BulkOrderFilledCard key={`fill-${fill.fillId}-${i}`} fill={fill} />
+        ))
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <GeneralTableHeaderCell header="Side" />
+              <GeneralTableHeaderCell header="Market" />
+              <GeneralTableHeaderCell header="Price" />
+              <GeneralTableHeaderCell header="Filled Size" />
+              {hasOrigPrice && <GeneralTableHeaderCell header="Orig Price" />}
+              <GeneralTableHeaderCell header="Order ID" />
+              <GeneralTableHeaderCell header="Fill ID" />
+              <GeneralTableHeaderCell header="User" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {fills.map((fill, i) => (
+              <BulkOrderFilledRow
+                // biome-ignore lint/suspicious/noArrayIndexKey: fills lack a guaranteed unique identifier
+                key={`fill-${fill.fillId}-${i}`}
+                fill={fill}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main Tab
 // ---------------------------------------------------------------------------
@@ -557,7 +975,10 @@ export default function DecibelTab({
   const hasContent =
     summary.orders.length > 0 ||
     summary.deposits.length > 0 ||
-    summary.withdrawals.length > 0;
+    summary.withdrawals.length > 0 ||
+    summary.bulkOrderDetail !== undefined ||
+    summary.bulkOrderPlacedEvents.length > 0 ||
+    summary.bulkOrderFilledEvents.length > 0;
 
   if (!hasContent) {
     return (
@@ -573,6 +994,11 @@ export default function DecibelTab({
     <ContentBox>
       <Stack spacing={3}>
         <OrdersSection orders={summary.orders} />
+        {summary.bulkOrderDetail && (
+          <BulkOrderDetailSection detail={summary.bulkOrderDetail} />
+        )}
+        <BulkOrderPlacedSection events={summary.bulkOrderPlacedEvents} />
+        <BulkOrderFilledSection fills={summary.bulkOrderFilledEvents} />
         <DepositsSection
           deposits={summary.deposits}
           coinData={coinData?.data}

--- a/app/utils/decibel/index.ts
+++ b/app/utils/decibel/index.ts
@@ -1,6 +1,10 @@
 export {DECIBEL_CONTRACTS, ORDER_TYPE_LABELS} from "./constants";
 export {isDecibelTransaction, parseDecibelTransaction} from "./parser";
 export type {
+  BulkOrderLeg,
+  DecibelBulkOrderDetail,
+  DecibelBulkOrderFilledEvent,
+  DecibelBulkOrderPlacedEvent,
   DecibelDeposit,
   DecibelOrder,
   DecibelTransactionSummary,

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -160,7 +160,15 @@ describe("parseDecibelTransaction", () => {
         payload: {
           type: "entry_function_payload",
           function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
-          arguments: ["sub1", {inner: "0xmarket1"}, "data"],
+          arguments: [
+            "sub1",
+            {inner: "0xmarket1"},
+            "42",
+            ["5000", "4900"],
+            ["100", "200"],
+            ["5100", "5200"],
+            ["150", "250"],
+          ],
         },
       });
       const summary = parseDecibelTransaction(txn);
@@ -399,6 +407,225 @@ describe("parseDecibelTransaction", () => {
       expect(summary.orders).toHaveLength(0);
       expect(summary.deposits).toHaveLength(0);
       expect(summary.withdrawals).toHaveLength(0);
+    });
+  });
+
+  describe("bulk order detail", () => {
+    it("extracts bid/ask ladders from bulk order payload", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: [
+            {inner: "0xsub1"},
+            {inner: "0xmarket1"},
+            "42",
+            ["5000", "4900", "4800"],
+            ["100", "200", "300"],
+            ["5100", "5200"],
+            ["150", "250"],
+            "0xbuilder",
+            "10",
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      const detail = summary.bulkOrderDetail;
+      if (!detail) throw new Error("expected bulkOrderDetail");
+      expect(detail.market).toBe("0xmarket1");
+      expect(detail.subaccount).toBe("0xsub1");
+      expect(detail.sequenceNumber).toBe("42");
+      expect(detail.bids).toHaveLength(3);
+      expect(detail.bids[0]).toEqual({price: "5000", size: "100"});
+      expect(detail.bids[2]).toEqual({price: "4800", size: "300"});
+      expect(detail.asks).toHaveLength(2);
+      expect(detail.asks[0]).toEqual({price: "5100", size: "150"});
+      expect(detail.builderAddress).toBe("0xbuilder");
+      expect(detail.builderFees).toBe("10");
+    });
+
+    it("omits builder when address is 0x0", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: [
+            "sub1",
+            {inner: "0xmarket1"},
+            "1",
+            ["5000"],
+            ["100"],
+            [],
+            [],
+            "0x0",
+            "0",
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderDetail).toBeDefined();
+      expect(summary.bulkOrderDetail?.builderAddress).toBeUndefined();
+      expect(summary.bulkOrderDetail?.builderFees).toBeUndefined();
+    });
+
+    it("returns undefined bulkOrderDetail for non-bulk payloads", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::deposit_to_subaccount_at`,
+          arguments: ["sub1", {inner: "0xasset1"}, "1000000"],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderDetail).toBeUndefined();
+    });
+
+    it("returns undefined bulkOrderDetail for failed transactions", () => {
+      const txn = makeUserTxn({
+        success: false,
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: [
+            "sub1",
+            {inner: "0xmarket1"},
+            "1",
+            ["5000"],
+            ["100"],
+            [],
+            [],
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderDetail).toBeUndefined();
+    });
+  });
+
+  describe("bulk order events", () => {
+    it("parses BulkOrderPlacedEvent", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::BulkOrderPlacedEvent`,
+            data: {
+              market: "0xmarket1",
+              order_id: "123",
+              user: "0xuser1",
+              sequence_number: "5",
+              previous_seq_num: "4",
+              bid_prices: ["5000", "4900"],
+              bid_sizes: ["100", "200"],
+              ask_prices: ["5100"],
+              ask_sizes: ["150"],
+              cancelled_bid_prices: ["4800"],
+              cancelled_bid_sizes: ["50"],
+              cancelled_ask_prices: [],
+              cancelled_ask_sizes: [],
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderPlacedEvents).toHaveLength(1);
+      const placed = summary.bulkOrderPlacedEvents[0];
+      expect(placed.market).toBe("0xmarket1");
+      expect(placed.orderId).toBe("123");
+      expect(placed.user).toBe("0xuser1");
+      expect(placed.sequenceNumber).toBe("5");
+      expect(placed.previousSeqNum).toBe("4");
+      expect(placed.bids).toHaveLength(2);
+      expect(placed.asks).toHaveLength(1);
+      expect(placed.cancelledBids).toHaveLength(1);
+      expect(placed.cancelledBids[0]).toEqual({price: "4800", size: "50"});
+      expect(placed.cancelledAsks).toHaveLength(0);
+    });
+
+    it("parses BulkOrderFilledEvent", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::BulkOrderFilledEvent`,
+            data: {
+              market: "0xmarket1",
+              order_id: "123",
+              user: "0xuser1",
+              fill_id: "456",
+              is_bid: true,
+              price: "5000",
+              orig_price: "4950",
+              filled_size: "50",
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderFilledEvents).toHaveLength(1);
+      const filled = summary.bulkOrderFilledEvents[0];
+      expect(filled.market).toBe("0xmarket1");
+      expect(filled.side).toBe("buy");
+      expect(filled.price).toBe("5000");
+      expect(filled.origPrice).toBe("4950");
+      expect(filled.filledSize).toBe("50");
+      expect(filled.fillId).toBe("456");
+    });
+
+    it("parses BulkOrderFilledEvent for testnet", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${TESTNET_CONTRACT}::market_types::BulkOrderFilledEvent`,
+            data: {
+              market: "0xmarket2",
+              order_id: "789",
+              user: "0xuser2",
+              fill_id: "012",
+              is_bid: false,
+              price: "5100",
+              filled_size: "75",
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderFilledEvents).toHaveLength(1);
+      expect(summary.bulkOrderFilledEvents[0].side).toBe("sell");
+      expect(summary.bulkOrderFilledEvents[0].origPrice).toBeUndefined();
+    });
+
+    it("parses both placed and filled events in same transaction", () => {
+      const txn = makeUserTxn({
+        events: [
+          {
+            type: `${MAINNET_CONTRACT}::market_types::BulkOrderPlacedEvent`,
+            data: {
+              market: "0xmarket1",
+              order_id: "100",
+              user: "0xuser1",
+              sequence_number: "1",
+              bid_prices: ["5000"],
+              bid_sizes: ["100"],
+              ask_prices: [],
+              ask_sizes: [],
+            },
+          } as unknown as Types.Event,
+          {
+            type: `${MAINNET_CONTRACT}::market_types::BulkOrderFilledEvent`,
+            data: {
+              market: "0xmarket1",
+              order_id: "100",
+              user: "0xuser2",
+              fill_id: "200",
+              is_bid: true,
+              price: "5000",
+              filled_size: "50",
+            },
+          } as unknown as Types.Event,
+        ],
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderPlacedEvents).toHaveLength(1);
+      expect(summary.bulkOrderFilledEvents).toHaveLength(1);
     });
   });
 });

--- a/app/utils/decibel/parser.test.ts
+++ b/app/utils/decibel/parser.test.ts
@@ -468,6 +468,52 @@ describe("parseDecibelTransaction", () => {
       expect(summary.bulkOrderDetail?.builderFees).toBeUndefined();
     });
 
+    it("unwraps Option<address> builder from {vec: [...]} envelope", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: [
+            "sub1",
+            {inner: "0xmarket1"},
+            "1",
+            ["5000"],
+            ["100"],
+            [],
+            [],
+            {vec: ["0xbuilder_addr"]},
+            {vec: ["500"]},
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderDetail?.builderAddress).toBe("0xbuilder_addr");
+      expect(summary.bulkOrderDetail?.builderFees).toBe("500");
+    });
+
+    it("handles empty Option<> vec for builder", () => {
+      const txn = makeUserTxn({
+        payload: {
+          type: "entry_function_payload",
+          function: `${MAINNET_CONTRACT}::dex_accounts_entry::place_bulk_orders_to_subaccount`,
+          arguments: [
+            "sub1",
+            {inner: "0xmarket1"},
+            "1",
+            ["5000"],
+            ["100"],
+            [],
+            [],
+            {vec: []},
+            {vec: []},
+          ],
+        },
+      });
+      const summary = parseDecibelTransaction(txn);
+      expect(summary.bulkOrderDetail?.builderAddress).toBeUndefined();
+      expect(summary.bulkOrderDetail?.builderFees).toBeUndefined();
+    });
+
     it("returns undefined bulkOrderDetail for non-bulk payloads", () => {
       const txn = makeUserTxn({
         payload: {

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -1,6 +1,10 @@
 import type {Types} from "~/types/aptos";
 import {DECIBEL_CONTRACTS} from "./constants";
 import type {
+  BulkOrderLeg,
+  DecibelBulkOrderDetail,
+  DecibelBulkOrderFilledEvent,
+  DecibelBulkOrderPlacedEvent,
   DecibelDeposit,
   DecibelOrder,
   DecibelTransactionSummary,
@@ -246,18 +250,148 @@ function parsePayloadAction(
   return undefined;
 }
 
+function zipLegs(prices: unknown, sizes: unknown): BulkOrderLeg[] {
+  const p = Array.isArray(prices) ? prices : [];
+  const s = Array.isArray(sizes) ? sizes : [];
+  const len = Math.max(p.length, s.length);
+  const legs: BulkOrderLeg[] = [];
+  for (let i = 0; i < len; i++) {
+    legs.push({
+      price: String(p[i] ?? "0"),
+      size: String(s[i] ?? "0"),
+    });
+  }
+  return legs;
+}
+
+function parseBulkOrderPayloadDetail(
+  transaction: Types.Transaction,
+): DecibelBulkOrderDetail | undefined {
+  if (
+    !("payload" in transaction) ||
+    !("success" in transaction) ||
+    !transaction.success
+  ) {
+    return undefined;
+  }
+
+  const payload = transaction.payload;
+  if (
+    payload.type !== "entry_function_payload" ||
+    !("function" in payload) ||
+    !("arguments" in payload)
+  ) {
+    return undefined;
+  }
+
+  const typedPayload = payload as Types.TransactionPayload_EntryFunctionPayload;
+  const fn = typedPayload.function;
+  const args = typedPayload.arguments;
+
+  const matchesDecibel = DECIBEL_CONTRACTS.some((addr) =>
+    fn.startsWith(`${addr}::dex_accounts_entry::`),
+  );
+  if (!matchesDecibel) return undefined;
+
+  const fnName = fn.split("::").pop() ?? "";
+  if (fnName !== "place_bulk_orders_to_subaccount") return undefined;
+
+  // API args (signer stripped): [subaccount(0), market(1), sequence_number(2),
+  //   bid_prices(3), bid_sizes(4), ask_prices(5), ask_sizes(6),
+  //   builder_address(7), builder_fees(8)]
+  if (args.length < 7) return undefined;
+
+  return {
+    market: extractObjectInner(args[1]),
+    subaccount: extractObjectInner(args[0]),
+    sequenceNumber: args[2] != null ? String(args[2]) : undefined,
+    bids: zipLegs(args[3], args[4]),
+    asks: zipLegs(args[5], args[6]),
+    builderAddress:
+      args.length > 7 && args[7] && String(args[7]) !== "0x0"
+        ? String(args[7])
+        : undefined,
+    builderFees:
+      args.length > 8 && args[8] && String(args[8]) !== "0"
+        ? String(args[8])
+        : undefined,
+  };
+}
+
+function parseBulkOrderPlacedEvent(
+  event: Types.Event,
+): DecibelBulkOrderPlacedEvent | undefined {
+  const isMatch = DECIBEL_CONTRACTS.some(
+    (addr) => event.type === `${addr}::market_types::BulkOrderPlacedEvent`,
+  );
+  if (!isMatch) return undefined;
+
+  const data = event.data as Record<string, unknown>;
+  return {
+    market: String(data.market ?? ""),
+    orderId: String(data.order_id ?? ""),
+    user: String(data.user ?? ""),
+    sequenceNumber: String(data.sequence_number ?? ""),
+    previousSeqNum:
+      data.previous_seq_num !== undefined
+        ? String(data.previous_seq_num)
+        : undefined,
+    bids: zipLegs(data.bid_prices, data.bid_sizes),
+    asks: zipLegs(data.ask_prices, data.ask_sizes),
+    cancelledBids: zipLegs(data.cancelled_bid_prices, data.cancelled_bid_sizes),
+    cancelledAsks: zipLegs(data.cancelled_ask_prices, data.cancelled_ask_sizes),
+  };
+}
+
+function parseBulkOrderFilledEvent(
+  event: Types.Event,
+): DecibelBulkOrderFilledEvent | undefined {
+  const isMatch = DECIBEL_CONTRACTS.some(
+    (addr) => event.type === `${addr}::market_types::BulkOrderFilledEvent`,
+  );
+  if (!isMatch) return undefined;
+
+  const data = event.data as Record<string, unknown>;
+  return {
+    market: String(data.market ?? ""),
+    orderId: String(data.order_id ?? ""),
+    user: String(data.user ?? ""),
+    fillId: String(data.fill_id ?? ""),
+    side: data.is_bid === true ? "buy" : "sell",
+    price: String(data.price ?? ""),
+    origPrice: data.orig_price ? String(data.orig_price) : undefined,
+    filledSize: String(data.filled_size ?? ""),
+  };
+}
+
 export function parseDecibelTransaction(
   transaction: Types.Transaction,
 ): DecibelTransactionSummary {
   const orders: DecibelOrder[] = [];
   const deposits: DecibelDeposit[] = [];
   const withdrawals: DecibelWithdraw[] = [];
+  const bulkOrderPlacedEvents: DecibelBulkOrderPlacedEvent[] = [];
+  const bulkOrderFilledEvents: DecibelBulkOrderFilledEvent[] = [];
 
-  // Parse events for order data
+  // Parse events for order data and bulk-specific events
   if ("events" in transaction && Array.isArray(transaction.events)) {
     for (const event of transaction.events) {
       const order = parseOrderEvent(event);
-      if (order) orders.push(order);
+      if (order) {
+        orders.push(order);
+        continue;
+      }
+
+      const placed = parseBulkOrderPlacedEvent(event);
+      if (placed) {
+        bulkOrderPlacedEvents.push(placed);
+        continue;
+      }
+
+      const filled = parseBulkOrderFilledEvent(event);
+      if (filled) {
+        bulkOrderFilledEvents.push(filled);
+      }
     }
   }
 
@@ -288,5 +422,15 @@ export function parseDecibelTransaction(
     }
   }
 
-  return {orders, deposits, withdrawals};
+  // Parse bulk order detail from payload arguments
+  const bulkOrderDetail = parseBulkOrderPayloadDetail(transaction);
+
+  return {
+    orders,
+    deposits,
+    withdrawals,
+    bulkOrderDetail,
+    bulkOrderPlacedEvents,
+    bulkOrderFilledEvents,
+  };
 }

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -253,12 +253,12 @@ function parsePayloadAction(
 function zipLegs(prices: unknown, sizes: unknown): BulkOrderLeg[] {
   const p = Array.isArray(prices) ? prices : [];
   const s = Array.isArray(sizes) ? sizes : [];
-  const len = Math.max(p.length, s.length);
+  const len = Math.min(p.length, s.length);
   const legs: BulkOrderLeg[] = [];
   for (let i = 0; i < len; i++) {
     legs.push({
-      price: String(p[i] ?? "0"),
-      size: String(s[i] ?? "0"),
+      price: String(p[i]),
+      size: String(s[i]),
     });
   }
   return legs;
@@ -367,7 +367,7 @@ function parseBulkOrderFilledEvent(
     fillId: String(data.fill_id ?? ""),
     side: data.is_bid === true ? "buy" : "sell",
     price: String(data.price ?? ""),
-    origPrice: data.orig_price ? String(data.orig_price) : undefined,
+    origPrice: data.orig_price != null ? String(data.orig_price) : undefined,
     filledSize: String(data.filled_size ?? ""),
   };
 }

--- a/app/utils/decibel/parser.ts
+++ b/app/utils/decibel/parser.ts
@@ -264,6 +264,16 @@ function zipLegs(prices: unknown, sizes: unknown): BulkOrderLeg[] {
   return legs;
 }
 
+function extractOptionValue(val: unknown): string | undefined {
+  if (typeof val === "object" && val !== null && "vec" in val) {
+    const vec = (val as {vec: unknown[]}).vec;
+    if (vec.length > 0) return String(vec[0]);
+    return undefined;
+  }
+  if (typeof val === "string") return val;
+  return undefined;
+}
+
 function parseBulkOrderPayloadDetail(
   transaction: Types.Transaction,
 ): DecibelBulkOrderDetail | undefined {
@@ -301,6 +311,9 @@ function parseBulkOrderPayloadDetail(
   //   builder_address(7), builder_fees(8)]
   if (args.length < 7) return undefined;
 
+  const builderAddr = args.length > 7 ? extractOptionValue(args[7]) : undefined;
+  const builderFee = args.length > 8 ? extractOptionValue(args[8]) : undefined;
+
   return {
     market: extractObjectInner(args[1]),
     subaccount: extractObjectInner(args[0]),
@@ -308,13 +321,8 @@ function parseBulkOrderPayloadDetail(
     bids: zipLegs(args[3], args[4]),
     asks: zipLegs(args[5], args[6]),
     builderAddress:
-      args.length > 7 && args[7] && String(args[7]) !== "0x0"
-        ? String(args[7])
-        : undefined,
-    builderFees:
-      args.length > 8 && args[8] && String(args[8]) !== "0"
-        ? String(args[8])
-        : undefined,
+      builderAddr && builderAddr !== "0x0" ? builderAddr : undefined,
+    builderFees: builderFee && builderFee !== "0" ? builderFee : undefined,
   };
 }
 

--- a/app/utils/decibel/types.ts
+++ b/app/utils/decibel/types.ts
@@ -10,6 +10,44 @@ export type DecibelOrder = {
   subaccount: string | undefined;
 };
 
+export type BulkOrderLeg = {
+  price: string;
+  size: string;
+};
+
+export type DecibelBulkOrderDetail = {
+  market: string;
+  subaccount: string | undefined;
+  sequenceNumber: string | undefined;
+  bids: BulkOrderLeg[];
+  asks: BulkOrderLeg[];
+  builderAddress: string | undefined;
+  builderFees: string | undefined;
+};
+
+export type DecibelBulkOrderPlacedEvent = {
+  market: string;
+  orderId: string;
+  user: string;
+  sequenceNumber: string;
+  previousSeqNum: string | undefined;
+  bids: BulkOrderLeg[];
+  asks: BulkOrderLeg[];
+  cancelledBids: BulkOrderLeg[];
+  cancelledAsks: BulkOrderLeg[];
+};
+
+export type DecibelBulkOrderFilledEvent = {
+  market: string;
+  orderId: string;
+  user: string;
+  fillId: string;
+  side: "buy" | "sell";
+  price: string;
+  origPrice: string | undefined;
+  filledSize: string;
+};
+
 export type DecibelDeposit = {
   asset: string;
   amount: string;
@@ -28,4 +66,7 @@ export type DecibelTransactionSummary = {
   orders: DecibelOrder[];
   deposits: DecibelDeposit[];
   withdrawals: DecibelWithdraw[];
+  bulkOrderDetail: DecibelBulkOrderDetail | undefined;
+  bulkOrderPlacedEvents: DecibelBulkOrderPlacedEvent[];
+  bulkOrderFilledEvents: DecibelBulkOrderFilledEvent[];
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Enriches the Decibel bulk order visualization on the transaction page with significantly more data and proper formatting.

**Changes:**

1. **Bulk order detail grouped under order item**: The bid/ask ladders, placed events, and fill events are now nested under the "Bulk Orders" row in the Orders section via a collapsible accordion with a rotating arrow and "Show details" / "Hide details" label (collapsed by default, with `aria-label` for screen readers).

2. **Fixed `[object Object]` for builder address/fees**: Added `extractOptionValue()` to properly unwrap Move `Option<>` types serialized as `{vec: [...]}` by the Aptos API.

3. **Prices and sizes formatted with proper decimals and currency labels**:
   - Prices display as `$74,780` for USD markets (6 decimal places, USDC precision)
   - Sizes display as `0.001 BTC` using `sz_precision.decimals` from the on-chain `PerpMarketConfiguration` resource
   - Market name (e.g. `BTC/USD`) is parsed into base/quote assets for labels
   - Leg table headers show `Price (USD)` and `Size (BTC)`

4. **Removed redundant previous sequence number**: `previous_seq_num` is always `sequence_number - 1`, adding no useful information. Removed from both the Decibel tab and Events tab views.

5. **PR review fixes**:
   - `zipLegs`: uses `Math.min` instead of `Math.max` to avoid fabricating synthetic legs from mismatched arrays
   - `origPrice`: uses `!= null` instead of truthiness to preserve valid falsy values like `"0"`
   - `totalSize`: sums with `BigInt` instead of `Number` to avoid precision loss on large u64 values
   - Fills table: `FillsDesktopTable` conditionally shows Orig Price column and renders `—` for fills without it

**Files changed:**
- `app/api/hooks/useGetDecibelMarketName.ts` — New `useGetDecibelMarketConfig` hook
- `app/pages/Transaction/Tabs/DecibelTab.tsx` — Inline expandable detail, formatted prices/sizes with currency labels, BigInt totals, FillsDesktopTable
- `app/pages/Transaction/Tabs/Components/DecibelEventView.tsx` — Removed previous_seq_num display
- `app/utils/decibel/parser.ts` — `extractOptionValue()`, `zipLegs` with `Math.min`, `origPrice` null check
- `app/utils/decibel/parser.test.ts` — Tests for Option unwrapping, bulk order parsing
- `app/utils/decibel/types.ts` — New structured types for bulk order data
- `app/utils/decibel/index.ts` — Updated exports
- `CHANGELOG.md` — Entry under [Unreleased]

### Related Links

N/A

### Checklist

- [x] Lint passes (`pnpm lint`)
- [x] Tests pass (`pnpm test --run`) — 622/622
- [x] Formatting applied (`pnpm fmt`)
- [x] CHANGELOG updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40a09e42-8a0b-47b2-ac9a-29e9e8a74fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40a09e42-8a0b-47b2-ac9a-29e9e8a74fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

