### PR TITLE
feat(data): Labs-verify Decibel Dollar (usDCBL) on mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Labs verified token**: Decibel Dollar fungible asset (`usDCBL`, metadata object `0x9640…45b0` on mainnet) is included in the explorer manual verification list and coin metadata merge so it shows the Labs verified badge and correct branding where supported
 - **Settings page** (`/settings`): dedicated full-page settings replacing the old header popup dialog. Includes API key overrides (per network) and a new Move Bytecode Decompilation opt-in toggle
 - **Decompilation opt-in**: decompiled and disassembly code views now require explicit user opt-in at `/settings`. Users must acknowledge a disclaimer that decompiled output may not match original source before the feature is enabled
 - **Settings**: optional geomi.dev API key override can be set **per network** (instead of one key for all networks). Existing saved single keys are migrated to all networks on load until you save again.

--- a/app/components/Table/verifiedLevel.test.ts
+++ b/app/components/Table/verifiedLevel.test.ts
@@ -1,6 +1,10 @@
 // Covers FEAT-COIN-003 / FEAT-UI-002 — Verification level determination
 import {describe, expect, it} from "vitest";
+import {manuallyVerifiedTokens} from "../../constants";
 import {VerifiedType, verifiedLevel} from "./VerifiedCell";
+
+const USDCBL_FA =
+  "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0";
 
 describe("FEAT-COIN-003 / FEAT-UI-002 — verifiedLevel", () => {
   it("returns NATIVE_TOKEN for APT", () => {
@@ -86,5 +90,11 @@ describe("FEAT-COIN-003 / FEAT-UI-002 — verifiedLevel", () => {
       "mainnet",
     );
     expect(result.level).toBe(VerifiedType.UNVERIFIED);
+  });
+
+  it("returns LABS_VERIFIED for manually listed usDCBL fungible asset", () => {
+    expect(manuallyVerifiedTokens[USDCBL_FA]).toBe("usDCBL");
+    const result = verifiedLevel({id: USDCBL_FA, known: false}, "mainnet");
+    expect(result.level).toBe(VerifiedType.LABS_VERIFIED);
   });
 });

--- a/app/data/mainnet/assets.ts
+++ b/app/data/mainnet/assets.ts
@@ -506,6 +506,29 @@ export const mainnetHardCodedCoins: Record<string, CoinDescription> = {
     usdPrice: null,
     panoraTags: ["Native", "Verified"],
   },
+  "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0": {
+    chainId: 1,
+    tokenAddress: null,
+    faAddress:
+      "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0",
+    name: "Decibel Dollar",
+    symbol: "usDCBL",
+    decimals: 6,
+    panoraSymbol: null,
+    bridge: null,
+    logoUrl: "https://token-metadata.bridge.xyz/images/usDCBL.png",
+    websiteUrl: "https://decibel.trade/",
+    category: "Native",
+    isInPanoraTokenList: false,
+    isBanned: false,
+    panoraOrderIndex: 999999998,
+    panoraIndex: 999999998,
+    coinGeckoId: null,
+    coinMarketCapId: null,
+    panoraUI: false,
+    usdPrice: null,
+    panoraTags: ["Verified"],
+  },
 };
 
 /**
@@ -556,6 +579,8 @@ export const mainnetVerifiedTokens: Record<string, string> = {
     "ELON",
   "0xe50684a338db732d8fb8a3ac71c4b8633878bd0193bca5de2ebc852a83b35099::propbase_coin::PROPS":
     "PROPS",
+  "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0":
+    "usDCBL",
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers the Decibel Dollar fungible asset metadata object on Aptos mainnet as a **Labs verified** token and merges it into the hardcoded coin list so tables and coin flows get consistent metadata.

- **FA metadata address**: `0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0`
- **Symbol**: `usDCBL` (on-chain `0x1::fungible_asset::Metadata`)
- **Name / decimals / icon**: aligned with on-chain metadata (`Decibel Dollar`, 6 decimals, `https://token-metadata.bridge.xyz/images/usDCBL.png`, project URI `https://decibel.trade/`)

## Changes

- `app/data/mainnet/assets.ts`: `mainnetVerifiedTokens` + `mainnetHardCodedCoins`
- `app/components/Table/verifiedLevel.test.ts`: regression test for Labs verified level
- `CHANGELOG.md`: user-facing note under [Unreleased]

## Testing

- `pnpm fmt && pnpm lint`
- `pnpm test --run app/components/Table/verifiedLevel.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1776290467922519?thread_ts=1776290467.922519&cid=C040LV2NWQ4)

<div><a href="https://cursor.com/agents/bc-1e2a68f3-651b-5144-ba39-4c9d289ab4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e2a68f3-651b-5144-ba39-4c9d289ab4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

