### PR TITLE
fix(api): treat HTML/CDN 429 on legacy REST and truncate error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Rate limiting (REST)**: when the node or an upstream edge returns **HTTP 429 as an HTML page** (common for CDN rate limits), the explorer now treats it like other 429s—**rate-limit drawer** and `emitRateLimit()` fire from the legacy REST path, and error messages **truncate HTML** instead of embedding the full document.
 - **Wallet transactions on localnet**: non-Petra wallets that report a **custom** network name but use a **loopback** REST URL (for example `http://127.0.0.1:8080/v1`) are no longer blocked when the explorer is on the **local** network; submission still requires a real loopback endpoint match.
 - **Blocks list** (`/blocks`): recent rows now use the same REST block API as block detail pages, so block hash, timestamps, and transaction version ranges match what you see after opening a block (previously the indexer `block_metadata_transactions` row was mislabeled as the block hash and version bounds could disagree with the node).
 - **Coins page** (`/coins`): changing verification filters or the Emojicoins toggle no longer freezes the tab when thousands of assets match — the table virtualizes rows via an on-demand `renderRow` path and scrolls inside a bounded-height container instead of allocating every row up front

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -1,0 +1,31 @@
+// Covers FEAT-RATELIMIT-003 — legacy REST `withResponseError` treats HTML/CDN 429 bodies as rate limits
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {emitRateLimit} from "../context/rate-limit/rateLimitEvents";
+import {withResponseError} from "./index";
+
+vi.mock("../context/rate-limit/rateLimitEvents", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../context/rate-limit/rateLimitEvents")
+    >();
+  return {
+    ...actual,
+    emitRateLimit: vi.fn(),
+  };
+});
+
+describe("withResponseError (legacy app/api/index)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits rate limit when error message includes 429 (HTML edge/CDN body)", async () => {
+    const html429 = new Error(
+      "Aptos API error 429: <!doctype html><title>429</title>Too Many Requests",
+    );
+    await expect(withResponseError(Promise.reject(html429))).rejects.toThrow(
+      /Request failed:/,
+    );
+    expect(emitRateLimit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -8,7 +8,10 @@ import {
 } from "@aptos-labs/ts-sdk";
 import type {Types} from "~/types/aptos";
 import {OCTA} from "../constants";
-import {emitRateLimit} from "../context/rate-limit/rateLimitEvents";
+import {
+  emitRateLimit,
+  isRateLimitLike,
+} from "../context/rate-limit/rateLimitEvents";
 import {isNumeric} from "../pages/utils";
 import {sortTransactions} from "../utils/utils";
 import {AptosClient} from "./legacyClient";
@@ -18,19 +21,13 @@ export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
   try {
     return await promise;
   } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "status" in error &&
-      (error as {status: number}).status === 429
-    ) {
+    // HTML/CDN 429 pages say "429" in the body but not "too many requests";
+    // `isRateLimitLike` matches those and AptosApiError-style shapes.
+    if (isRateLimitLike(error)) {
       emitRateLimit();
     }
 
     if (error instanceof Error) {
-      if (error.message.toLowerCase().includes("too many requests")) {
-        emitRateLimit();
-      }
       error.message = `Request failed: ${error.message}`;
       throw error;
     }

--- a/app/api/legacyClient.test.ts
+++ b/app/api/legacyClient.test.ts
@@ -1,0 +1,33 @@
+// Covers FEAT-RATELIMIT-003 — REST client truncates HTML error pages on non-OK responses
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {AptosClient} from "./legacyClient";
+
+describe("AptosClient request errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shortens HTML 429 bodies instead of dumping the full page", async () => {
+    const hugeHtml = `<!doctype html><meta charset="utf-8"><title>429</title>429 Too Many Requests${"x".repeat(5000)}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve(hugeHtml),
+      }),
+    );
+
+    const client = new AptosClient("https://example.com/v1");
+    try {
+      await client.getLedgerInfo();
+      expect.fail("expected getLedgerInfo to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/Aptos API error 429:/);
+      expect(msg).toMatch(/HTML error page, not JSON/);
+      expect(msg.length).toBeLessThan(1200);
+    }
+  });
+});

--- a/app/api/legacyClient.ts
+++ b/app/api/legacyClient.ts
@@ -17,6 +17,31 @@ interface AptosClientConfig {
   HEADERS?: Record<string, string>;
 }
 
+const MAX_ERROR_BODY_CHARS = 800;
+
+/**
+ * Keep API error messages readable when the server returns an HTML error page
+ * (e.g. CDN / edge 429) instead of JSON.
+ */
+function formatErrorResponseBody(body: string): string {
+  const trimmed = body.trim();
+  const lower = trimmed.toLowerCase();
+  const looksHtml =
+    trimmed.startsWith("<!") ||
+    lower.includes("<!doctype html") ||
+    lower.includes("<html");
+  if (looksHtml) {
+    const oneLine = trimmed.replace(/\s+/g, " ");
+    const snippet = oneLine.slice(0, 280);
+    const suffix = oneLine.length > 280 ? "…" : "";
+    return `${snippet}${suffix} (HTML error page, not JSON — often edge or CDN rate limiting)`;
+  }
+  if (trimmed.length > MAX_ERROR_BODY_CHARS) {
+    return `${trimmed.slice(0, MAX_ERROR_BODY_CHARS)}…`;
+  }
+  return trimmed;
+}
+
 export class AptosClient {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
@@ -43,7 +68,8 @@ export class AptosClient {
       },
     });
     if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
+      const rawBody = await resp.text().catch(() => "");
+      const body = formatErrorResponseBody(rawBody);
       throw new Error(`Aptos API error ${resp.status}: ${body}`);
     }
     return resp.json() as Promise<T>;

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -930,7 +930,7 @@ The app shell that wraps every page.
 
 | Aspect | Detail |
 |--------|--------|
-| **Trigger** | HTTP 429 or "Too Many Requests" error detected in API client, queries, or router error handler via `emitRateLimit()`. |
+| **Trigger** | HTTP 429, "Too Many Requests", or error text that indicates HTTP 429 (including HTML error pages from an edge/CDN) detected in API client, queries, or router error handler via `emitRateLimit()`. |
 | **Display** | Persistent bottom `Drawer` (non-blocking) informing user of rate limit, offering "Set API key override" button (opens Settings) or wait ~5 minutes. Link to geomi.dev for key. |
 | **Auto-clear** | Rate limit state auto-clears after 5 minutes (`RATE_LIMIT_WINDOW_MS`). |
 | **Dismiss** | Close icon dismisses drawer while timer continues. |
@@ -947,8 +947,8 @@ The app shell that wraps every page.
 
 | Aspect | Detail |
 |--------|--------|
-| **Hook** | `withResponseError` in `app/api/client.ts`. |
-| **Mappings** | 429 → `TOO_MANY_REQUESTS` + `emitRateLimit()`; 404 → `NOT_FOUND`; 400 → `INVALID_INPUT`; Error with "too many requests" → rate limit; other → `UNHANDLED`. |
+| **Hook** | `withResponseError` in `app/api/client.ts` (TS SDK paths) and `withResponseError` in `app/api/index.ts` (legacy REST `AptosClient`). |
+| **Mappings** | 429 → `TOO_MANY_REQUESTS` + `emitRateLimit()`; 404 → `NOT_FOUND`; 400 → `INVALID_INPUT`; rate-limit-like errors (including messages containing `429` from HTML edge responses) → `emitRateLimit()` on legacy REST; other → `UNHANDLED`. |
 
 ---
 
@@ -1166,6 +1166,8 @@ The app shell that wraps every page.
 | `app/utils/routerParams.test.ts` | FEAT-ROUTING-003 (`pathSplatToSegments` normalization) |
 | `app/utils/sentioCallTrace.test.ts` | FEAT-TXN-010 (Sentio helpers: network ID, paths, address normalization, node validation) |
 | `app/api/client.test.ts` | FEAT-RATELIMIT-003 (API error classification, 429 → `emitRateLimit`) |
+| `app/api/index.test.ts` | FEAT-RATELIMIT-003 (legacy REST `withResponseError`: HTML/CDN 429 body → `emitRateLimit`) |
+| `app/api/legacyClient.test.ts` | FEAT-RATELIMIT-003 (REST client truncates HTML error bodies on non-OK responses) |
 | `app/api/hooks/useGetObjectRefs.test.ts` | FEAT-ACCOUNT-010 (object ref detection in transactions) |
 | `app/api/hooks/useGetAccountResource.test.ts` | FEAT-MODULES-008 (`mapRegistryQueryToAccountPackages`: 404 → empty packages, not error) |
 | `app/api/hooks/useGetFaProperties.test.ts` | FEAT-FA-002 (FA property derivation from resources) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the REST API returns **HTTP 429 as an HTML page** (typical for CDN or edge rate limits), `AptosClient` threw `Error` messages that included `429` in the text but not the phrase "too many requests". The legacy `withResponseError` in `app/api/index.ts` only emitted `emitRateLimit()` for `error.status === 429` or that phrase, so the **rate-limit drawer never appeared** and users saw huge "Unknown error" style blobs.

## Changes

- **`app/api/index.ts`**: use shared `isRateLimitLike()` so HTML/CDN 429 bodies match the same detection as GraphQL and the TS SDK client path.
- **`app/api/legacyClient.ts`**: truncate/replace HTML error bodies with a short snippet plus a hint that the response was HTML (edge/CDN), instead of dumping the full document into the error message.
- **Tests**: `app/api/index.test.ts`, `app/api/legacyClient.test.ts`.
- **Docs**: `docs/FEATURES_SPECIFICATION.md` (FEAT-RATELIMIT-001/003 + Appendix B), `CHANGELOG.md`.

## Note

This fixes **in-app** handling and messaging. Raising Netlify/host rate limits for scripted traffic is a separate ops change; users doing bulk replay should still call the Aptos REST base URL directly or use their own API key and spacing.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1777052109594579?thread_ts=1777052109.594579&cid=C040LV2NWQ4)

<div><a href="https://cursor.com/agents/bc-d15decb5-9e3d-5010-bfb1-da06e726847e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d15decb5-9e3d-5010-bfb1-da06e726847e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

