### PR TITLE
fix(discovery): add homepage Link headers

### DIFF
--- a/app/utils/netlifyHeaders.test.ts
+++ b/app/utils/netlifyHeaders.test.ts
@@ -1,0 +1,54 @@
+import {readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+const _dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(_dirname, "..", "..");
+
+const REQUIRED_DISCOVERY_LINKS = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"',
+  '</llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)"',
+  '</llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)"',
+  '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+] as const;
+
+function getHeadersBlock(config: string, path: string): string {
+  const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = config.match(
+    new RegExp(
+      String.raw`\[\[headers\]\]\s+for = "${escapedPath}"\s+\[headers\.values\]([\s\S]*?)(?=\n\[\[|\n\[context|\n# Environment|$)`,
+    ),
+  );
+
+  expect(
+    match,
+    `Expected netlify.toml to include a ${path} headers block`,
+  ).not.toBeNull();
+
+  return match?.[1] ?? "";
+}
+
+describe("Netlify discovery Link headers", () => {
+  const config = readFileSync(join(repoRoot, "netlify.toml"), "utf8");
+
+  it("sets RFC 8288 agent-discovery links on the exact homepage route", () => {
+    // Covers FEAT-SEO-004: homepage Link headers for agent discovery.
+    const homeHeaders = getHeadersBlock(config, "/");
+
+    expect(homeHeaders).toContain('Vary = "Accept"');
+    for (const link of REQUIRED_DISCOVERY_LINKS) {
+      expect(homeHeaders).toContain(link);
+    }
+  });
+
+  it("keeps global discovery links aligned with the homepage links", () => {
+    // Covers FEAT-SEO-004: non-home HTML responses also advertise discovery.
+    const globalHeaders = getHeadersBlock(config, "/*");
+
+    for (const link of REQUIRED_DISCOVERY_LINKS) {
+      expect(globalHeaders).toContain(link);
+    }
+  });
+});

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -1196,6 +1196,7 @@ top of the HTML site.
 | `app/utils/moduleErrorHandler.test.ts` | FEAT-ERROR-001 (chunk error handling, reload behavior) |
 | `app/utils/llmsRouteCoverage.test.ts` | FEAT-SEO-003 (LLM doc drift) |
 | `app/utils/agentSkillsIndex.test.ts` | FEAT-SEO-004 (agent-skills index schema, digest integrity, frontmatter) |
+| `app/utils/netlifyHeaders.test.ts` | FEAT-SEO-004 (homepage and global RFC 8288 discovery `Link` headers) |
 | `app/utils/acceptMarkdown.test.ts` | FEAT-SEO-004 (`Accept: text/markdown` negotiation helper) |
 | `app/components/webMcpTools.test.ts` | FEAT-SEO-004 (WebMCP navigation tools: routing, validation) |
 | `app/utils/routerParams.test.ts` | FEAT-ROUTING-003 (`pathSplatToSegments` normalization) |

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,13 +32,14 @@
     # and the LLM reference docs under /llms.txt and /llms-full.txt.
     Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
 
-# Homepage Vary header so caches key on Accept (used by the
-# markdown-negotiation edge function below). Link headers come from the
-# `/*` rule above.
+# Homepage discovery headers. Keep Link in this exact-route block so agents
+# scanning `/` can discover resources even when hosting merges only the most
+# specific header rule.
 [[headers]]
   for = "/"
   [headers.values]
     Vary = "Accept"
+    Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds an explicit RFC 8288 `Link` response header to the exact homepage Netlify header block so agent scanners hitting `/` can discover the API catalog, agent-skills index, LLM docs, and sitemap even when only the most specific host header rule is applied.

Also adds a Vitest drift check for the homepage and global discovery headers, and records the new FEAT-SEO-004 coverage in the feature specification.

### Related Links

- RFC 8288: https://www.rfc-editor.org/rfc/rfc8288
- RFC 9727 Section 3: https://www.rfc-editor.org/rfc/rfc9727#section-3

### Checklist

- [x] `pnpm fmt`
- [x] `pnpm test --run app/utils/netlifyHeaders.test.ts`
- [x] `pnpm lint`
- [x] `pnpm test --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eda4456c-7123-47d5-94df-44b6e9960b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eda4456c-7123-47d5-94df-44b6e9960b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

