### PR TITLE
Publish MCP Server Card for agent discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Agent-readiness discovery surfaces**: the explorer now ships structured metadata for autonomous agents and LLM-powered crawlers:
-  - `Link` response headers (RFC 8288) on `/` and `/*` advertising the API catalog, the Agent Skills index, `llms.txt`, `llms-full.txt`, and the sitemap
+  - `Link` response headers (RFC 8288) on `/` and `/*` advertising the API catalog, the Agent Skills index, MCP Server Card, `llms.txt`, `llms-full.txt`, and the sitemap
   - `/.well-known/api-catalog` (RFC 9727 / RFC 9264 linkset JSON) pointing to the upstream Aptos fullnode REST APIs (mainnet/testnet/devnet), the indexer GraphQL API, and the explorer itself
   - `/.well-known/agent-skills/index.json` plus per-skill `SKILL.md` bundles (`aptos-explorer-urls`, `aptos-explorer-search`) following the Agent Skills Discovery RFC v0.2.0, with SHA-256 digests
+  - `/.well-known/mcp/server-card.json` (SEP-1649 / SEP-2127 draft) describing the Explorer server, WebMCP transport endpoint, and read-only navigation tool capabilities for pre-connection MCP agent discovery
   - `scripts/update-agent-skills-index.mjs` helper to regenerate the discovery index when skills change
   - `robots.txt` `Content-Signal` directives — `ai-train=no, search=yes, ai-input=yes` — at the top of the file and inside every AI-crawler group (contentsignals.org / draft-romm-aipref-contentsignals)
   - Netlify Edge Function (`netlify/edge-functions/markdown-negotiation.ts`) that serves the homepage as `Content-Type: text/markdown` (backed by `/llms.txt`) when the request includes `Accept: text/markdown`; HTML remains the default for browsers

--- a/app/utils/mcpServerCard.test.ts
+++ b/app/utils/mcpServerCard.test.ts
@@ -1,0 +1,57 @@
+import {readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {buildWebMcpTools} from "../components/webMcpTools";
+
+const _dirname = dirname(fileURLToPath(import.meta.url));
+const publicDir = join(_dirname, "..", "..", "public");
+const serverCardPath = join(
+  publicDir,
+  ".well-known",
+  "mcp",
+  "server-card.json",
+);
+
+type McpServerCard = {
+  serverInfo?: {
+    name?: string;
+    version?: string;
+  };
+  transport?: {
+    type?: string;
+    endpoint?: string;
+  };
+  capabilities?: {
+    tools?: unknown;
+    resources?: unknown;
+    prompts?: unknown;
+  };
+  tools?: Array<{name?: string}>;
+};
+
+describe("MCP Server Card (/.well-known/mcp/server-card.json)", () => {
+  const card = JSON.parse(
+    readFileSync(serverCardPath, "utf8"),
+  ) as McpServerCard;
+  const webMcpToolNames = buildWebMcpTools(() => undefined).map(
+    (tool) => tool.name,
+  );
+
+  it("publishes the minimum SEP-1649 discovery fields", () => {
+    // Covers FEAT-SEO-004.
+    expect(card.serverInfo?.name).toBe("aptos-explorer");
+    expect(card.serverInfo?.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(card.transport?.endpoint).toBe("https://explorer.aptoslabs.com/");
+    expect(card.capabilities).toMatchObject({
+      resources: false,
+      prompts: false,
+    });
+    expect(card.capabilities?.tools).toBeTruthy();
+  });
+
+  it("advertises the read-only WebMCP navigation tools", () => {
+    expect(card.transport?.type).toBe("webmcp");
+    expect(card.tools?.map((tool) => tool.name)).toEqual(webMcpToolNames);
+  });
+});

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -985,9 +985,10 @@ top of the HTML site.
 
 | Aspect | Detail |
 |--------|--------|
-| **Link headers (RFC 8288)** | `netlify.toml` sets a `Link` response header on `/` and `/*` advertising `</.well-known/api-catalog>`, `</.well-known/agent-skills/index.json>`, `</llms.txt>`, `</llms-full.txt>`, and `</sitemap.xml>`. |
+| **Link headers (RFC 8288)** | `netlify.toml` sets a `Link` response header on `/` and `/*` advertising `</.well-known/api-catalog>`, `</.well-known/agent-skills/index.json>`, `</.well-known/mcp/server-card.json>`, `</llms.txt>`, `</llms-full.txt>`, and `</sitemap.xml>`. |
 | **API catalog (RFC 9727)** | `public/.well-known/api-catalog` served as `application/linkset+json`. Lists upstream Aptos fullnode REST APIs (mainnet/testnet/devnet), the indexer GraphQL API, and the explorer itself, with `service-desc`, `service-doc`, and `status` links. |
 | **Agent Skills index** | `public/.well-known/agent-skills/index.json` conforms to cloudflare/agent-skills-discovery-rfc v0.2.0. Publishes `aptos-explorer-urls` and `aptos-explorer-search` skills, each with a SHA-256 `digest`. Regenerate via `node scripts/update-agent-skills-index.mjs`. |
+| **MCP Server Card** | `public/.well-known/mcp/server-card.json` publishes a draft SEP-1649 / SEP-2127 MCP Server Card with `serverInfo`, a WebMCP transport endpoint, read-only tool capabilities, and the currently exposed browser WebMCP navigation tools. Served as `application/json` with CORS enabled for agent discovery. |
 | **Content Signals** | `public/robots.txt` declares `Content-Signal: ai-train=no, search=yes, ai-input=yes` at the top of the file and inside every AI-crawler `User-agent` group (contentsignals.org / draft-romm-aipref-contentsignals). |
 | **Markdown negotiation** | Netlify Edge Function `netlify/edge-functions/markdown-negotiation.ts` returns `/llms.txt` contents with `Content-Type: text/markdown` when the homepage request has `Accept: text/markdown`; HTML remains the default for browsers. Helper: `app/utils/acceptMarkdown.ts` (`prefersMarkdown`). |
 | **WebMCP** | `app/components/WebMCPProvider.tsx` registers read-only navigation tools (`search_explorer`, `open_transaction`, `open_account`, `open_block`, `open_releases`, `open_coin`) on `navigator.modelContext` when supported. Tool definitions live in `app/components/webMcpTools.ts`; registration is cleaned up via `AbortSignal` on unmount. |
@@ -1196,6 +1197,7 @@ top of the HTML site.
 | `app/utils/moduleErrorHandler.test.ts` | FEAT-ERROR-001 (chunk error handling, reload behavior) |
 | `app/utils/llmsRouteCoverage.test.ts` | FEAT-SEO-003 (LLM doc drift) |
 | `app/utils/agentSkillsIndex.test.ts` | FEAT-SEO-004 (agent-skills index schema, digest integrity, frontmatter) |
+| `app/utils/mcpServerCard.test.ts` | FEAT-SEO-004 (MCP Server Card minimum fields and advertised WebMCP tools) |
 | `app/utils/acceptMarkdown.test.ts` | FEAT-SEO-004 (`Accept: text/markdown` negotiation helper) |
 | `app/components/webMcpTools.test.ts` | FEAT-SEO-004 (WebMCP navigation tools: routing, validation) |
 | `app/utils/routerParams.test.ts` | FEAT-ROUTING-003 (`pathSplatToSegments` normalization) |

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,8 +29,9 @@
     X-XSS-Protection = "1; mode=block"
     # RFC 8288 Link headers — advertise well-known agent-discovery resources.
     # Kept in sync with /.well-known/api-catalog, /.well-known/agent-skills/index.json,
-    # and the LLM reference docs under /llms.txt and /llms-full.txt.
-    Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
+    # /.well-known/mcp/server-card.json, and the LLM reference docs under /llms.txt
+    # and /llms-full.txt.
+    Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"; title="MCP Server Card", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
 
 # Homepage Vary header so caches key on Accept (used by the
 # markdown-negotiation edge function below). Link headers come from the
@@ -125,6 +126,14 @@
 # Well-known: Agent Skills discovery index
 [[headers]]
   for = "/.well-known/agent-skills/index.json"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+    Content-Type = "application/json; charset=utf-8"
+    Access-Control-Allow-Origin = "*"
+
+# Well-known: MCP Server Card (SEP-1649 / SEP-2127 draft)
+[[headers]]
+  for = "/.well-known/mcp/server-card.json"
   [headers.values]
     Cache-Control = "public, max-age=3600"
     Content-Type = "application/json; charset=utf-8"

--- a/netlify/edge-functions/markdown-negotiation.ts
+++ b/netlify/edge-functions/markdown-negotiation.ts
@@ -65,6 +65,7 @@ export default async function handler(
     [
       '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
       '</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"',
+      '</.well-known/mcp/server-card.json>; rel="https://modelcontextprotocol.io/rel/server-card"; type="application/json"',
       '</llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)"',
       '</sitemap.xml>; rel="sitemap"; type="application/xml"',
     ].join(", "),

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,70 @@
+{
+  "mcpCard": "0.1",
+  "serverInfo": {
+    "name": "aptos-explorer",
+    "version": "1.1.0"
+  },
+  "name": "com.aptoslabs.explorer",
+  "version": "1.1.0",
+  "title": "Aptos Explorer",
+  "description": "Official Aptos blockchain explorer with read-only WebMCP navigation tools for opening transactions, accounts, blocks, releases, coins, and search results.",
+  "websiteUrl": "https://explorer.aptoslabs.com",
+  "transport": {
+    "type": "webmcp",
+    "endpoint": "https://explorer.aptoslabs.com/",
+    "description": "Open the explorer in a browser that supports navigator.modelContext. The page registers the tools listed in this card as read-only WebMCP navigation tools."
+  },
+  "remotes": [
+    {
+      "type": "webmcp",
+      "url": "https://explorer.aptoslabs.com/",
+      "name": "aptos-explorer-webmcp",
+      "title": "Aptos Explorer WebMCP",
+      "description": "Client-side WebMCP tools registered on explorer.aptoslabs.com for read-only Aptos Explorer navigation."
+    }
+  ],
+  "capabilities": {
+    "tools": {
+      "listChanged": false,
+      "readOnly": true
+    },
+    "resources": false,
+    "prompts": false
+  },
+  "tools": [
+    {
+      "name": "search_explorer",
+      "title": "Search Aptos Explorer",
+      "description": "Route the explorer home-page search to an on-chain entity. Supports addresses, transaction versions or hashes, ANS .apt names, coin types, and block heights."
+    },
+    {
+      "name": "open_transaction",
+      "title": "Open transaction",
+      "description": "Open the Aptos Explorer transaction page for a version number or transaction hash, with an optional detail tab."
+    },
+    {
+      "name": "open_account",
+      "title": "Open account",
+      "description": "Open the Aptos Explorer account page for a 0x-prefixed address or ANS .apt name, with an optional account tab."
+    },
+    {
+      "name": "open_block",
+      "title": "Open block",
+      "description": "Open the Aptos Explorer block page for a block height."
+    },
+    {
+      "name": "open_releases",
+      "title": "Open releases hub",
+      "description": "Open the releases hub for network deployment status, AIPs, or SDK and tool releases."
+    },
+    {
+      "name": "open_coin",
+      "title": "Open coin",
+      "description": "Open the Aptos Explorer coin page for a fully-qualified Move coin type."
+    }
+  ],
+  "_meta": {
+    "specification": "SEP-1649 / SEP-2127 draft MCP Server Cards",
+    "generatedFrom": "app/components/webMcpTools.ts"
+  }
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Aptos Explorer — Full LLM Reference
 
-> Last updated: 2026-04-29 (rev 17)
+> Last updated: 2026-04-29 (rev 18)
 
 > Comprehensive reference for AI systems interacting with or answering questions about the Aptos Explorer at [explorer.aptoslabs.com](https://explorer.aptoslabs.com).
 
@@ -398,16 +398,21 @@ canonical user experience.
   - `aptos-explorer-search` — teaches agents to use the home-page
     `/?search={query}` auto-detection for opaque inputs.
   Each skill entry includes a SHA-256 digest of its `SKILL.md` artifact.
+- **`/.well-known/mcp/server-card.json`** — MCP Server Card (SEP-1649 /
+  SEP-2127 draft), served as `application/json`. Publishes `serverInfo`,
+  the WebMCP transport endpoint (`https://explorer.aptoslabs.com/`), and
+  the read-only navigation tool capabilities exposed by the Explorer.
 
 ### HTTP Link headers (RFC 8288)
 
 The home page (and, as a fallback, every path) responds with a `Link`
-header that advertises the api-catalog, the agent-skills index, and both
-`llms.txt` / `llms-full.txt`. Example:
+header that advertises the api-catalog, the MCP Server Card, the
+agent-skills index, and both `llms.txt` / `llms-full.txt`. Example:
 
 ```
 Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json",
       </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json",
+      </.well-known/mcp/server-card.json>; rel="https://modelcontextprotocol.io/rel/server-card"; type="application/json",
       </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)",
       </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)",
       </sitemap.xml>; rel="sitemap"; type="application/xml"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -95,9 +95,10 @@ All URLs default to mainnet. Append `?network=testnet`, `?network=devnet`, or `?
 
 ## Agent Discovery
 
+- MCP Server Card (SEP-1649 / SEP-2127 draft): [/.well-known/mcp/server-card.json](https://explorer.aptoslabs.com/.well-known/mcp/server-card.json) — describes the Explorer server, WebMCP transport endpoint, and read-only navigation tool capabilities for pre-connection agent discovery.
 - API catalog (RFC 9727, `application/linkset+json`): [/.well-known/api-catalog](https://explorer.aptoslabs.com/.well-known/api-catalog) — lists upstream Aptos REST and Indexer GraphQL APIs with `service-desc` / `service-doc` / `status` links.
 - Agent Skills discovery index (cloudflare/agent-skills-discovery-rfc v0.2.0): [/.well-known/agent-skills/index.json](https://explorer.aptoslabs.com/.well-known/agent-skills/index.json) — published skills for routing Aptos lookups to explorer URLs.
-- HTTP `Link` response header: the homepage advertises `api-catalog`, the agent-skills index, and both `llms.txt` / `llms-full.txt` via RFC 8288 `Link` headers so agents can discover resources without parsing HTML.
+- HTTP `Link` response header: the homepage advertises the MCP Server Card, `api-catalog`, the agent-skills index, and both `llms.txt` / `llms-full.txt` via RFC 8288 `Link` headers so agents can discover resources without parsing HTML.
 - Markdown content negotiation: the homepage responds with a markdown view (`Content-Type: text/markdown`) when the request includes `Accept: text/markdown`; HTML remains the default for browsers.
 - WebMCP: when the user's browser supports `navigator.modelContext`, the Explorer registers read-only navigation tools (`search_explorer`, `open_transaction`, `open_account`, `open_block`, `open_releases`, `open_coin`) so in-browser agents can open pages by identifier.
 - Content usage: [/robots.txt](https://explorer.aptoslabs.com/robots.txt) declares Content Signals — `ai-train=no, search=yes, ai-input=yes`.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -166,4 +166,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>https://explorer.aptoslabs.com/.well-known/mcp/server-card.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Publish an MCP Server Card at `/.well-known/mcp/server-card.json` for SEP-1649 / SEP-2127 draft discovery. The card includes `serverInfo`, the WebMCP transport endpoint, read-only tool capabilities, and the existing Explorer WebMCP navigation tools.

Also advertises the card through Netlify `Link` headers, adds content headers/CORS, updates LLM discovery docs, sitemap, changelog, and the feature specification, and adds a drift test for the card shape.

### Related Links

- https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
- https://isitagentready.com/.well-known/agent-skills/mcp-server-card/SKILL.md

### Checklist

- [x] Added MCP Server Card well-known JSON
- [x] Updated agent discovery documentation and sitemap
- [x] Added test coverage
- [x] Ran `pnpm fmt`
- [x] Ran `pnpm lint`
- [x] Ran `pnpm test --run`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d622febf-5aa0-4939-93d8-e1a806241b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d622febf-5aa0-4939-93d8-e1a806241b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

