### PR TITLE
Fix Markdown for Agents negotiation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,7 +486,7 @@ The explorer maintains dedicated documentation for AI systems and LLM-powered to
 | `public/.well-known/agent-skills/index.json` | Agent Skills Discovery RFC v0.2.0 index with SHA-256 digests | Any `SKILL.md` under `public/.well-known/agent-skills/*/` is added, edited, or removed — run `node scripts/update-agent-skills-index.mjs` |
 | `public/.well-known/agent-skills/*/SKILL.md` | Individual agent skills (URL routing, search, etc.) | Feature/routing changes that affect how agents should link into the explorer |
 | `netlify.toml` | `Link` response headers (RFC 8288), `Vary: Accept`, well-known Content-Types, and edge-function registration | New discovery resources, new well-known paths, or changes to the discovery URL list |
-| `netlify/edge-functions/markdown-negotiation.ts` | Returns `/llms.txt` as `Content-Type: text/markdown` when the request has `Accept: text/markdown` | The markdown-for-agents contract changes, or the source file for the markdown view moves |
+| `netlify/edge-functions/markdown-negotiation.ts` | Converts HTML route responses to `Content-Type: text/markdown` when the request has `Accept: text/markdown` | The markdown-for-agents contract changes, or the source file for the markdown view moves |
 | `app/utils/acceptMarkdown.ts` | Pure `Accept`-header parser mirrored in the edge function | Keep in sync with `markdown-negotiation.ts` whenever the negotiation logic changes |
 | `app/components/WebMCPProvider.tsx` + `app/components/webMcpTools.ts` | WebMCP tools registered on `navigator.modelContext` | A major new top-level route becomes important for agent navigation, or tool schemas need to change |
 | `scripts/update-agent-skills-index.mjs` | Regenerates `SHA-256` digests in the agent-skills index | Any change to a `SKILL.md` under `public/.well-known/agent-skills/*/` |
@@ -531,7 +531,7 @@ Machine-readable metadata for autonomous agents lives alongside the LLM docs. Ke
 - [ ] **New upstream API** (new chain, new indexer, a price/analytics feed): add an `anchor` entry to `public/.well-known/api-catalog` with `service-desc` (OpenAPI URL), `service-doc`, and `status` links. Also add it to the "API Endpoints Used by the Explorer" section of `public/llms-full.txt`.
 - [ ] **New discovery resource** (anything under `/.well-known/…`): add it to both `Link` response headers in `netlify.toml` (the `/` and `/*` entries) and to the Content-Types / Cache-Control block further down. Add a `<url>` entry to `public/sitemap.xml`.
 - [ ] **Content Signals** (`public/robots.txt`): if the `ai-train`, `search`, or `ai-input` defaults change, update the top-level `Content-Signal` line **and** the per-AI-crawler copies (they must agree).
-- [ ] **Markdown negotiation**: the homepage edge function (`netlify/edge-functions/markdown-negotiation.ts`) serves `/llms.txt` for `Accept: text/markdown`. If the canonical markdown source moves, update both the edge function and `app/utils/acceptMarkdown.ts` (they share logic but run in different runtimes — Deno vs Node/Vite).
+- [ ] **Markdown negotiation**: the HTML route edge function (`netlify/edge-functions/markdown-negotiation.ts`) converts downstream HTML to markdown for `Accept: text/markdown`. If the markdown conversion contract changes, update the edge function, `app/utils/acceptMarkdown.ts`, and related conversion tests.
 - [ ] **Docs + changelog**: add `FEAT-SEO-004` coverage notes to `docs/FEATURES_SPECIFICATION.md` (Appendix B) for new tests, and list user-facing discovery changes under `CHANGELOG.md` → `[Unreleased]`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Markdown for Agents — HTML routes negotiate to markdown without 500s**: the Netlify Edge Function now runs as middleware for HTML routes and converts the downstream SSR/static HTML response to `Content-Type: text/markdown` when agents send `Accept: text/markdown`. Browser requests still receive HTML by default, and markdown responses include an `X-Markdown-Tokens` estimate header.
 - **Network deployments — framework release uses gas schedule**: `/releases/networks` cards no longer label `0x1::version::Version.major` as “framework version”. The UI now shows **Framework Release** from `0x1::gas_schedule::GasScheduleV2.feature_version`, mapped to the framework train per aptos-core `gas_feature_versions`, plus **Bytecode Format (max)** from VM Binary Format feature flags.
 
 - **Network deployments — release branch URL never points to a non-existent branch**: the commit-message parser used to accept three-component release tags like `[aptos-release-v1.43.1]` (the patch-suffixed form is malformed; Aptos cuts release branches per minor only). When such a tag slipped through, the network card on `/releases/networks` rendered `v1.43.1.x` and linked to `aptos-release-v1.43.1`, which 404s. The parser now only accepts the canonical `[aptos-release-vX.Y]` form and the consumer adds a defensive `^\d+\.\d+$` guard, so malformed tags fall back to the commit-only display rather than producing a broken link.

--- a/app/utils/acceptMarkdown.test.ts
+++ b/app/utils/acceptMarkdown.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from "vitest";
 import {prefersMarkdown} from "./acceptMarkdown";
 
 describe("prefersMarkdown", () => {
+  // Covers FEAT-SEO-004.
   it("returns false for null / empty Accept", () => {
     expect(prefersMarkdown(null)).toBe(false);
     expect(prefersMarkdown("")).toBe(false);

--- a/app/utils/acceptMarkdown.ts
+++ b/app/utils/acceptMarkdown.ts
@@ -4,8 +4,8 @@
  *
  * Returns true when `text/markdown` appears as a media range with a non-zero
  * q-value (or with no explicit q-value — defaulting to 1 per RFC 9110). This
- * is used by the edge markdown-negotiation function to serve a markdown view
- * of the homepage for AI agents without affecting browser requests.
+ * is used by the edge markdown-negotiation function to serve markdown views of
+ * HTML routes for AI agents without affecting browser requests.
  */
 export function prefersMarkdown(accept: string | null | undefined): boolean {
   if (!accept) return false;

--- a/app/utils/htmlToMarkdown.test.ts
+++ b/app/utils/htmlToMarkdown.test.ts
@@ -46,9 +46,13 @@ describe("htmlToMarkdown", () => {
       `<html><body>
         <a href="https://explorer.aptoslabs.com/txn/1">Transaction</a>
         <a href="/account/0x1">Account</a>
+        <a href="//example.com/path">Scheme-relative link</a>
+        <a href="\\example.com\\path">Backslash link</a>
         <a href="javascript:alert(1)">Script link</a>
         <a href="data:text/html,alert(1)">Data link</a>
         <img src="https://example.com/logo.png" alt="Logo">
+        <img src="//example.com/logo.png" alt="Scheme-relative image">
+        <img src="\\example.com\\logo.png" alt="Backslash image">
         <img src="vbscript:alert(1)" alt="Bad image">
       </body></html>`,
     );
@@ -57,12 +61,18 @@ describe("htmlToMarkdown", () => {
       "[Transaction](https://explorer.aptoslabs.com/txn/1)",
     );
     expect(markdown).toContain("[Account](/account/0x1)");
+    expect(markdown).toContain("Scheme-relative link");
+    expect(markdown).toContain("Backslash link");
     expect(markdown).toContain("Script link");
     expect(markdown).toContain("Data link");
     expect(markdown).toContain("![Logo](https://example.com/logo.png)");
+    expect(markdown).not.toContain("](//example.com");
+    expect(markdown).not.toContain("\\\\example.com");
     expect(markdown).not.toContain("javascript:");
     expect(markdown).not.toContain("data:text/html");
     expect(markdown).not.toContain("vbscript:");
+    expect(markdown).not.toContain("Scheme-relative image");
+    expect(markdown).not.toContain("Backslash image");
     expect(markdown).not.toContain("Bad image");
   });
 

--- a/app/utils/htmlToMarkdown.test.ts
+++ b/app/utils/htmlToMarkdown.test.ts
@@ -30,6 +30,16 @@ describe("htmlToMarkdown", () => {
     expect(markdown).not.toContain("<main>");
   });
 
+  it("escapes angle brackets from text content", () => {
+    // Covers FEAT-SEO-004.
+    const markdown = htmlToMarkdown(
+      `<html><body><p>&lt;script&gt;alert("xss")&lt;/script&gt;</p></body></html>`,
+    );
+
+    expect(markdown).toBe('&lt;script&gt;alert("xss")&lt;/script&gt;');
+    expect(markdown).not.toContain("<script>");
+  });
+
   it("estimates token count for the markdown response header", () => {
     // Covers FEAT-SEO-004.
     expect(estimateMarkdownTokens("")).toBe(0);

--- a/app/utils/htmlToMarkdown.test.ts
+++ b/app/utils/htmlToMarkdown.test.ts
@@ -40,6 +40,32 @@ describe("htmlToMarkdown", () => {
     expect(markdown).not.toContain("<script>");
   });
 
+  it("only emits markdown links and images for safe URL schemes", () => {
+    // Covers FEAT-SEO-004.
+    const markdown = htmlToMarkdown(
+      `<html><body>
+        <a href="https://explorer.aptoslabs.com/txn/1">Transaction</a>
+        <a href="/account/0x1">Account</a>
+        <a href="javascript:alert(1)">Script link</a>
+        <a href="data:text/html,alert(1)">Data link</a>
+        <img src="https://example.com/logo.png" alt="Logo">
+        <img src="vbscript:alert(1)" alt="Bad image">
+      </body></html>`,
+    );
+
+    expect(markdown).toContain(
+      "[Transaction](https://explorer.aptoslabs.com/txn/1)",
+    );
+    expect(markdown).toContain("[Account](/account/0x1)");
+    expect(markdown).toContain("Script link");
+    expect(markdown).toContain("Data link");
+    expect(markdown).toContain("![Logo](https://example.com/logo.png)");
+    expect(markdown).not.toContain("javascript:");
+    expect(markdown).not.toContain("data:text/html");
+    expect(markdown).not.toContain("vbscript:");
+    expect(markdown).not.toContain("Bad image");
+  });
+
   it("estimates token count for the markdown response header", () => {
     // Covers FEAT-SEO-004.
     expect(estimateMarkdownTokens("")).toBe(0);

--- a/app/utils/htmlToMarkdown.test.ts
+++ b/app/utils/htmlToMarkdown.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest";
+import {estimateMarkdownTokens, htmlToMarkdown} from "./htmlToMarkdown";
+
+describe("htmlToMarkdown", () => {
+  it("converts HTML responses into readable markdown", () => {
+    // Covers FEAT-SEO-004.
+    const markdown = htmlToMarkdown(
+      `<!doctype html>
+      <html>
+        <head><title>Aptos Explorer</title><style>.hidden{display:none}</style></head>
+        <body>
+          <main>
+            <h1>Explore Aptos</h1>
+            <p>View <a href="/transactions">transactions</a> &amp; blocks.</p>
+            <ul><li><strong>Mainnet</strong></li><li>Testnet</li></ul>
+            <script>console.log("ignored")</script>
+          </main>
+        </body>
+      </html>`,
+      "https://explorer.aptoslabs.com/",
+    );
+
+    expect(markdown).toContain("# Aptos Explorer");
+    expect(markdown).toContain("Source: https://explorer.aptoslabs.com/");
+    expect(markdown).toContain("# Explore Aptos");
+    expect(markdown).toContain("View [transactions](/transactions) & blocks.");
+    expect(markdown).toContain("- Mainnet");
+    expect(markdown).toContain("- Testnet");
+    expect(markdown).not.toContain("console.log");
+    expect(markdown).not.toContain("<main>");
+  });
+
+  it("estimates token count for the markdown response header", () => {
+    // Covers FEAT-SEO-004.
+    expect(estimateMarkdownTokens("")).toBe(0);
+    expect(estimateMarkdownTokens("Aptos")).toBe(2);
+  });
+});

--- a/app/utils/htmlToMarkdown.ts
+++ b/app/utils/htmlToMarkdown.ts
@@ -1,6 +1,3 @@
-const BLOCK_TAGS =
-  /<\/?(article|aside|blockquote|body|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|header|hr|main|nav|p|section)[^>]*>/gi;
-
 const ENTITY_MAP: Record<string, string> = {
   amp: "&",
   apos: "'",
@@ -10,23 +7,65 @@ const ENTITY_MAP: Record<string, string> = {
   quot: '"',
 };
 
+const BLOCK_TAGS = new Set([
+  "article",
+  "aside",
+  "blockquote",
+  "body",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "header",
+  "hr",
+  "main",
+  "nav",
+  "p",
+  "section",
+]);
+
+const RAW_TEXT_TAGS = new Set(["script", "style", "noscript", "svg"]);
+
+type HtmlToken =
+  | {type: "text"; value: string}
+  | {
+      attrs: Record<string, string>;
+      closing: boolean;
+      name: string;
+      type: "tag";
+    };
+
+type RenderContext =
+  | {buffer: string; href?: string; tag: "a"}
+  | {buffer: string; tag: "code" | "li" | "pre"}
+  | {buffer: string; level: number; tag: "heading"};
+
 function decodeHtmlEntities(value: string): string {
   return value.replace(/&(#x?[0-9a-f]+|[a-z][a-z0-9]+);/gi, (match, entity) => {
     const normalized = entity.toLowerCase();
     if (normalized.startsWith("#x")) {
       const codePoint = Number.parseInt(normalized.slice(2), 16);
-      return Number.isFinite(codePoint)
+      return isValidCodePoint(codePoint)
         ? String.fromCodePoint(codePoint)
         : match;
     }
     if (normalized.startsWith("#")) {
       const codePoint = Number.parseInt(normalized.slice(1), 10);
-      return Number.isFinite(codePoint)
+      return isValidCodePoint(codePoint)
         ? String.fromCodePoint(codePoint)
         : match;
     }
     return ENTITY_MAP[normalized] ?? match;
   });
+}
+
+function isValidCodePoint(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 0x10ffff;
 }
 
 function normalizeWhitespace(value: string): string {
@@ -37,106 +76,322 @@ function normalizeWhitespace(value: string): string {
     .trim();
 }
 
-function stripTags(value: string): string {
-  return decodeHtmlEntities(value.replace(/<[^>]*>/g, ""))
-    .replace(/[ \t]+/g, " ")
-    .trim();
+function isWhitespace(value: string): boolean {
+  return value === " " || value === "\n" || value === "\r" || value === "\t";
 }
 
-function getAttribute(tag: string, attribute: string): string | undefined {
-  const pattern = new RegExp(
-    `${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
-    "i",
-  );
-  const match = tag.match(pattern);
-  const value = match?.[1] ?? match?.[2] ?? match?.[3];
-  return value ? decodeHtmlEntities(value).trim() : undefined;
-}
-
-function convertLinks(value: string): string {
-  return value.replace(
-    /<a\b([^>]*)>([\s\S]*?)<\/a>/gi,
-    (_match, attrs, label) => {
-      const href = getAttribute(attrs, "href");
-      const text = stripTags(label);
-      if (!text) return "";
-      if (!href || href.startsWith("#") || /^javascript:/i.test(href))
-        return text;
-      return `[${text}](${href})`;
-    },
+function isNameChar(value: string): boolean {
+  const code = value.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    value === "-" ||
+    value === "_" ||
+    value === ":"
   );
 }
 
-function convertImages(value: string): string {
-  return value.replace(/<img\b([^>]*)>/gi, (_match, attrs) => {
-    const src = getAttribute(attrs, "src");
-    if (!src) return "";
-    const alt = getAttribute(attrs, "alt") ?? "";
-    return `![${alt}](${src})`;
-  });
+function escapeMarkdownHtml(value: string): string {
+  let escaped = "";
+  for (const char of value) {
+    if (char === "<") {
+      escaped += "&lt;";
+    } else if (char === ">") {
+      escaped += "&gt;";
+    } else {
+      escaped += char;
+    }
+  }
+  return escaped;
 }
 
-function convertPreBlocks(value: string): string {
-  return value.replace(/<pre\b[^>]*>([\s\S]*?)<\/pre>/gi, (_match, code) => {
-    const text = stripTags(code);
-    return text ? `\n\n\`\`\`\n${text}\n\`\`\`\n\n` : "";
-  });
+function normalizeInline(value: string): string {
+  return normalizeWhitespace(value).replace(/[ \t]+/g, " ");
 }
 
-function convertHeadings(value: string): string {
-  return value.replace(
-    /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
-    (_match, level, text) => {
-      const heading = stripTags(text);
-      return heading ? `\n\n${"#".repeat(Number(level))} ${heading}\n\n` : "";
-    },
+function appendText(target: RenderContext[] | {buffer: string}, value: string) {
+  if (Array.isArray(target)) {
+    const context = target.at(-1);
+    if (context) {
+      context.buffer += value;
+    }
+    return;
+  }
+  target.buffer += value;
+}
+
+function readTagEnd(html: string, start: number): number {
+  let quote: string | undefined;
+  for (let i = start; i < html.length; i += 1) {
+    const char = html[i];
+    if (quote) {
+      if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === ">") return i;
+  }
+  return -1;
+}
+
+function readName(value: string, start: number): {end: number; name: string} {
+  let end = start;
+  while (end < value.length && isNameChar(value[end])) end += 1;
+  return {end, name: value.slice(start, end).toLowerCase()};
+}
+
+function parseTag(raw: string): HtmlToken | undefined {
+  let i = 0;
+  while (i < raw.length && isWhitespace(raw[i])) i += 1;
+  if (raw[i] === "!" || raw[i] === "?") return undefined;
+
+  const closing = raw[i] === "/";
+  if (closing) i += 1;
+  while (i < raw.length && isWhitespace(raw[i])) i += 1;
+
+  const {end, name} = readName(raw, i);
+  if (!name) return undefined;
+  i = end;
+
+  const attrs: Record<string, string> = {};
+
+  while (i < raw.length) {
+    while (i < raw.length && isWhitespace(raw[i])) i += 1;
+    if (raw[i] === "/") {
+      i += 1;
+      continue;
+    }
+
+    const attr = readName(raw, i);
+    if (!attr.name) break;
+    i = attr.end;
+    while (i < raw.length && isWhitespace(raw[i])) i += 1;
+
+    let value = "";
+    if (raw[i] === "=") {
+      i += 1;
+      while (i < raw.length && isWhitespace(raw[i])) i += 1;
+      const quote = raw[i] === '"' || raw[i] === "'" ? raw[i] : undefined;
+      if (quote) i += 1;
+      const valueStart = i;
+      if (quote) {
+        while (i < raw.length && raw[i] !== quote) i += 1;
+        value = raw.slice(valueStart, i);
+        if (raw[i] === quote) i += 1;
+      } else {
+        while (i < raw.length && !isWhitespace(raw[i]) && raw[i] !== "/") {
+          i += 1;
+        }
+        value = raw.slice(valueStart, i);
+      }
+    }
+
+    attrs[attr.name] = decodeHtmlEntities(value).trim();
+  }
+
+  return {attrs, closing, name, type: "tag"};
+}
+
+function tokenizeHtml(html: string): HtmlToken[] {
+  const tokens: HtmlToken[] = [];
+  let i = 0;
+
+  while (i < html.length) {
+    const tagStart = html.indexOf("<", i);
+    if (tagStart === -1) {
+      tokens.push({type: "text", value: html.slice(i)});
+      break;
+    }
+    if (tagStart > i)
+      tokens.push({type: "text", value: html.slice(i, tagStart)});
+
+    if (html.startsWith("<!--", tagStart)) {
+      const commentEnd = html.indexOf("-->", tagStart + 4);
+      i = commentEnd === -1 ? html.length : commentEnd + 3;
+      continue;
+    }
+
+    const tagEnd = readTagEnd(html, tagStart + 1);
+    if (tagEnd === -1) {
+      tokens.push({type: "text", value: html.slice(tagStart)});
+      break;
+    }
+
+    const tag = parseTag(html.slice(tagStart + 1, tagEnd));
+    if (!tag) {
+      i = tagEnd + 1;
+      continue;
+    }
+    tokens.push(tag);
+    i = tagEnd + 1;
+
+    if (tag.type === "tag" && !tag.closing && RAW_TEXT_TAGS.has(tag.name)) {
+      const closeNeedle = `</${tag.name}`;
+      const rawCloseStart = html.toLowerCase().indexOf(closeNeedle, i);
+      if (rawCloseStart === -1) {
+        i = html.length;
+        continue;
+      }
+      const rawCloseEnd = readTagEnd(html, rawCloseStart + 1);
+      i = rawCloseEnd === -1 ? html.length : rawCloseEnd + 1;
+    }
+  }
+
+  return tokens;
+}
+
+function tokensInside(
+  tokens: HtmlToken[],
+  tagName: string,
+  fallback: HtmlToken[] = [],
+): HtmlToken[] {
+  const start = tokens.findIndex(
+    (token) => token.type === "tag" && !token.closing && token.name === tagName,
   );
+  if (start === -1) return fallback;
+
+  let depth = 0;
+  for (let i = start; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type !== "tag" || token.name !== tagName) continue;
+    if (!token.closing) depth += 1;
+    if (token.closing) depth -= 1;
+    if (depth === 0) return tokens.slice(start + 1, i);
+  }
+
+  return tokens.slice(start + 1);
 }
 
-function convertLists(value: string): string {
-  return value
-    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_match, item) => {
-      const text = normalizeWhitespace(stripTags(item));
-      return text ? `\n- ${text}` : "";
-    })
-    .replace(/<\/?(ul|ol)\b[^>]*>/gi, "\n");
+function textContent(tokens: HtmlToken[]): string {
+  let text = "";
+  for (const token of tokens) {
+    if (token.type === "text") text += decodeHtmlEntities(token.value);
+  }
+  return normalizeInline(escapeMarkdownHtml(text));
 }
 
-function convertInlineCode(value: string): string {
-  return value.replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (_match, code) => {
-    const text = stripTags(code);
+function renderContext(context: RenderContext): string {
+  if (context.tag === "heading") {
+    const text = normalizeInline(context.buffer);
+    return text ? `\n\n${"#".repeat(context.level)} ${text}\n\n` : "";
+  }
+  if (context.tag === "a") {
+    const text = normalizeInline(context.buffer);
+    if (!text) return "";
+    const href = context.href?.trim();
+    if (
+      !href ||
+      href.startsWith("#") ||
+      href.toLowerCase().startsWith("javascript:")
+    ) {
+      return text;
+    }
+    return `[${text}](${href})`;
+  }
+  if (context.tag === "li") {
+    const text = normalizeWhitespace(context.buffer);
+    return text ? `\n- ${text}` : "";
+  }
+  if (context.tag === "code") {
+    const text = normalizeInline(context.buffer);
     return text ? `\`${text}\`` : "";
-  });
+  }
+
+  const text = normalizeWhitespace(context.buffer);
+  return text ? `\n\n\`\`\`\n${text}\n\`\`\`\n\n` : "";
 }
 
-function extractTitle(html: string): string | undefined {
-  const title = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1];
-  return title ? stripTags(title) : undefined;
+function closeContext(
+  stack: RenderContext[],
+  root: {buffer: string},
+  predicate: (context: RenderContext) => boolean,
+) {
+  const context = stack.at(-1);
+  if (!context || !predicate(context)) return;
+  stack.pop();
+  const rendered = renderContext(context);
+  if (stack.length > 0) {
+    appendText(stack, rendered);
+  } else {
+    root.buffer += rendered;
+  }
 }
 
-function extractBody(html: string): string {
-  return html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i)?.[1] ?? html;
+function renderTokens(tokens: HtmlToken[]): string {
+  const root = {buffer: ""};
+  const stack: RenderContext[] = [];
+
+  for (const token of tokens) {
+    if (token.type === "text") {
+      appendText(
+        stack.length > 0 ? stack : root,
+        escapeMarkdownHtml(decodeHtmlEntities(token.value)),
+      );
+      continue;
+    }
+
+    const level =
+      token.name.length === 2 && token.name[0] === "h"
+        ? Number(token.name[1])
+        : 0;
+
+    if (token.closing) {
+      if (level >= 1 && level <= 6) {
+        closeContext(stack, root, (context) => context.tag === "heading");
+      } else if (token.name === "a") {
+        closeContext(stack, root, (context) => context.tag === "a");
+      } else if (token.name === "li") {
+        closeContext(stack, root, (context) => context.tag === "li");
+      } else if (token.name === "code") {
+        closeContext(stack, root, (context) => context.tag === "code");
+      } else if (token.name === "pre") {
+        closeContext(stack, root, (context) => context.tag === "pre");
+      }
+      continue;
+    }
+
+    if (level >= 1 && level <= 6) {
+      stack.push({buffer: "", level, tag: "heading"});
+    } else if (token.name === "a") {
+      stack.push({buffer: "", href: token.attrs.href, tag: "a"});
+    } else if (token.name === "li") {
+      stack.push({buffer: "", tag: "li"});
+    } else if (token.name === "code") {
+      stack.push({buffer: "", tag: "code"});
+    } else if (token.name === "pre") {
+      stack.push({buffer: "", tag: "pre"});
+    } else if (token.name === "img") {
+      const src = token.attrs.src?.trim();
+      if (src)
+        appendText(
+          stack.length > 0 ? stack : root,
+          `![${token.attrs.alt ?? ""}](${src})`,
+        );
+    } else if (token.name === "br") {
+      appendText(stack.length > 0 ? stack : root, "\n");
+    } else if (token.name === "ul" || token.name === "ol") {
+      appendText(stack.length > 0 ? stack : root, "\n");
+    } else if (BLOCK_TAGS.has(token.name)) {
+      appendText(stack.length > 0 ? stack : root, "\n\n");
+    }
+  }
+
+  while (stack.length > 0) {
+    const context = stack.pop();
+    if (context) root.buffer += renderContext(context);
+  }
+
+  return normalizeWhitespace(root.buffer);
 }
 
 export function htmlToMarkdown(html: string, sourceUrl?: string): string {
-  const title = extractTitle(html);
-  let markdown = extractBody(html)
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<(script|style|noscript|svg)\b[\s\S]*?<\/\1>/gi, "")
-    .replace(/<!doctype[^>]*>/gi, "");
-
-  markdown = convertPreBlocks(markdown);
-  markdown = convertHeadings(markdown);
-  markdown = convertLinks(markdown);
-  markdown = convertImages(markdown);
-  markdown = convertInlineCode(markdown);
-  markdown = convertLists(markdown);
-  markdown = markdown
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(BLOCK_TAGS, "\n\n")
-    .replace(/<[^>]*>/g, "");
-
-  const content = normalizeWhitespace(decodeHtmlEntities(markdown));
+  const tokens = tokenizeHtml(html);
+  const title = textContent(tokensInside(tokens, "title"));
+  const content = renderTokens(tokensInside(tokens, "body", tokens));
   const heading = [
     title ? `# ${title}` : undefined,
     sourceUrl ? `Source: ${sourceUrl}` : undefined,

--- a/app/utils/htmlToMarkdown.ts
+++ b/app/utils/htmlToMarkdown.ts
@@ -1,0 +1,154 @@
+const BLOCK_TAGS =
+  /<\/?(article|aside|blockquote|body|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|header|hr|main|nav|p|section)[^>]*>/gi;
+
+const ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+};
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-f]+|[a-z][a-z0-9]+);/gi, (match, entity) => {
+    const normalized = entity.toLowerCase();
+    if (normalized.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16);
+      return Number.isFinite(codePoint)
+        ? String.fromCodePoint(codePoint)
+        : match;
+    }
+    if (normalized.startsWith("#")) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10);
+      return Number.isFinite(codePoint)
+        ? String.fromCodePoint(codePoint)
+        : match;
+    }
+    return ENTITY_MAP[normalized] ?? match;
+  });
+}
+
+function normalizeWhitespace(value: string): string {
+  return value
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function stripTags(value: string): string {
+  return decodeHtmlEntities(value.replace(/<[^>]*>/g, ""))
+    .replace(/[ \t]+/g, " ")
+    .trim();
+}
+
+function getAttribute(tag: string, attribute: string): string | undefined {
+  const pattern = new RegExp(
+    `${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    "i",
+  );
+  const match = tag.match(pattern);
+  const value = match?.[1] ?? match?.[2] ?? match?.[3];
+  return value ? decodeHtmlEntities(value).trim() : undefined;
+}
+
+function convertLinks(value: string): string {
+  return value.replace(
+    /<a\b([^>]*)>([\s\S]*?)<\/a>/gi,
+    (_match, attrs, label) => {
+      const href = getAttribute(attrs, "href");
+      const text = stripTags(label);
+      if (!text) return "";
+      if (!href || href.startsWith("#") || /^javascript:/i.test(href))
+        return text;
+      return `[${text}](${href})`;
+    },
+  );
+}
+
+function convertImages(value: string): string {
+  return value.replace(/<img\b([^>]*)>/gi, (_match, attrs) => {
+    const src = getAttribute(attrs, "src");
+    if (!src) return "";
+    const alt = getAttribute(attrs, "alt") ?? "";
+    return `![${alt}](${src})`;
+  });
+}
+
+function convertPreBlocks(value: string): string {
+  return value.replace(/<pre\b[^>]*>([\s\S]*?)<\/pre>/gi, (_match, code) => {
+    const text = stripTags(code);
+    return text ? `\n\n\`\`\`\n${text}\n\`\`\`\n\n` : "";
+  });
+}
+
+function convertHeadings(value: string): string {
+  return value.replace(
+    /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+    (_match, level, text) => {
+      const heading = stripTags(text);
+      return heading ? `\n\n${"#".repeat(Number(level))} ${heading}\n\n` : "";
+    },
+  );
+}
+
+function convertLists(value: string): string {
+  return value
+    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_match, item) => {
+      const text = normalizeWhitespace(stripTags(item));
+      return text ? `\n- ${text}` : "";
+    })
+    .replace(/<\/?(ul|ol)\b[^>]*>/gi, "\n");
+}
+
+function convertInlineCode(value: string): string {
+  return value.replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (_match, code) => {
+    const text = stripTags(code);
+    return text ? `\`${text}\`` : "";
+  });
+}
+
+function extractTitle(html: string): string | undefined {
+  const title = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1];
+  return title ? stripTags(title) : undefined;
+}
+
+function extractBody(html: string): string {
+  return html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i)?.[1] ?? html;
+}
+
+export function htmlToMarkdown(html: string, sourceUrl?: string): string {
+  const title = extractTitle(html);
+  let markdown = extractBody(html)
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<(script|style|noscript|svg)\b[\s\S]*?<\/\1>/gi, "")
+    .replace(/<!doctype[^>]*>/gi, "");
+
+  markdown = convertPreBlocks(markdown);
+  markdown = convertHeadings(markdown);
+  markdown = convertLinks(markdown);
+  markdown = convertImages(markdown);
+  markdown = convertInlineCode(markdown);
+  markdown = convertLists(markdown);
+  markdown = markdown
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(BLOCK_TAGS, "\n\n")
+    .replace(/<[^>]*>/g, "");
+
+  const content = normalizeWhitespace(decodeHtmlEntities(markdown));
+  const heading = [
+    title ? `# ${title}` : undefined,
+    sourceUrl ? `Source: ${sourceUrl}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return normalizeWhitespace([heading, content].filter(Boolean).join("\n\n"));
+}
+
+export function estimateMarkdownTokens(markdown: string): number {
+  const trimmed = markdown.trim();
+  if (!trimmed) return 0;
+  return Math.max(1, Math.ceil(trimmed.length / 4));
+}

--- a/app/utils/htmlToMarkdown.ts
+++ b/app/utils/htmlToMarkdown.ts
@@ -110,6 +110,31 @@ function normalizeInline(value: string): string {
   return normalizeWhitespace(value).replace(/[ \t]+/g, " ");
 }
 
+function hasControlCharacter(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function safeMarkdownUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.startsWith("#")) return undefined;
+  if (hasControlCharacter(trimmed)) return undefined;
+
+  try {
+    const parsed = new URL(trimmed, "https://explorer.aptoslabs.com");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return trimmed;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 function appendText(target: RenderContext[] | {buffer: string}, value: string) {
   if (Array.isArray(target)) {
     const context = target.at(-1);
@@ -282,14 +307,8 @@ function renderContext(context: RenderContext): string {
   if (context.tag === "a") {
     const text = normalizeInline(context.buffer);
     if (!text) return "";
-    const href = context.href?.trim();
-    if (
-      !href ||
-      href.startsWith("#") ||
-      href.toLowerCase().startsWith("javascript:")
-    ) {
-      return text;
-    }
+    const href = safeMarkdownUrl(context.href);
+    if (!href) return text;
     return `[${text}](${href})`;
   }
   if (context.tag === "li") {
@@ -365,7 +384,7 @@ function renderTokens(tokens: HtmlToken[]): string {
     } else if (token.name === "pre") {
       stack.push({buffer: "", tag: "pre"});
     } else if (token.name === "img") {
-      const src = token.attrs.src?.trim();
+      const src = safeMarkdownUrl(token.attrs.src);
       if (src)
         appendText(
           stack.length > 0 ? stack : root,

--- a/app/utils/htmlToMarkdown.ts
+++ b/app/utils/htmlToMarkdown.ts
@@ -122,10 +122,20 @@ function safeMarkdownUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.startsWith("#")) return undefined;
   if (hasControlCharacter(trimmed)) return undefined;
+  if (trimmed.startsWith("\\")) return undefined;
+
+  if (trimmed.startsWith("/")) {
+    return trimmed.startsWith("//") ? undefined : trimmed;
+  }
 
   try {
+    const lowerTrimmed = trimmed.toLowerCase();
     const parsed = new URL(trimmed, "https://explorer.aptoslabs.com");
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    if (
+      (lowerTrimmed.startsWith("http://") ||
+        lowerTrimmed.startsWith("https://")) &&
+      (parsed.protocol === "http:" || parsed.protocol === "https:")
+    ) {
       return trimmed;
     }
   } catch {
@@ -223,6 +233,7 @@ function parseTag(raw: string): HtmlToken | undefined {
 
 function tokenizeHtml(html: string): HtmlToken[] {
   const tokens: HtmlToken[] = [];
+  const lowerHtml = html.toLowerCase();
   let i = 0;
 
   while (i < html.length) {
@@ -256,7 +267,7 @@ function tokenizeHtml(html: string): HtmlToken[] {
 
     if (tag.type === "tag" && !tag.closing && RAW_TEXT_TAGS.has(tag.name)) {
       const closeNeedle = `</${tag.name}`;
-      const rawCloseStart = html.toLowerCase().indexOf(closeNeedle, i);
+      const rawCloseStart = lowerHtml.indexOf(closeNeedle, i);
       if (rawCloseStart === -1) {
         i = html.length;
         continue;

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -990,7 +990,7 @@ top of the HTML site.
 | **Agent Skills index** | `public/.well-known/agent-skills/index.json` conforms to cloudflare/agent-skills-discovery-rfc v0.2.0. Publishes `aptos-explorer-urls` and `aptos-explorer-search` skills, each with a SHA-256 `digest`. Regenerate via `node scripts/update-agent-skills-index.mjs`. |
 | **MCP Server Card** | `public/.well-known/mcp/server-card.json` publishes a draft SEP-1649 / SEP-2127 MCP Server Card with `serverInfo`, a WebMCP transport endpoint, read-only tool capabilities, and the currently exposed browser WebMCP navigation tools. Served as `application/json` with CORS enabled for agent discovery. |
 | **Content Signals** | `public/robots.txt` declares `Content-Signal: ai-train=no, search=yes, ai-input=yes` at the top of the file and inside every AI-crawler `User-agent` group (contentsignals.org / draft-romm-aipref-contentsignals). |
-| **Markdown negotiation** | Netlify Edge Function `netlify/edge-functions/markdown-negotiation.ts` returns `/llms.txt` contents with `Content-Type: text/markdown` when the homepage request has `Accept: text/markdown`; HTML remains the default for browsers. Helper: `app/utils/acceptMarkdown.ts` (`prefersMarkdown`). |
+| **Markdown negotiation** | Netlify Edge Function `netlify/edge-functions/markdown-negotiation.ts` intercepts HTML routes when the request has `Accept: text/markdown`, asks the normal SSR/static handler for HTML, converts that response to markdown, and returns `Content-Type: text/markdown` plus `X-Markdown-Tokens`; HTML remains the default for browsers. Helpers: `app/utils/acceptMarkdown.ts` (`prefersMarkdown`) and `app/utils/htmlToMarkdown.ts`. |
 | **WebMCP** | `app/components/WebMCPProvider.tsx` registers read-only navigation tools (`search_explorer`, `open_transaction`, `open_account`, `open_block`, `open_releases`, `open_coin`) on `navigator.modelContext` when supported. Tool definitions live in `app/components/webMcpTools.ts`; registration is cleaned up via `AbortSignal` on unmount. |
 
 ---
@@ -1199,6 +1199,7 @@ top of the HTML site.
 | `app/utils/netlifyHeaders.test.ts` | FEAT-SEO-004 (homepage and global RFC 8288 discovery `Link` headers) |
 | `app/utils/mcpServerCard.test.ts` | FEAT-SEO-004 (MCP Server Card minimum fields and advertised WebMCP tools) |
 | `app/utils/acceptMarkdown.test.ts` | FEAT-SEO-004 (`Accept: text/markdown` negotiation helper) |
+| `app/utils/htmlToMarkdown.test.ts` | FEAT-SEO-004 (HTML-response-to-markdown conversion and `X-Markdown-Tokens` estimate) |
 | `app/components/webMcpTools.test.ts` | FEAT-SEO-004 (WebMCP navigation tools: routing, validation) |
 | `app/utils/routerParams.test.ts` | FEAT-ROUTING-003 (`pathSplatToSegments` normalization) |
 | `app/api/hooks/aptosFeatureFlagsUpstream.test.ts` | FEAT-RELEASES-001 (upstream Rust enum parse for unlisted feature flag names) |

--- a/docs/LLM_ACCESS.md
+++ b/docs/LLM_ACCESS.md
@@ -35,7 +35,7 @@ Searched the app route tree for per-route `head:` callbacks (TanStack Router fil
 | `public/.well-known/api-catalog` | RFC 9727 API catalog (`application/linkset+json`) listing upstream Aptos REST / GraphQL APIs |
 | `public/.well-known/agent-skills/index.json` | Agent Skills Discovery RFC v0.2.0 index; per-skill `SKILL.md` under `public/.well-known/agent-skills/*/` |
 | `netlify.toml` | `Link` response headers (RFC 8288) on `/` and `/*` pointing to the discovery files |
-| `netlify/edge-functions/markdown-negotiation.ts` | Serves `/llms.txt` as `Content-Type: text/markdown` when the request has `Accept: text/markdown` |
+| `netlify/edge-functions/markdown-negotiation.ts` | Converts HTML route responses to `Content-Type: text/markdown` when the request has `Accept: text/markdown`; browser HTML remains the default |
 | `app/components/WebMCPProvider.tsx` + `app/components/webMcpTools.ts` | `navigator.modelContext` tools for browser-resident agents |
 
 Root [`app/routes/__root.tsx`](../app/routes/__root.tsx) exposes `<link rel="help">` / `alternate` hints to the LLM text files and mounts `<WebMCPProvider />`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,15 +8,11 @@
 [build.environment]
   NODE_VERSION = "20"
 
-# Markdown-for-Agents negotiation on the homepage. See
+# Markdown-for-Agents negotiation for HTML routes. See
 # netlify/edge-functions/markdown-negotiation.ts for details.
 [[edge_functions]]
   function = "markdown-negotiation"
-  path = "/"
-
-[[edge_functions]]
-  function = "markdown-negotiation"
-  path = "/index.html"
+  path = "/*"
 
 # Headers for security and caching
 [[headers]]
@@ -40,7 +36,7 @@
   for = "/"
   [headers.values]
     Vary = "Accept"
-    Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
+    Link = '''</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json", </.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"; title="MCP Server Card", </llms.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Summary)", </llms-full.txt>; rel="alternate"; type="text/plain"; title="LLM Documentation (Full)", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
 
 [[headers]]
   for = "/assets/*"

--- a/netlify/edge-functions/markdown-negotiation.ts
+++ b/netlify/edge-functions/markdown-negotiation.ts
@@ -1,4 +1,8 @@
 import type {Config, Context} from "@netlify/edge-functions";
+import {
+  estimateMarkdownTokens,
+  htmlToMarkdown,
+} from "../../app/utils/htmlToMarkdown.ts";
 // Shared with the app (unit-tested in app/utils/acceptMarkdown.test.ts).
 // Netlify Edge Functions run under Deno and support TypeScript imports from
 // inside the repo, so we re-use the single implementation instead of keeping
@@ -10,21 +14,52 @@ import {prefersMarkdown} from "../../app/utils/acceptMarkdown.ts";
  *
  * When a client sends `Accept: text/markdown` (or `text/markdown` appears
  * anywhere in the Accept header with non-zero q-value, e.g. Cloudflare's
- * "Markdown for Agents" pattern), we return a pre-rendered markdown view of
- * the page instead of the HTML SPA shell.
+ * "Markdown for Agents" pattern), we ask the normal SSR/static handler for
+ * HTML and convert that HTML response to markdown at the edge.
  *
  * Strategy:
- *  - `/` (and a small set of top-level landing paths) → serve the short LLM
- *    reference (`/llms.txt`) with `Content-Type: text/markdown`.
- *  - Fall through to the default HTML handler for all other paths and for
- *    requests without a markdown preference in Accept.
+ *  - Requests without a markdown preference fall through unchanged.
+ *  - Markdown requests keep the default browser behavior downstream by sending
+ *    `Accept: text/html`; this avoids SSR/content-type negotiation surprises.
+ *  - Only HTML responses are transformed. Assets, API responses, and direct
+ *    text files pass through unchanged.
  *
- * This gives AI agents a stable, concise markdown summary of the Explorer
- * without shipping a full HTML→markdown converter at the edge. The full LLM
- * reference stays available at `/llms-full.txt`.
+ * This gives AI agents a markdown representation of the same route browsers
+ * see while preserving HTML as the default.
  */
+function appendVary(headers: Headers, value: string) {
+  const current = headers.get("Vary");
+  if (!current) {
+    headers.set("Vary", value);
+    return;
+  }
 
-const MARKDOWN_ROUTES: ReadonlySet<string> = new Set(["/", "/index.html"]);
+  const values = current.split(",").map((part) => part.trim().toLowerCase());
+  if (!values.includes(value.toLowerCase())) {
+    headers.set("Vary", `${current}, ${value}`);
+  }
+}
+
+function isHtmlResponse(response: Response): boolean {
+  return response.headers.get("Content-Type")?.includes("text/html") ?? false;
+}
+
+function createHtmlRequest(request: Request): Request {
+  const headers = new Headers(request.headers);
+  headers.set(
+    "Accept",
+    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  );
+
+  if (request.method === "HEAD") {
+    return new Request(request.url, {
+      headers,
+      method: "GET",
+    });
+  }
+
+  return new Request(request, {headers});
+}
 
 export default async function handler(
   request: Request,
@@ -35,31 +70,12 @@ export default async function handler(
   const accept = request.headers.get("accept");
   if (!prefersMarkdown(accept)) return undefined;
 
-  const url = new URL(request.url);
-  if (!MARKDOWN_ROUTES.has(url.pathname)) {
-    // For non-landing paths we still let the HTML handler respond. Agents that
-    // want full markdown reference should fetch /llms-full.txt directly.
-    return undefined;
-  }
+  const response = await context.next(createHtmlRequest(request));
+  if (!isHtmlResponse(response)) return response;
 
-  const llmsUrl = new URL("/llms.txt", url.origin);
-  const upstream = await context.fetch(llmsUrl.toString(), {
-    headers: {Accept: "text/plain"},
-  });
+  const headers = new Headers(response.headers);
 
-  if (!upstream.ok) {
-    // Fall through to the default HTML renderer rather than returning 500.
-    return undefined;
-  }
-
-  const body = request.method === "HEAD" ? null : await upstream.text();
-  const headers = new Headers();
   headers.set("Content-Type", "text/markdown; charset=utf-8");
-  headers.set(
-    "Cache-Control",
-    "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",
-  );
-  headers.set("Vary", "Accept");
   headers.set(
     "Link",
     [
@@ -70,11 +86,30 @@ export default async function handler(
       '</sitemap.xml>; rel="sitemap"; type="application/xml"',
     ].join(", "),
   );
-  headers.set("X-Markdown-Source", "/llms.txt");
+  headers.set("X-Markdown-Source", "html-response");
+  appendVary(headers, "Accept");
+  headers.delete("Content-Encoding");
+  headers.delete("Content-Length");
 
-  return new Response(body, {status: 200, headers});
+  if (request.method === "HEAD") {
+    return new Response(null, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+
+  const html = await response.text();
+  const markdown = htmlToMarkdown(html, request.url);
+  headers.set("X-Markdown-Tokens", String(estimateMarkdownTokens(markdown)));
+
+  return new Response(markdown, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 export const config: Config = {
-  path: ["/", "/index.html"],
+  path: "/*",
 };

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -420,13 +420,15 @@ Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+j
 
 ### Markdown content negotiation
 
-When a request to `/` (or `/index.html`) includes `Accept: text/markdown`,
-a Netlify Edge Function (`netlify/edge-functions/markdown-negotiation.ts`)
-serves the contents of `/llms.txt` with `Content-Type: text/markdown;
-charset=utf-8`, a `Vary: Accept` header, and an `X-Markdown-Source` hint
-pointing to the underlying file. Browsers (which request `text/html`) are
-unaffected — they still receive the SSR HTML. For the full markdown
-reference, agents should fetch `/llms-full.txt` directly.
+When an HTML route request includes `Accept: text/markdown`, a Netlify Edge
+Function (`netlify/edge-functions/markdown-negotiation.ts`) fetches the normal
+HTML response, converts it to markdown, and returns it with
+`Content-Type: text/markdown; charset=utf-8`, `Vary: Accept`,
+`X-Markdown-Source: html-response`, and `X-Markdown-Tokens`. Browsers (which
+request `text/html`) are unaffected — they still receive the SSR HTML. Static
+assets, APIs, and direct text files pass through with their original response
+types. For the full markdown reference, agents should fetch `/llms-full.txt`
+directly.
 
 ### WebMCP tools
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes Markdown-for-Agents negotiation so `Accept: text/markdown` requests are handled as middleware for HTML routes instead of fetching `/llms.txt` from the edge function. The edge function now asks the normal SSR/static handler for HTML, converts that response to markdown, and returns `Content-Type: text/markdown; charset=utf-8` with `X-Markdown-Tokens` and `Vary: Accept`. Browser requests continue to receive HTML by default, and non-HTML responses pass through unchanged.

Also adds unit coverage for the HTML-to-markdown conversion/token estimate and updates FEAT-SEO-004 docs plus the LLM reference.

Follow-up for CodeQL/review comments:
- Replaced regex-based HTML stripping with a tokenizer/parser that skips raw-text elements and escapes literal angle brackets from text nodes before emitting markdown.
- Markdown link/image emission now uses an explicit URL allowlist (`http:`, `https:`, and root-relative URLs), so unsafe schemes such as `javascript:`, `data:`, and `vbscript:` are not emitted.
- Scheme-relative (`//...`) and backslash-prefixed URLs are rejected.
- Raw-text close-tag scanning reuses a single lowercase HTML copy.
- Markdown `HEAD` responses skip HTML body parsing/token estimation.

Rebased onto latest `main` (`6b071d05`).

### Related Links

- https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md
- https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/

### Checklist

- [x] `pnpm fmt`
- [x] `pnpm lint`
- [x] `pnpm test --run`
- [x] `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8422d6bb-b8cd-463f-8383-8f5970b34d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8422d6bb-b8cd-463f-8383-8f5970b34d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

