### PR TITLE
fix(releases): split fullnode vs validator-set node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Network deployments — separate fullnode vs validator node software**: `/releases/networks` cards now label **Fullnode** release/commit from the explorer's configured Aptos REST URL (`GET …/v1/` `git_hash`) and show **Validator set** release/commit separately by sampling active validators: DNS names are parsed from on-chain `network_addresses` / `fullnode_addresses`, a handful of hosts are probed for `git_hash`, and the most common hash drives the row (tooltips explain the sampling). This avoids treating the API gateway fullnode as representative of validator binaries.
+
 - **Releases / Feature flags**: Registered Aptos feature flag **112** as “Versioned Transaction Validation”. For IDs not yet in the explorer’s static list, names are now resolved on the fly from the aptos-core `FeatureFlag` enum (via a CORS-friendly mirror), falling back to “Feature #N” only when that fetch fails.
 
 - **Header — compact layout earlier on medium widths**: the main nav, wallet, and settings now switch to the hamburger menu at the `lg` breakpoint (~1200px) instead of `md` (~900px), so the top bar no longer crowds or clips between those widths.

--- a/app/api/hooks/useGetNetworkStatus.test.ts
+++ b/app/api/hooks/useGetNetworkStatus.test.ts
@@ -59,7 +59,11 @@ describe("fetchNetworkStatus", () => {
     expect(result.blockHeight).toBe("5000000");
     expect(result.ledgerVersion).toBe("10000000");
     expect(result.chainId).toBe("1");
-    expect(result.gitHash).toBe("9bd3d6d15afcf579d4745b761fe8913026354f9d");
+    expect(result.fullnodeGitHash).toBe(
+      "9bd3d6d15afcf579d4745b761fe8913026354f9d",
+    );
+    expect(result.validatorSetGitHash).toBeNull();
+    expect(result.gitHash).toBe(result.fullnodeGitHash);
     expect(result.frameworkRelease).toBe("1.43");
     expect(result.gasFeatureVersion).toBe(47);
     expect(result.bytecodeFormatVersion).toBe(6);
@@ -104,8 +108,9 @@ describe("fetchNetworkStatus", () => {
     expect(result.bytecodeFormatVersion).toBeNull();
     expect(result.validatorCount).toBeNull();
     expect(result.enabledFeatures).toBeNull();
-    // The mock ledger always supplies a git_hash; gitHash should pass through.
-    expect(result.gitHash).toBe("9bd3d6d15afcf579d4745b761fe8913026354f9d");
+    expect(result.fullnodeGitHash).toBe(mockLedger.git_hash);
+    expect(result.validatorSetGitHash).toBeNull();
+    expect(result.gitHash).toBe(result.fullnodeGitHash);
   });
 
   it("uses null frameworkRelease when gas feature_version is unmapped", async () => {
@@ -170,6 +175,67 @@ describe("fetchNetworkStatus", () => {
     );
 
     const result = await fetchNetworkStatus("devnet");
+    expect(result.fullnodeGitHash).toBeNull();
+    expect(result.validatorSetGitHash).toBeNull();
     expect(result.gitHash).toBeNull();
+  });
+
+  it("sets validatorSetGitHash from probing advertised validator REST endpoints", async () => {
+    const validatorHex =
+      "016804023d76616c696461746f722e62626237366432642d303262352d346533652d626663332d3966313061326536393834392e6170746f732e6269736f6e2e72756e05241807203601215a079b0114a32104bd02149cf2258a206c8f8c79790e0684f4adfeae400800";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith("/")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockLedger),
+          });
+        }
+        if (url.includes("0x1::gas_schedule::GasScheduleV2")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({data: {feature_version: "47", entries: []}}),
+          });
+        }
+        if (url.includes("0x1::stake::ValidatorSet")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                data: {
+                  active_validators: [
+                    {config: {network_addresses: validatorHex}},
+                  ],
+                },
+              }),
+          });
+        }
+        if (url.includes("0x1::features::Features")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({data: {features: "0x220082"}}),
+          });
+        }
+        if (url.includes("aptos.bison.run")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                git_hash:
+                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              }),
+          });
+        }
+        return Promise.resolve({ok: false, status: 404});
+      }),
+    );
+
+    const result = await fetchNetworkStatus("mainnet");
+    expect(result.validatorSetGitHash).toBe(
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    expect(result.fullnodeGitHash).toBe(mockLedger.git_hash);
   });
 });

--- a/app/api/hooks/useGetNetworkStatus.test.ts
+++ b/app/api/hooks/useGetNetworkStatus.test.ts
@@ -186,6 +186,17 @@ describe("fetchNetworkStatus", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation((url: string) => {
+        // Validator probes use GET …/v1/ on operator DNS names — match before the
+        // generic "/" branch or they'd receive mockLedger.
+        if (url.includes("aptos.bison.run")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                git_hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              }),
+          });
+        }
         if (url.endsWith("/")) {
           return Promise.resolve({
             ok: true,
@@ -216,16 +227,6 @@ describe("fetchNetworkStatus", () => {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({data: {features: "0x220082"}}),
-          });
-        }
-        if (url.includes("aptos.bison.run")) {
-          return Promise.resolve({
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                git_hash:
-                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-              }),
           });
         }
         return Promise.resolve({ok: false, status: 404});

--- a/app/api/hooks/useGetNetworkStatus.ts
+++ b/app/api/hooks/useGetNetworkStatus.ts
@@ -4,7 +4,18 @@ import {
   frameworkReleaseFromGasFeatureVersion,
   maxBytecodeFormatVersionFromFlags,
 } from "../../utils/aptosDeploymentVersions";
+import {
+  extractAdvertisedHostnameFromAddressBlob,
+  fetchGitHashFromAdvertisedHostname,
+  mapWithConcurrency,
+  modeGitHash,
+  normalizeAptosCoreGitHash,
+} from "../../utils/aptosValidatorAdvertisedHosts";
 import {decodeFeatureBitmap} from "./aptosFeatureFlags";
+
+/** Sample size + concurrency for probing validators' advertised REST endpoints. */
+const VALIDATOR_GIT_HASH_SAMPLE = 12;
+const VALIDATOR_PROBE_CONCURRENCY = 4;
 
 export type NetworkStatus = {
   healthy: boolean;
@@ -12,7 +23,23 @@ export type NetworkStatus = {
   blockHeight: string;
   ledgerVersion: string;
   chainId: string;
-  /** Aptos node software git commit hash from `GET /v1/` `git_hash`. */
+  /**
+   * `git_hash` from the configured Aptos API gateway / fullnode (`GET …/v1/`).
+   * This reflects whichever node backs the explorer's REST URL, not an individual
+   * validator.
+   */
+  fullnodeGitHash: string | null;
+  /**
+   * Representative `git_hash` for the active validator set: sampled from
+   * on-chain `ValidatorSet` by probing a few operators' advertised hostnames
+   * (see `network_addresses` / `fullnode_addresses` blobs) for `GET /v1/`.
+   * `null` when we could not reach any sampled endpoint.
+   */
+  validatorSetGitHash: string | null;
+  /**
+   * @deprecated Use `fullnodeGitHash` (API endpoint) or `validatorSetGitHash`
+   * (validator set). Kept as an alias of `fullnodeGitHash` for older consumers.
+   */
   gitHash: string | null;
   /**
    * Mapped framework release train from `gasFeatureVersion` (e.g. `"1.43"`).
@@ -80,11 +107,43 @@ export async function fetchNetworkStatus(
   }
 
   let validatorCount: number | null = null;
+  let validatorSetGitHash: string | null = null;
   if (sResult.status === "fulfilled" && sResult.value.ok) {
     const s = (await sResult.value.json()) as {
-      data: {active_validators: unknown[]};
+      data: {
+        active_validators: Array<{
+          config?: {
+            network_addresses?: string;
+            fullnode_addresses?: string;
+          };
+        }>;
+      };
     };
     validatorCount = s.data.active_validators.length;
+
+    const hostnames = new Set<string>();
+    for (const v of s.data.active_validators.slice(0, VALIDATOR_GIT_HASH_SAMPLE)) {
+      const cfg = v.config;
+      if (!cfg) continue;
+      for (const key of [
+        "network_addresses",
+        "fullnode_addresses",
+      ] as const) {
+        const hex = cfg[key];
+        if (typeof hex !== "string") continue;
+        const host = extractAdvertisedHostnameFromAddressBlob(hex);
+        if (host) hostnames.add(host);
+      }
+    }
+
+    if (hostnames.size > 0) {
+      const hashes = await mapWithConcurrency(
+        [...hostnames],
+        VALIDATOR_PROBE_CONCURRENCY,
+        (hostname) => fetchGitHashFromAdvertisedHostname(hostname),
+      );
+      validatorSetGitHash = modeGitHash(hashes.filter((h): h is string => !!h));
+    }
   }
 
   let enabledFeatures: number[] | null = null;
@@ -98,13 +157,17 @@ export async function fetchNetworkStatus(
     bytecodeFormatVersion = maxBytecodeFormatVersionFromFlags(enabledFeatures);
   }
 
+  const fullnodeGitHash = normalizeAptosCoreGitHash(ledger.git_hash);
+
   return {
     healthy: true,
     epoch: String(ledger.epoch),
     blockHeight: String(ledger.block_height),
     ledgerVersion: String(ledger.ledger_version),
     chainId: String(ledger.chain_id),
-    gitHash: ledger.git_hash ?? null,
+    fullnodeGitHash,
+    validatorSetGitHash,
+    gitHash: fullnodeGitHash,
     frameworkRelease,
     gasFeatureVersion,
     bytecodeFormatVersion,
@@ -115,9 +178,10 @@ export async function fetchNetworkStatus(
 
 export function useGetNetworkStatus(networkName: NetworkName) {
   return useQuery({
-    queryKey: ["deployments", "networkStatus", networkName],
+    queryKey: ["deployments", "networkStatus", "v2", networkName],
     queryFn: () => fetchNetworkStatus(networkName),
-    staleTime: 60_000,
+    // Validator probes hit third-party operator endpoints — avoid hammering them on rapid refetch.
+    staleTime: 5 * 60_000,
     retry: 1,
   });
 }

--- a/app/pages/Deployments/NetworkCard.tsx
+++ b/app/pages/Deployments/NetworkCard.tsx
@@ -66,28 +66,36 @@ export function NetworkCard({network}: {network: NetworkName}) {
     });
   };
 
-  const gitHash = data?.gitHash ?? null;
-  const shortHash = gitHash ? gitHash.slice(0, 7) : null;
-  const {data: release, isFetching: releaseFetching} =
-    useGetNodeReleaseFromCommit(gitHash);
-
-  // `branchVersion` is contractually `X.Y` (the parser refuses malformed
-  // three-component tags). Guard at the consumer too: anything that isn't
-  // exactly `digits.digits` falls back to the commit-only display rather
-  // than rendering `v1.43.1.x` or linking to a non-existent
-  // `aptos-release-v1.43.1` branch.
-  const branchVersion =
-    release?.branchVersion && /^\d+\.\d+$/.test(release.branchVersion)
-      ? release.branchVersion
-      : null;
-  const releaseLabel = release?.fullVersion
-    ? `v${release.fullVersion}`
-    : branchVersion
-      ? `v${branchVersion}.x`
-      : null;
-  const releaseBranchUrl = branchVersion
-    ? `https://github.com/aptos-labs/aptos-core/tree/aptos-release-v${branchVersion}`
+  const fullnodeGitHash = data?.fullnodeGitHash ?? data?.gitHash ?? null;
+  const validatorSetGitHash = data?.validatorSetGitHash ?? null;
+  const fullnodeShort = fullnodeGitHash ? fullnodeGitHash.slice(0, 7) : null;
+  const validatorShort = validatorSetGitHash
+    ? validatorSetGitHash.slice(0, 7)
     : null;
+
+  const {data: fullnodeRelease, isFetching: fullnodeReleaseFetching} =
+    useGetNodeReleaseFromCommit(fullnodeGitHash);
+  const {data: validatorRelease, isFetching: validatorReleaseFetching} =
+    useGetNodeReleaseFromCommit(validatorSetGitHash);
+
+  function releasePresentation(release: typeof fullnodeRelease) {
+    const branchVersion =
+      release?.branchVersion && /^\d+\.\d+$/.test(release.branchVersion)
+        ? release.branchVersion
+        : null;
+    const releaseLabel = release?.fullVersion
+      ? `v${release.fullVersion}`
+      : branchVersion
+        ? `v${branchVersion}.x`
+        : null;
+    const releaseBranchUrl = branchVersion
+      ? `https://github.com/aptos-labs/aptos-core/tree/aptos-release-v${branchVersion}`
+      : null;
+    return {releaseLabel, releaseBranchUrl};
+  }
+
+  const fullnodeRel = releasePresentation(fullnodeRelease);
+  const validatorRel = releasePresentation(validatorRelease);
 
   return (
     <Card variant="outlined" sx={{height: "100%"}}>
@@ -151,37 +159,78 @@ export function NetworkCard({network}: {network: NetworkName}) {
               }
             />
             <StatusRow
-              label="Node Release"
+              label="Fullnode Release"
               value={
-                releaseFetching && gitHash ? (
+                fullnodeReleaseFetching && fullnodeGitHash ? (
                   <CircularProgress size={12} />
-                ) : releaseLabel && releaseBranchUrl ? (
+                ) : fullnodeRel.releaseLabel && fullnodeRel.releaseBranchUrl ? (
                   <Link
-                    href={releaseBranchUrl}
+                    href={fullnodeRel.releaseBranchUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     underline="hover"
                   >
-                    {releaseLabel}
+                    {fullnodeRel.releaseLabel}
                   </Link>
                 ) : null
               }
             />
             <StatusRow
-              label="Node Commit"
+              label="Fullnode Commit"
               value={
-                gitHash && shortHash ? (
-                  <Tooltip title={gitHash}>
+                fullnodeGitHash && fullnodeShort ? (
+                  <Tooltip title={fullnodeGitHash}>
                     <Link
-                      href={`https://github.com/aptos-labs/aptos-core/commit/${gitHash}`}
+                      href={`https://github.com/aptos-labs/aptos-core/commit/${fullnodeGitHash}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       underline="hover"
                     >
-                      {shortHash}
+                      {fullnodeShort}
                     </Link>
                   </Tooltip>
                 ) : null
+              }
+            />
+            <StatusRow
+              label="Validator Set Release"
+              value={
+                <Tooltip title="Most common git_hash among a sample of active validators, by probing on-chain advertised REST hostnames (not the API gateway fullnode).">
+                  <span>
+                    {validatorReleaseFetching && validatorSetGitHash ? (
+                      <CircularProgress size={12} />
+                    ) : validatorRel.releaseLabel &&
+                      validatorRel.releaseBranchUrl ? (
+                      <Link
+                        href={validatorRel.releaseBranchUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="hover"
+                      >
+                        {validatorRel.releaseLabel}
+                      </Link>
+                    ) : null}
+                  </span>
+                </Tooltip>
+              }
+            />
+            <StatusRow
+              label="Validator Set Commit"
+              value={
+                <Tooltip title="Most common git_hash among a sample of active validators (see Validator Set Release).">
+                  <span>
+                    {validatorSetGitHash && validatorShort ? (
+                      <Link
+                        href={`https://github.com/aptos-labs/aptos-core/commit/${validatorSetGitHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="hover"
+                      >
+                        {validatorShort}
+                      </Link>
+                    ) : null}
+                  </span>
+                </Tooltip>
               }
             />
             <StatusRow label="Validators" value={data.validatorCount} />

--- a/app/utils/aptosValidatorAdvertisedHosts.test.ts
+++ b/app/utils/aptosValidatorAdvertisedHosts.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from "vitest";
+import {
+  extractAdvertisedHostnameFromAddressBlob,
+  modeGitHash,
+  normalizeAptosCoreGitHash,
+} from "./aptosValidatorAdvertisedHosts";
+
+// Covers FEAT-RELEASES-001 (validator advertised hostname parsing helpers)
+
+describe("normalizeAptosCoreGitHash", () => {
+  it("accepts lowercase 40-char hex", () => {
+    const h = "9bd3d6d15afcf579d4745b761fe8913026354f9d";
+    expect(normalizeAptosCoreGitHash(h)).toBe(h);
+  });
+
+  it("normalizes uppercase to lowercase", () => {
+    expect(
+      normalizeAptosCoreGitHash("9BD3D6D15AFCF579D4745B761FE8913026354F9D"),
+    ).toBe("9bd3d6d15afcf579d4745b761fe8913026354f9d");
+  });
+
+  it("rejects wrong length and non-hex", () => {
+    expect(normalizeAptosCoreGitHash("abc")).toBeNull();
+    expect(normalizeAptosCoreGitHash("g" + "0".repeat(39))).toBeNull();
+    expect(normalizeAptosCoreGitHash(null)).toBeNull();
+  });
+});
+
+describe("extractAdvertisedHostnameFromAddressBlob", () => {
+  it("extracts DNS hostname from mainnet-style validator blob", () => {
+    const hex =
+      "016804023d76616c696461746f722e62626237366432642d303262352d346533652d626663332d3966313061326536393834392e6170746f732e6269736f6e2e72756e05241807203601215a079b0114a32104bd02149cf2258a206c8f8c79790e0684f4adfeae400800";
+    expect(extractAdvertisedHostnameFromAddressBlob(hex)).toBe(
+      "validator.bbb76d2d-02b5-4e3e-bfc3-9f10a2e69849.aptos.bison.run",
+    );
+  });
+
+  it("returns null for empty or unusable blobs", () => {
+    expect(extractAdvertisedHostnameFromAddressBlob("")).toBeNull();
+    expect(extractAdvertisedHostnameFromAddressBlob("0x00")).toBeNull();
+    expect(extractAdvertisedHostnameFromAddressBlob("zz")).toBeNull();
+  });
+});
+
+describe("modeGitHash", () => {
+  it("returns the hash with highest count, lexicographic tie-break", () => {
+    expect(modeGitHash(["a".repeat(40), "a".repeat(40), "b".repeat(40)])).toBe(
+      "a".repeat(40),
+    );
+    expect(modeGitHash(["c".repeat(40), "b".repeat(40), "b".repeat(40)])).toBe(
+      "b".repeat(40),
+    );
+  });
+
+  it("returns null for empty input", () => {
+    expect(modeGitHash([])).toBeNull();
+  });
+});

--- a/app/utils/aptosValidatorAdvertisedHosts.test.ts
+++ b/app/utils/aptosValidatorAdvertisedHosts.test.ts
@@ -21,7 +21,7 @@ describe("normalizeAptosCoreGitHash", () => {
 
   it("rejects wrong length and non-hex", () => {
     expect(normalizeAptosCoreGitHash("abc")).toBeNull();
-    expect(normalizeAptosCoreGitHash("g" + "0".repeat(39))).toBeNull();
+    expect(normalizeAptosCoreGitHash(`g${"0".repeat(39)}`)).toBeNull();
     expect(normalizeAptosCoreGitHash(null)).toBeNull();
   });
 });

--- a/app/utils/aptosValidatorAdvertisedHosts.ts
+++ b/app/utils/aptosValidatorAdvertisedHosts.ts
@@ -1,0 +1,142 @@
+/**
+ * On-chain `ValidatorConfig.{network_addresses,fullnode_addresses}` values are
+ * length-prefixed blobs that embed a DNS hostname as printable ASCII.
+ * We recover the longest plausible hostname substring for REST probing.
+ *
+ * This is a best-effort parse — operators sometimes publish addresses that do
+ * not expose a public `GET /v1/` listener on standard ports.
+ */
+const HOSTNAME_SUBSTRING_RE =
+  /[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?\.[a-zA-Z]{2,}/g;
+
+export function extractAdvertisedHostnameFromAddressBlob(
+  hexMaybeWith0x: string,
+): string | null {
+  const trimmed = hexMaybeWith0x.trim();
+  if (!trimmed || trimmed === "0x00" || trimmed === "00") return null;
+  const hex = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
+  if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
+    return null;
+  }
+  let raw: Uint8Array;
+  try {
+    raw = Uint8Array.from(
+      hex.match(/.{1,2}/g)!.map((byte) => Number.parseInt(byte, 16)),
+    );
+  } catch {
+    return null;
+  }
+  if (raw.length === 0) return null;
+  const latin1 = new TextDecoder("latin1").decode(raw);
+  let best: string | null = null;
+  let bestLen = 0;
+  HOSTNAME_SUBSTRING_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HOSTNAME_SUBSTRING_RE.exec(latin1)) !== null) {
+    const host = m[0];
+    if (host.length >= bestLen) {
+      bestLen = host.length;
+      best = host;
+    }
+  }
+  return best;
+}
+
+/** 40-char lowercase hex aptos-core commit sha */
+const GIT_HASH_RE = /^[0-9a-f]{40}$/;
+
+export function normalizeAptosCoreGitHash(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const h = raw.trim().toLowerCase();
+  return GIT_HASH_RE.test(h) ? h : null;
+}
+
+export async function fetchLedgerGitHashFromBaseUrl(
+  baseUrl: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const url = `${baseUrl.replace(/\/$/, "")}/`;
+  try {
+    const res = await fetch(url, {signal});
+    if (!res.ok) return null;
+    const data = (await res.json()) as {git_hash?: string};
+    return normalizeAptosCoreGitHash(data.git_hash);
+  } catch {
+    return null;
+  }
+}
+
+const PROBE_TIMEOUT_MS = 4500;
+
+function probeUrlsForHostname(hostname: string): string[] {
+  return [
+    `https://${hostname}/v1`,
+    `http://${hostname}:8080/v1`,
+    `http://${hostname}:8180/v1`,
+  ];
+}
+
+/**
+ * Try common HTTPS / HTTP+port shapes against an advertised hostname.
+ * No Authorization header — these are third-party operator endpoints.
+ */
+export async function fetchGitHashFromAdvertisedHostname(
+  hostname: string,
+): Promise<string | null> {
+  const bases = probeUrlsForHostname(hostname);
+  const attempts = bases.map((base) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    return fetchLedgerGitHashFromBaseUrl(base, controller.signal).finally(() =>
+      clearTimeout(timer),
+    );
+  });
+  const results = await Promise.allSettled(attempts);
+  for (const r of results) {
+    if (r.status === "fulfilled" && r.value) return r.value;
+  }
+  return null;
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]!, i);
+    }
+  }
+
+  const workers = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({length: workers}, () => worker()));
+  return results;
+}
+
+/** Pick the most frequent hash; break ties with lexicographic order (deterministic). */
+export function modeGitHash(hashes: readonly string[]): string | null {
+  if (hashes.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const h of hashes) {
+    counts.set(h, (counts.get(h) ?? 0) + 1);
+  }
+  let best: string | null = null;
+  let bestCount = -1;
+  for (const [h, c] of counts) {
+    if (
+      c > bestCount ||
+      (c === bestCount && best !== null && h.localeCompare(best) < 0)
+    ) {
+      bestCount = c;
+      best = h;
+    }
+  }
+  return best;
+}

--- a/app/utils/aptosValidatorAdvertisedHosts.ts
+++ b/app/utils/aptosValidatorAdvertisedHosts.ts
@@ -18,11 +18,11 @@ export function extractAdvertisedHostnameFromAddressBlob(
   if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
     return null;
   }
+  const bytePairs = hex.match(/.{1,2}/g);
+  if (!bytePairs) return null;
   let raw: Uint8Array;
   try {
-    raw = Uint8Array.from(
-      hex.match(/.{1,2}/g)!.map((byte) => Number.parseInt(byte, 16)),
-    );
+    raw = Uint8Array.from(bytePairs.map((pair) => Number.parseInt(pair, 16)));
   } catch {
     return null;
   }
@@ -31,9 +31,10 @@ export function extractAdvertisedHostnameFromAddressBlob(
   let best: string | null = null;
   let bestLen = 0;
   HOSTNAME_SUBSTRING_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = HOSTNAME_SUBSTRING_RE.exec(latin1)) !== null) {
-    const host = m[0];
+  for (;;) {
+    const match = HOSTNAME_SUBSTRING_RE.exec(latin1);
+    if (match === null) break;
+    const host = match[0];
     if (host.length >= bestLen) {
       bestLen = host.length;
       best = host;
@@ -111,7 +112,9 @@ export async function mapWithConcurrency<T, R>(
     for (;;) {
       const i = next++;
       if (i >= items.length) return;
-      results[i] = await fn(items[i]!, i);
+      const item = items[i];
+      if (item === undefined) return;
+      results[i] = await fn(item, i);
     }
   }
 

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -1161,6 +1161,7 @@ top of the HTML site.
 | **Framework release** | Shown per network from `0x1::gas_schedule::GasScheduleV2.feature_version`, mapped to a framework train via aptos-core `gas_feature_versions` (`app/utils/aptosDeploymentVersions.ts`). When unmapped, UI shows `gas N (unmapped)` and `frameworkRelease` in API data is `null`. |
 | **Bytecode format (max)** | Highest Move module bytecode format enabled, derived from VM Binary Format feature flags (see `maxBytecodeFormatVersionFromFlags`). |
 | **Feature flags** | Table compares on-chain `0x1::features::Features` per network. Static labels mirror aptos-core `FeatureFlag`; labels not yet in the static list are filled from live aptos-core source when available (jsDelivr mirror). |
+| **Fullnode vs validator `git_hash`** | **Fullnode commit/release** comes from `GET {network REST base}/v1/` on the configured API URL (the gateway node). **Validator set commit/release** is estimated by sampling the active `ValidatorSet`: extract DNS hostnames from on-chain `network_addresses` / `fullnode_addresses` blobs, probe each host for `GET …/v1/` `git_hash`, and take the mode among successful probes (tooltips explain sampling). Operator endpoints may be unreachable from the browser or omit REST — rows stay empty instead of falling back to the gateway hash. |
 
 ---
 
@@ -1206,6 +1207,7 @@ top of the HTML site.
 | `app/utils/routerParams.test.ts` | FEAT-ROUTING-003 (`pathSplatToSegments` normalization) |
 | `app/api/hooks/aptosFeatureFlagsUpstream.test.ts` | FEAT-RELEASES-001 (upstream Rust enum parse for unlisted feature flag names) |
 | `app/api/hooks/useGetNetworkStatus.test.ts` | FEAT-RELEASES-001 (`fetchNetworkStatus`) |
+| `app/utils/aptosValidatorAdvertisedHosts.test.ts` | FEAT-RELEASES-001 (validator advertised hostname parsing + mode git hash) |
 | `app/utils/mapWithConcurrencyLimit.test.ts` | FEAT-BLOCKS-001 (bounded concurrency for batched REST fetches) |
 | `app/utils/sentioCallTrace.test.ts` | FEAT-TXN-010 (Sentio helpers: network ID, paths, address normalization, node validation) |
 | `app/api/client.test.ts` | FEAT-RATELIMIT-003 (API error classification, 429 → `emitRateLimit`) |

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Aptos Explorer — Full LLM Reference
 
-> Last updated: 2026-04-30 (rev 18)
+> Last updated: 2026-05-01 (rev 19)
 
 > Comprehensive reference for AI systems interacting with or answering questions about the Aptos Explorer at [explorer.aptoslabs.com](https://explorer.aptoslabs.com).
 
@@ -104,7 +104,7 @@ Each detail page has tabs accessible via path segments:
 #### Releases Hub
 - `/releases` — top-level hub for everything network-version-related; redirects to the `networks` tab by default
   - `/releases/networks` — live deployment status across mainnet / testnet / devnet
-    - Per-network card: epoch, block height, ledger version, chain ID, **framework release** derived from `0x1::gas_schedule::GasScheduleV2.feature_version` (mapped to aptos-core `gas_feature_versions` in `aptos-gas-schedule/src/ver.rs`, e.g. `1.43`; unmapped versions show as `gas N (unmapped)`), **bytecode format (max)** from VM Binary Format feature flags (highest Move module bytecode version accepted), node release (e.g. `v1.43.2`, resolved from `git_hash` via the GitHub commit message), node commit (short hash linked to `aptos-labs/aptos-core`), validator count, healthy/down chip
+    - Per-network card: epoch, block height, ledger version, chain ID, **framework release** derived from `0x1::gas_schedule::GasScheduleV2.feature_version` (mapped to aptos-core `gas_feature_versions` in `aptos-gas-schedule/src/ver.rs`, e.g. `1.43`; unmapped versions show as `gas N (unmapped)`), **bytecode format (max)** from VM Binary Format feature flags (highest Move module bytecode version accepted), **fullnode** release + commit from the configured REST gateway's `GET /v1/` `git_hash`, **validator set** release + commit estimated by probing on-chain advertised validator/fullnode hostnames from `ValidatorSet` (mode among a sample — not the gateway node), validator count, healthy/down chip
     - **Feature Flags by Network** comparison table sourced from `0x1::features::Features`; default view shows only flags whose enabled state differs across mainnet/testnet/devnet, with chip filters for All / Differences / Enabled (anywhere) / Disabled (everywhere). Names mirror the `FeatureFlag` Rust enum in `aptos-core`
   - `/releases/aips` — Aptos Improvement Proposals index sourced from `aptos-foundation/AIPs`
     - Sortable by AIP #, title, status, author; status filter chips (Draft / Last Call / Accepted / Final / Withdrawn / Living); each row deep-links to the proposal markdown on GitHub

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -49,7 +49,7 @@ All URLs default to mainnet. Append `?network=testnet`, `?network=devnet`, or `?
 - Verification: `/verification`
 - Releases hub: `/releases` (redirects to default tab `networks`)
   - Tabs: `/releases/networks`, `/releases/aips`, `/releases/sdks`
-  - Networks tab — live deployment status (epoch, block height, framework release from gas schedule, max Move bytecode format, node release, node commit, validators, feature flag comparison) for mainnet, testnet, and devnet
+  - Networks tab — live deployment status (epoch, block height, framework release from gas schedule, max Move bytecode format, fullnode release/commit from the REST gateway, validator-set release/commit sampled from on-chain advertised hosts, validators, feature flag comparison) for mainnet, testnet, and devnet
   - AIPs tab — Aptos Improvement Proposals index sourced from `aptos-foundation/AIPs` (number, title, status, author, link)
   - SDKs & Tools tab — latest stable releases for the Aptos CLI, `aptos-node`, and the TypeScript / Python / Rust / Go SDKs, with a drill-in list of recent versions per registry
   - Legacy paths `/deployments` and `/aips` redirect to `/releases/networks` and `/releases/aips` respectively


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Network cards on `/releases/networks` previously showed a single **Node Release** / **Node Commit** pair sourced from `GET …/v1/` on the configured Aptos REST URL. That `git_hash` reflects the **gateway fullnode**, not active validators.

This change:

- Keeps **Fullnode Release** / **Fullnode Commit** tied to the explorer’s configured REST base URL (`fullnodeGitHash`, still exposed as `gitHash` for backward compatibility).
- Adds **Validator Set Release** / **Validator Set Commit** by sampling the on-chain `ValidatorSet`: extract DNS hostnames from `network_addresses` / `fullnode_addresses` blobs for the first validators, probe common REST URL shapes (`https://host/v1`, `http://host:8080/v1`, `http://host:8180/v1`), take the **mode** among successful `git_hash` responses, and resolve both rows via the existing GitHub commit-message parser.

Operator endpoints may be unreachable from browsers (firewall, TLS, non-standard ports, or CORS). In those cases the validator rows stay empty rather than reusing the gateway hash; tooltips explain the sampling.

## Tests / verification

- Added `app/utils/aptosValidatorAdvertisedHosts.test.ts` (hostname extraction, hash normalization, mode).
- Extended `useGetNetworkStatus.test.ts` with a probe mock.

CI initially failed **Biome** on `aptosValidatorAdvertisedHosts.ts` (non-null assertions, assignment-in-while). Follow-up commit fixes those.

## Docs

- Updated `docs/FEATURES_SPECIFICATION.md` (FEAT-RELEASES-001), `CHANGELOG.md`, `public/llms.txt`, and `public/llms-full.txt`.
- Bumped React Query key to `["deployments","networkStatus","v2",network]` and increased stale time to 5 minutes to reduce repeated third-party probing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6285ceb3-9c81-4cd3-9dc1-15baffa8e8d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6285ceb3-9c81-4cd3-9dc1-15baffa8e8d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

