### PR TITLE
feat(txn): conditional Modules tab for package publish and bytecode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Transaction detail — Modules tab**: When a transaction publishes or upgrades Move packages (`PublishPackage` events) or touches module bytecode (`write_module` / `delete_module` write-set changes), the explorer shows a **Modules** tab before **Changes** with publish addresses and per-module rows (with links to the account module code view when the module name is known).
+
 - **Confidential assets — aggregate supply and account hints**: fungible asset and coin info tabs show **Confidential supply (pool)** from `0x1::confidential_asset::get_total_confidential_supply` when the view succeeds. The account **Coins** tab calls `has_confidential_store` per FA metadata (v2 balances, or v1 when Panora lists a paired `faAddress`); when initialized, the row shows the actual visible balance/USD and a new **Confidential** column displays a `VisibilityOff` icon (with tooltip) signalling that an additional encrypted balance exists. Mobile card view shows the same icon next to the verification badge.
 
 - **Agent-readiness discovery surfaces**: the explorer now ships structured metadata for autonomous agents and LLM-powered crawlers:

--- a/app/pages/Transaction/Tabs.tsx
+++ b/app/pages/Transaction/Tabs.tsx
@@ -8,6 +8,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import ShowChartOutlinedIcon from "@mui/icons-material/ShowChartOutlined";
+import ViewModuleOutlinedIcon from "@mui/icons-material/ViewModuleOutlined";
 import {
   Accordion,
   AccordionDetails,
@@ -42,10 +43,27 @@ import GenesisTransactionOverviewTab from "./Tabs/GenesisTransactionOverviewTab"
 import PayloadTab from "./Tabs/PayloadTab";
 import PendingTransactionOverviewTab from "./Tabs/PendingTransactionOverviewTab";
 import StateCheckpointOverviewTab from "./Tabs/StateCheckpointOverviewTab";
+import TransactionModulesTab from "./Tabs/TransactionModulesTab";
 import TransactionTraceTab from "./Tabs/TransactionTraceTab";
 import UnknownTab from "./Tabs/UnknownTab";
 import UserTransactionOverviewTab from "./Tabs/UserTransactionOverviewTab";
 import ValidatorTransactionTab from "./Tabs/ValidatorTransactionTab";
+import {transactionHasModuleSummary} from "./transactionModuleChanges";
+
+function insertModulesTabBeforeChanges(tabs: TabValue[]): TabValue[] {
+  const i = tabs.indexOf("changes");
+  if (i === -1) return [...tabs, "modules"];
+  return [...tabs.slice(0, i), "modules", ...tabs.slice(i)];
+}
+
+function withModulesTabWhenApplicable(
+  transaction: Types.Transaction,
+  tabs: TabValue[],
+): TabValue[] {
+  return transactionHasModuleSummary(transaction)
+    ? insertModulesTabBeforeChanges(tabs)
+    : tabs;
+}
 
 export function getTabValues(transaction: Types.Transaction): TabValue[] {
   switch (transaction.type) {
@@ -55,22 +73,43 @@ export function getTabValues(transaction: Types.Transaction): TabValue[] {
         tabs.push("decibelDetail");
       }
       tabs.push("balanceChange", "events", "payload", "changes", "trace");
-      return tabs;
+      return withModulesTabWhenApplicable(transaction, tabs);
     }
     case TransactionTypeName.BlockMetadata:
-      return ["blockMetadataOverview", "events", "changes"];
+      return withModulesTabWhenApplicable(transaction, [
+        "blockMetadataOverview",
+        "events",
+        "changes",
+      ]);
     case TransactionTypeName.StateCheckpoint:
       return ["stateCheckpointOverview"];
     case TransactionTypeName.Pending:
       return ["pendingTxnOverview", "payload"];
     case TransactionTypeName.Genesis:
-      return ["genesisTxnOverview", "events", "payload", "changes"];
+      return withModulesTabWhenApplicable(transaction, [
+        "genesisTxnOverview",
+        "events",
+        "payload",
+        "changes",
+      ]);
     case TransactionTypeName.Validator:
-      return ["validatorTxnOverview", "events", "changes"];
+      return withModulesTabWhenApplicable(transaction, [
+        "validatorTxnOverview",
+        "events",
+        "changes",
+      ]);
     case TransactionTypeName.BlockEpilogue:
-      return ["blockEpilogueOverview", "events", "changes"];
+      return withModulesTabWhenApplicable(transaction, [
+        "blockEpilogueOverview",
+        "events",
+        "changes",
+      ]);
     default:
-      return ["unknown", "events", "changes"];
+      return withModulesTabWhenApplicable(transaction, [
+        "unknown",
+        "events",
+        "changes",
+      ]);
   }
 }
 
@@ -86,6 +125,7 @@ const TabComponents = Object.freeze({
   balanceChange: BalanceChangeTab,
   events: EventsTab,
   payload: PayloadTab,
+  modules: TransactionModulesTab,
   changes: ChangesTab,
   trace: TransactionTraceTab,
   unknown: UnknownTab,
@@ -112,6 +152,8 @@ function getTabLabel(value: TabValue): string {
       return "Events";
     case "payload":
       return "Payload";
+    case "modules":
+      return "Modules";
     case "changes":
       return "Changes";
     case "trace":
@@ -139,6 +181,8 @@ function getTabIcon(value: TabValue): React.JSX.Element {
       return <CallMergeOutlinedIcon fontSize="small" />;
     case "payload":
       return <FileCopyOutlinedIcon fontSize="small" />;
+    case "modules":
+      return <ViewModuleOutlinedIcon fontSize="small" />;
     case "changes":
       return <CodeOutlinedIcon fontSize="small" />;
     case "trace":

--- a/app/pages/Transaction/Tabs/TransactionModulesTab.tsx
+++ b/app/pages/Transaction/Tabs/TransactionModulesTab.tsx
@@ -1,0 +1,163 @@
+import {InfoOutlined} from "@mui/icons-material";
+import ViewModuleOutlinedIcon from "@mui/icons-material/ViewModuleOutlined";
+import {
+  Alert,
+  Box,
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import type React from "react";
+import type {Types} from "~/types/aptos";
+import HashButton, {HashType} from "../../../components/HashButton";
+import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {Link} from "../../../routing";
+import {tryStandardizeAddress} from "../../../utils";
+import {getTransactionModuleSummary} from "../transactionModuleChanges";
+
+type TransactionModulesTabProps = {
+  transaction: Types.Transaction;
+};
+
+function moduleCodePath(address: string, moduleName: string): string {
+  const std = tryStandardizeAddress(address) ?? address;
+  return `/account/${std}/modules/code/${encodeURIComponent(moduleName)}`;
+}
+
+export default function TransactionModulesTab({
+  transaction,
+}: TransactionModulesTabProps): React.JSX.Element {
+  const summary = getTransactionModuleSummary(transaction);
+
+  if (!summary) {
+    return <EmptyTabContent />;
+  }
+
+  const {publishPackageEvents, moduleChanges} = summary;
+
+  return (
+    <Stack spacing={3} sx={{mt: 2}}>
+      <Alert severity="info" icon={<InfoOutlined />}>
+        <Typography variant="body2" component="span">
+          Package publishes are inferred from{" "}
+          <Typography component="span" variant="body2" fontFamily="monospace">
+            PublishPackage
+          </Typography>{" "}
+          events. Module installs and removals come from{" "}
+          <Typography component="span" variant="body2" fontFamily="monospace">
+            write_module
+          </Typography>{" "}
+          and{" "}
+          <Typography component="span" variant="body2" fontFamily="monospace">
+            delete_module
+          </Typography>{" "}
+          write-set changes (same source as the Changes tab).
+        </Typography>
+      </Alert>
+
+      {publishPackageEvents.length > 0 && (
+        <Box>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1.5}}>
+            <ViewModuleOutlinedIcon fontSize="small" color="action" />
+            <Typography variant="h6" component="h2">
+              Package publish
+            </Typography>
+          </Stack>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Code address</TableCell>
+                <TableCell width={160}>Kind</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {publishPackageEvents.map((row) => (
+                <TableRow key={`publish:${row.codeAddress}:${String(row.isUpgrade)}`}>
+                  <TableCell>
+                    <HashButton
+                      hash={row.codeAddress}
+                      type={HashType.ACCOUNT}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={row.isUpgrade ? "Upgrade" : "New publish"}
+                      color={row.isUpgrade ? "warning" : "success"}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      )}
+
+      {moduleChanges.length > 0 && (
+        <Box>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1.5}}>
+            <ViewModuleOutlinedIcon fontSize="small" color="action" />
+            <Typography variant="h6" component="h2">
+              Module bytecode changes
+            </Typography>
+          </Stack>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell width={120}>Change</TableCell>
+                <TableCell>Address</TableCell>
+                <TableCell>Module</TableCell>
+                <TableCell width={100} align="right">
+                  Explorer
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {moduleChanges.map((row) => (
+                <TableRow key={`${row.kind}:${row.address}:${row.moduleName}`}>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={row.kind === "write_module" ? "Write" : "Delete"}
+                      color={row.kind === "write_module" ? "primary" : "error"}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <HashButton hash={row.address} type={HashType.ACCOUNT} />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" fontFamily="monospace">
+                      {row.moduleName}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {row.kind === "write_module" &&
+                    row.moduleName !== "(module name unavailable)" ? (
+                      <Link
+                        to={moduleCodePath(row.address, row.moduleName)}
+                        underline="hover"
+                      >
+                        Code
+                      </Link>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/app/pages/Transaction/transactionModuleChanges.test.ts
+++ b/app/pages/Transaction/transactionModuleChanges.test.ts
@@ -1,0 +1,167 @@
+// Covers FEAT-TXN-012 — transaction module / package summary parsing
+import {describe, expect, it} from "vitest";
+import type {Types} from "~/types/aptos";
+import {
+  getTransactionModuleSummary,
+  PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX,
+  transactionHasModuleSummary,
+} from "./transactionModuleChanges";
+
+function userTxn(
+  partial: Partial<Types.Transaction_UserTransaction>,
+): Types.Transaction_UserTransaction {
+  return {
+    type: "user_transaction",
+    version: "1",
+    hash: "0xabc",
+    state_change_hash: "0x",
+    event_root_hash: "0x",
+    state_checkpoint_hash: null,
+    gas_used: "0",
+    success: true,
+    vm_status: "Executed successfully",
+    accumulator_root_hash: "0x",
+    changes: [],
+    sender: "0xa",
+    sequence_number: "0",
+    max_gas_amount: "0",
+    gas_unit_price: "0",
+    expiration_timestamp_secs: "0",
+    payload: {
+      type: "entry_function_payload",
+      function: "0x1::a::b",
+      type_arguments: [],
+      arguments: [],
+    },
+    events: [],
+    timestamp: "0",
+    ...partial,
+  };
+}
+
+describe("FEAT-TXN-012 — getTransactionModuleSummary", () => {
+  it("returns null when there are no publish events and no module write-set rows", () => {
+    const txn = userTxn({
+      changes: [
+        {
+          type: "write_resource",
+          address: "0x1",
+          state_key_hash: "0x",
+          data: {type: "0x1::account::Account", data: {}},
+        },
+      ],
+      events: [
+        {
+          guid: {creation_number: "0", account_address: "0x1"},
+          sequence_number: "1",
+          type: "0x1::coin::DepositEvent",
+          data: {},
+        },
+      ],
+    });
+    expect(getTransactionModuleSummary(txn)).toBeNull();
+    expect(transactionHasModuleSummary(txn)).toBe(false);
+  });
+
+  it("collects write_module rows with ABI module names", () => {
+    const txn = userTxn({
+      changes: [
+        {
+          type: "write_module",
+          address: "0xbeef",
+          state_key_hash: "0x",
+          data: {
+            bytecode: "0x",
+            abi: {
+              address: "0xbeef",
+              name: "my_module",
+              friends: [],
+              exposed_functions: [],
+              structs: [],
+            },
+          },
+        },
+      ],
+    });
+    const s = getTransactionModuleSummary(txn);
+    expect(s).not.toBeNull();
+    expect(s?.moduleChanges).toEqual([
+      {kind: "write_module", address: "0xbeef", moduleName: "my_module"},
+    ]);
+    expect(s?.publishPackageEvents).toEqual([]);
+  });
+
+  it("uses a placeholder when write_module has no ABI name", () => {
+    const txn = userTxn({
+      changes: [
+        {
+          type: "write_module",
+          address: "0xbeef",
+          state_key_hash: "0x",
+          data: {bytecode: "0x"},
+        },
+      ],
+    });
+    expect(
+      getTransactionModuleSummary(txn)?.moduleChanges[0]?.moduleName,
+    ).toBe("(module name unavailable)");
+  });
+
+  it("collects delete_module rows", () => {
+    const txn = userTxn({
+      changes: [
+        {
+          type: "delete_module",
+          address: "0xdead",
+          state_key_hash: "0x",
+          module: "gone",
+        },
+      ],
+    });
+    expect(getTransactionModuleSummary(txn)?.moduleChanges).toEqual([
+      {kind: "delete_module", address: "0xdead", moduleName: "gone"},
+    ]);
+  });
+
+  it("parses PublishPackage events by type suffix and snake_case fields", () => {
+    const txn = userTxn({
+      changes: [],
+      events: [
+        {
+          guid: {creation_number: "0", account_address: "0x0"},
+          sequence_number: "0",
+          type: `0x0000000000000000000000000000000000000000000000000000000000000001${PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX}`,
+          data: {
+            code_address:
+              "0x0000000000000000000000000000000000000000000000000000000000cafe",
+            is_upgrade: true,
+          },
+        },
+      ],
+    });
+    const s = getTransactionModuleSummary(txn);
+    expect(s?.publishPackageEvents).toEqual([
+      {
+        codeAddress:
+          "0x0000000000000000000000000000000000000000000000000000000000cafe",
+        isUpgrade: true,
+      },
+    ]);
+  });
+
+  it("treats string is_upgrade truthy values as upgrade", () => {
+    const txn = userTxn({
+      events: [
+        {
+          guid: {creation_number: "0", account_address: "0x0"},
+          sequence_number: "0",
+          type: `0x1${PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX}`,
+          data: {code_address: "0x2", is_upgrade: "true"},
+        },
+      ],
+    });
+    expect(
+      getTransactionModuleSummary(txn)?.publishPackageEvents?.[0]?.isUpgrade,
+    ).toBe(true);
+  });
+});

--- a/app/pages/Transaction/transactionModuleChanges.ts
+++ b/app/pages/Transaction/transactionModuleChanges.ts
@@ -1,0 +1,106 @@
+import type {Types} from "~/types/aptos";
+
+/** REST / indexer event type for `aptos_framework::code::PublishPackage`. */
+export const PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX = "::code::PublishPackage";
+
+export type PublishPackageEventSummary = {
+  codeAddress: string;
+  isUpgrade: boolean;
+};
+
+export type ModuleWriteSetChangeRow = {
+  kind: "write_module" | "delete_module";
+  address: string;
+  moduleName: string;
+};
+
+export type TransactionModuleSummary = {
+  publishPackageEvents: PublishPackageEventSummary[];
+  moduleChanges: ModuleWriteSetChangeRow[];
+};
+
+function isPublishPackageEventType(type: string): boolean {
+  return type.endsWith(PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX);
+}
+
+function readBool(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function parsePublishPackageEvents(
+  events: Types.Event[],
+): PublishPackageEventSummary[] {
+  const out: PublishPackageEventSummary[] = [];
+  for (const event of events) {
+    if (!isPublishPackageEventType(event.type)) continue;
+    const data =
+      typeof event.data === "object" &&
+      event.data !== null &&
+      !Array.isArray(event.data)
+        ? (event.data as Record<string, unknown>)
+        : null;
+    const rawAddr = data?.code_address;
+    if (typeof rawAddr !== "string" || !rawAddr) continue;
+    out.push({
+      codeAddress: rawAddr,
+      isUpgrade: readBool(data?.is_upgrade),
+    });
+  }
+  return out;
+}
+
+function moduleNameFromWriteModule(
+  change: Types.WriteSetChange & {type: "write_module"},
+): string {
+  const name = change.data?.abi?.name;
+  if (typeof name === "string" && name.length > 0) return name;
+  return "(module name unavailable)";
+}
+
+function parseModuleChangesFromWriteSet(
+  changes: Types.WriteSetChange[],
+): ModuleWriteSetChangeRow[] {
+  const rows: ModuleWriteSetChangeRow[] = [];
+  for (const change of changes) {
+    if (change.type === "write_module") {
+      rows.push({
+        kind: "write_module",
+        address: change.address,
+        moduleName: moduleNameFromWriteModule(change),
+      });
+    } else if (change.type === "delete_module") {
+      rows.push({
+        kind: "delete_module",
+        address: change.address,
+        moduleName: change.module,
+      });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Summarizes package publish signals and module bytecode changes for a transaction.
+ * Returns `null` when there is nothing to show (no matching events or write-set rows).
+ */
+export function getTransactionModuleSummary(
+  transaction: Types.Transaction,
+): TransactionModuleSummary | null {
+  const changes = "changes" in transaction ? transaction.changes : [];
+  const events = "events" in transaction ? transaction.events : [];
+
+  const publishPackageEvents = parsePublishPackageEvents(events);
+  const moduleChanges = parseModuleChangesFromWriteSet(changes);
+
+  if (publishPackageEvents.length === 0 && moduleChanges.length === 0) {
+    return null;
+  }
+
+  return {publishPackageEvents, moduleChanges};
+}
+
+export function transactionHasModuleSummary(
+  transaction: Types.Transaction,
+): boolean {
+  return getTransactionModuleSummary(transaction) !== null;
+}

--- a/app/pages/Transaction/transactionTabMeta.ts
+++ b/app/pages/Transaction/transactionTabMeta.ts
@@ -11,6 +11,8 @@ export function getTransactionTabHeadLabel(tab: string | undefined): string {
       return "Events";
     case "payload":
       return "Payload";
+    case "modules":
+      return "Modules";
     case "changes":
       return "Changes";
     default:

--- a/app/pages/Transaction/txnTabValues.test.ts
+++ b/app/pages/Transaction/txnTabValues.test.ts
@@ -1,8 +1,10 @@
 // Covers FEAT-TXN-001 — Transaction tab selection by type
+// Covers FEAT-TXN-012 — Conditional Modules tab for package / bytecode changes
 import {describe, expect, it} from "vitest";
 import {TransactionTypeName} from "../../components/TransactionType";
 import {DECIBEL_CONTRACTS} from "../../utils/decibel";
 import {getTabValues} from "./Tabs";
+import {PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX} from "./transactionModuleChanges";
 
 function makeTxn(type: string) {
   return {type} as Parameters<typeof getTabValues>[0];
@@ -19,6 +21,47 @@ describe("FEAT-TXN-001 — getTabValues", () => {
       "changes",
       "trace",
     ]);
+  });
+
+  it("includes modules tab before changes when write_module changes exist", () => {
+    const txn = {
+      type: TransactionTypeName.User,
+      changes: [
+        {
+          type: "write_module",
+          address: "0x1",
+          state_key_hash: "0x",
+          data: {
+            bytecode: "0x",
+            abi: {
+              address: "0x1",
+              name: "m",
+              friends: [],
+              exposed_functions: [],
+              structs: [],
+            },
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof getTabValues>[0];
+    const tabs = getTabValues(txn);
+    expect(tabs).toContain("modules");
+    expect(tabs.indexOf("modules")).toBe(tabs.indexOf("changes") - 1);
+  });
+
+  it("includes modules tab when PublishPackage events exist", () => {
+    const txn = {
+      type: TransactionTypeName.User,
+      events: [
+        {
+          guid: {creation_number: "0", account_address: "0x0"},
+          sequence_number: "0",
+          type: `0x1${PUBLISH_PACKAGE_EVENT_TYPE_SUFFIX}`,
+          data: {code_address: "0x2", is_upgrade: false},
+        },
+      ],
+    } as unknown as Parameters<typeof getTabValues>[0];
+    expect(getTabValues(txn)).toContain("modules");
   });
 
   it("includes decibelDetail tab for Decibel user transactions", () => {

--- a/app/utils/llmsRouteCoverage.test.ts
+++ b/app/utils/llmsRouteCoverage.test.ts
@@ -34,6 +34,8 @@ const REQUIRED_PATH_SNIPPETS = [
   "balanceChange",
   /** User transaction Sentio call trace tab */
   "/trace",
+  /** Conditional transaction tab — Move package / module changes */
+  "/modules",
   /** Account multisig tab */
   "/multisig",
   /** Validators enhanced delegation tab */

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -176,14 +176,14 @@ The app shell that wraps every page.
 
 | Transaction Type | Available Tabs |
 |------------------|----------------|
-| User | Overview, Balance Change, Events, Payload, Changes, Trace |
-| Block metadata | Overview, Events, Changes |
+| User | Overview, Balance Change, Events, Payload, Modules (when package/modules changed), Changes, Trace |
+| Block metadata | Overview, Events, Modules (when applicable), Changes |
 | State checkpoint | Overview |
 | Pending | Overview, Payload |
-| Genesis | Overview, Events, Payload, Changes |
-| Validator | Overview, Events, Changes |
-| Block epilogue | Overview, Events, Changes |
-| Unknown | Overview, Events, Changes |
+| Genesis | Overview, Events, Payload, Modules (when applicable), Changes |
+| Validator | Overview, Events, Modules (when applicable), Changes |
+| Block epilogue | Overview, Events, Modules (when applicable), Changes |
+| Unknown | Overview, Events, Modules (when applicable), Changes |
 
 ### FEAT-TXN-002 — User Transaction Overview
 
@@ -206,6 +206,14 @@ The app shell that wraps every page.
 | **Views** | Aggregated and non-aggregated balance changes. |
 | **Verification filter** | Mainnet: Verified / Recognized / All asset filter via `VerifiedCell`. |
 | **Table** | Address, asset, amount, type columns. |
+
+### FEAT-TXN-012 — Modules Tab (package / bytecode changes)
+
+| Aspect | Detail |
+|--------|--------|
+| **Visibility** | Shown only when the transaction has at least one `0x1::code::PublishPackage`-style event (type suffix `::code::PublishPackage`) or write-set rows `write_module` / `delete_module`. Inserted immediately before **Changes** when present (user, genesis, validator, block metadata/epilogue, unknown types). |
+| **Publish rows** | Lists `code_address` and **New publish** vs **Upgrade** from event `is_upgrade`. |
+| **Bytecode rows** | Lists each `write_module` / `delete_module` with account address and module name (from module ABI when available). **Code** link opens `/account/{address}/modules/code/{module}` for successful writes with a known module name. |
 
 ### FEAT-TXN-004 — Events Tab
 
@@ -1231,7 +1239,8 @@ top of the HTML site.
 | `e2e/transaction-balance-change.spec.ts` | FEAT-TXN-003 (Playwright: testnet Balance Change tab loads indexer FA activities; asserts gas-fee row; skips outside CI when testnet gateway returns 401 for local preview origin) |
 | `app/pages/Transaction/Tabs/Components/SignatureOverviewTable.test.tsx` | FEAT-TXN-002 (signature overview: Ed25519, multi-Ed25519, single_sender, multi_agent, fee_payer, fallbacks; stable keys for duplicate secondary addresses) |
 | `app/pages/Transaction/Tabs/Components/moveParamTypeDisplay.test.ts` | FEAT-TXN-011 (Move type display badges) |
-| `app/pages/Transaction/txnTabValues.test.ts` | FEAT-TXN-001 (tab selection by transaction type, trace tab only for user txns) |
+| `app/pages/Transaction/txnTabValues.test.ts` | FEAT-TXN-001 (tab selection by transaction type, trace tab only for user txns), FEAT-TXN-012 (conditional Modules tab) |
+| `app/pages/Transaction/transactionModuleChanges.test.ts` | FEAT-TXN-012 (parse PublishPackage events and module write-set rows) |
 | `app/pages/Transaction/txnTabInvariants.test.ts` | FEAT-TXN-009 (DEX/LSD protocol coverage), TransactionTypeName enum values |
 | `app/pages/Account/hooks/useAccountTabValues.test.ts` | FEAT-ACCOUNT-005 (tab set computation: all GraphQL/object/multisig combos, invariants) |
 | `app/pages/Account/Tabs/ModulesTab/Contract.test.ts` | FEAT-MODULES-001 (contract result utilities, copy serialization) |

--- a/public/.well-known/agent-skills/aptos-explorer-urls/SKILL.md
+++ b/public/.well-known/agent-skills/aptos-explorer-urls/SKILL.md
@@ -12,7 +12,7 @@ Canonical URL templates for [Aptos Explorer](https://explorer.aptoslabs.com). Al
 ## Entity → URL template
 
 - **Transaction**: `/txn/{version}` or `/txn/{hash}`
-  - Tabs: `/txn/{id}/userTxnOverview`, `/events`, `/payload`, `/changes`, `/balanceChange`, `/trace`
+  - Tabs: `/txn/{id}/userTxnOverview`, `/events`, `/payload`, `/modules` (when applicable), `/changes`, `/balanceChange`, `/trace`
 - **Account**: `/account/{address}` (redirects to `/transactions`)
   - Tabs: `/transactions`, `/coins`, `/tokens`, `/resources`, `/modules`, `/multisig`, `/info`
   - Modules: `/modules/packages`, `/modules/code/{moduleName}`, `/modules/run/{moduleName}/{functionName}`, `/modules/view/{moduleName}/{functionName}`

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Map questions about Aptos blockchain entities (transactions, accounts, blocks, validators, coins, fungible assets, NFTs, Move objects, ANS names) to canonical Aptos Explorer URLs at explorer.aptoslabs.com. Use when a user asks to look up on-chain data on Aptos, wants to share or generate an explorer link, or needs to decide between transaction version, hash, account address, ANS name, or coin type identifiers.",
       "url": "/.well-known/agent-skills/aptos-explorer-urls/SKILL.md",
-      "digest": "sha256:f1487a1f72695ee99e10d1bb45e89e74b189f803336174b533366abf8b83e381"
+      "digest": "sha256:422d330e26901e04c4c477e54ae12cca0a972ec37ba02f33d00888adc924f8d2"
     },
     {
       "name": "aptos-explorer-search",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Aptos Explorer — Full LLM Reference
 
-> Last updated: 2026-04-30 (rev 18)
+> Last updated: 2026-05-05 (rev 19)
 
 > Comprehensive reference for AI systems interacting with or answering questions about the Aptos Explorer at [explorer.aptoslabs.com](https://explorer.aptoslabs.com).
 
@@ -45,7 +45,7 @@ Each detail page has tabs accessible via path segments:
   - `?fn={entry_function_id}` — filter by entry function (e.g. `?fn=0x1::coin::transfer`). On the User Transactions view this is server-side filtering via the indexer; on the All Transactions view it filters client-side on the current page.
 - `/txn/{version}` — transaction by version number (integer)
 - `/txn/{hash}` — transaction by hash (0x-prefixed hex)
-- Tab paths: `/txn/{id}/userTxnOverview`, `/txn/{id}/events`, `/txn/{id}/payload`, `/txn/{id}/changes`, `/txn/{id}/balanceChange`, `/txn/{id}/trace`
+- Tab paths: `/txn/{id}/userTxnOverview`, `/txn/{id}/events`, `/txn/{id}/payload`, `/txn/{id}/modules` (when the transaction emits package-publish signals or includes module write-set changes), `/txn/{id}/changes`, `/txn/{id}/balanceChange`, `/txn/{id}/trace`
   - **Trace** (`/txn/{id}/trace`): experimental **Move call trace** for user transactions (mainnet only). Fetches execution tree from Sentio’s public API when you open the tab; links into this explorer (callee account, module **Run** and **Code** tabs) plus Sentio’s interactive viewer.
 
 #### Accounts

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,7 +21,7 @@ All URLs default to mainnet. Append `?network=testnet`, `?network=devnet`, or `?
 **Crawlers and automated fetchers:** The site’s `robots.txt` disallows many bots from URLs that include `?network=devnet` or `?network=local` (testnet links are still crawlable but generally less useful). Use plain mainnet paths (no `network` query param) when linking for tools that crawl pages; humans can still switch network via the query param or UI.
 
 - Transaction: `/txn/{version}` or `/txn/{hash}`
-  - Tabs: `/txn/{id}/userTxnOverview`, `/txn/{id}/events`, `/txn/{id}/payload`, `/txn/{id}/changes`, `/txn/{id}/balanceChange`, `/txn/{id}/trace` (experimental Sentio Move call trace, mainnet)
+  - Tabs: `/txn/{id}/userTxnOverview`, `/txn/{id}/events`, `/txn/{id}/payload`, `/txn/{id}/modules` (when the tx publishes or upgrades Move modules), `/txn/{id}/changes`, `/txn/{id}/balanceChange`, `/txn/{id}/trace` (experimental Sentio Move call trace, mainnet)
 - Account: `/account/{address}`
   - Tabs: `/account/{address}/transactions`, `/account/{address}/coins`, `/account/{address}/tokens`, `/account/{address}/resources`, `/account/{address}/modules`, `/account/{address}/multisig`, `/account/{address}/info`
   - Modules sub-tabs: `/account/{address}/modules/packages`, `/account/{address}/modules/code/{moduleName}`, `/account/{address}/modules/run/{moduleName}/{functionName}`, `/account/{address}/modules/view/{moduleName}/{functionName}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Modules** tab on transaction detail pages when the REST payload signals Move package publication or module bytecode updates:

- **Events**: rows whose type ends with `::code::PublishPackage` (framework module events) are summarized as code address + **New publish** vs **Upgrade** using `code_address` and `is_upgrade`.
- **Write set**: `write_module` and `delete_module` changes list account address and module name (from module ABI when present).

The tab is inserted immediately before **Changes** for transaction kinds that already expose **Changes** (user, genesis, validator, block metadata/epilogue, unknown). Pending and state-checkpoint transactions are unchanged.

## Testing

- `pnpm fmt && pnpm lint && pnpm test --run`

## Docs / discovery

- Updated `public/llms.txt`, `public/llms-full.txt`, LLM route drift test snippet, `docs/FEATURES_SPECIFICATION.md` (**FEAT-TXN-012**), `CHANGELOG.md`, and regenerated `public/.well-known/agent-skills/index.json` after editing `aptos-explorer-urls` skill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bae5f5fe-4104-4d53-a811-6f02e2173e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bae5f5fe-4104-4d53-a811-6f02e2173e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

