### PR TITLE
fix(validators): load the delegation list whether or not a wallet is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Validators page: minute-long load with wallet connected**: The Delegation tab (`/validators/delegation` and `/validators/enhanced_delegation`) no longer waits up to a minute to display the validator list when a wallet is connected. Previously, `useValidatorDelegationData` triggered one sequential `0x1::delegation_pool::get_stake` view call per validator (~150 on mainnet) just to populate the "My Deposit" column, and the entire table render was gated on those calls finishing. `getBatchUserStakes` now first asks the indexer (`delegator_distinct_pool`) which pools the connected wallet actually has positions in — typically a handful — and only issues `get_stake` view calls for that subset, in parallel. The validator list itself no longer waits on this query at all: it renders immediately whether the wallet is connected, disconnected, or still loading, and the "My Deposit" column populates progressively. If the indexer call fails or any view call errors out, individual rows fall back to a neutral `0` instead of blocking the whole page.
+
 ### Added
 
 - **PWA share button**: When the explorer is launched as an installed Progressive Web App (display-mode `standalone` or `window-controls-overlay`, plus legacy iOS `navigator.standalone`), the persistent header now shows a Share icon on every page. Tapping it opens the OS share sheet via `navigator.share` with the current page URL and title; on platforms without Web Share, it falls back to copying the URL to the clipboard and shows a "Link copied to clipboard" snackbar. The button is hidden in regular browser tabs to avoid duplicating the address-bar share/copy action. New `useIsStandalonePWA` hook (`app/hooks/useIsStandalonePWA.ts`) and `sharePage` helper (`app/components/layout/sharePage.ts`) cover the detection and share/clipboard logic with unit tests.

--- a/app/pages/Validators/Delegation/hooks/useValidatorDelegationData.ts
+++ b/app/pages/Validators/Delegation/hooks/useValidatorDelegationData.ts
@@ -143,40 +143,50 @@ export function useValidatorDelegationData() {
         accountAddress,
         validatorAddresses,
         aptosClient,
+        networkName,
       );
     },
     enabled:
       connected &&
       !!accountAddress &&
       validatorAddresses.length > 0 &&
-      !!aptosClient,
+      !!aptosClient &&
+      !!networkName,
     staleTime: 60 * 1000,
     gcTime: 10 * 60 * 1000,
   });
 
-  // Combine all data
+  // Combine all data. While user stakes are still loading we leave
+  // `userStake` undefined so `MyDepositCell` shows its neutral placeholder
+  // ("-") instead of briefly flashing "N/A" before the real number arrives.
+  const userStakesPending = connected && !!accountAddress && userStakesLoading;
   const combinedValidators: ValidatorWithExtendedData[] =
     validatorsWithCommissionAndState?.map((validator, index) => {
-      // Ensure validator is treated as an object before spreading
       const validatorObj = validator as unknown as ValidatorData & {
         commission: number;
         status: number;
       };
+      const userStake = userStakesPending
+        ? undefined
+        : (userStakes?.[index] ?? 0);
       return {
         ...validatorObj,
         delegatorCount: delegatorCounts?.[index] || 0,
-        userStake: userStakes?.[index] || 0,
+        userStake,
       };
     }) || [];
 
-  // Determine loading state
-  const isLoading =
-    poolsLoading ||
-    commissionLoading ||
-    delegatorCountsLoading ||
-    (connected && userStakesLoading);
+  // Determine loading state.
+  //
+  // Note: user stakes are intentionally NOT part of the gating loading state.
+  // Previously, blocking on `userStakesLoading` while it issued ~150 sequential
+  // `get_stake` view calls caused the validator list to take up to a minute
+  // to appear whenever a wallet was connected. The "My Deposit" column will
+  // simply show its default placeholder until the per-user data arrives.
+  const isLoading = poolsLoading || commissionLoading || delegatorCountsLoading;
 
-  // Combine errors
+  // Combine errors. We still surface user-stake errors when connected, but
+  // they do not block initial render of the validator list.
   const error =
     commissionError ||
     delegatorCountsError ||

--- a/app/pages/Validators/Delegation/hooks/validatorDataService.test.ts
+++ b/app/pages/Validators/Delegation/hooks/validatorDataService.test.ts
@@ -1,0 +1,141 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import type {AptosClient} from "../../../../api/legacyClient";
+import {Network} from "../../../../constants";
+
+// Covers FEAT-VALIDATORS-003 — Delegation validators table loading behavior.
+//
+// Regression: when a wallet was connected, the table issued one
+// `0x1::delegation_pool::get_stake` view call per validator (~150 on
+// mainnet) sequentially, blocking the entire list from rendering for up
+// to a minute. The fix is to first query the indexer for the small set
+// of pools the user has any position in, and only call `get_stake` for
+// those.
+
+const queryIndexerMock = vi.fn();
+
+vi.mock("../../../../global-config", () => ({
+  getCachedV2Client: () => ({
+    queryIndexer: queryIndexerMock,
+  }),
+}));
+
+// Re-import after mocks are in place.
+import {getBatchUserStakes} from "./validatorDataService";
+
+const POOL_A =
+  "0x000000000000000000000000000000000000000000000000000000000000000a";
+const POOL_B =
+  "0x000000000000000000000000000000000000000000000000000000000000000b";
+const POOL_C =
+  "0x000000000000000000000000000000000000000000000000000000000000000c";
+const USER = "0x1";
+
+describe("getBatchUserStakes", () => {
+  beforeEach(() => {
+    queryIndexerMock.mockReset();
+  });
+
+  it("returns zeros and never calls the view function when the wallet has no delegator positions", async () => {
+    queryIndexerMock.mockResolvedValue({delegator_distinct_pool: []});
+    const view = vi.fn();
+    const client = {view} as unknown as AptosClient;
+
+    const result = await getBatchUserStakes(
+      USER,
+      [POOL_A, POOL_B, POOL_C],
+      client,
+      Network.MAINNET,
+    );
+
+    expect(result).toEqual([0, 0, 0]);
+    expect(view).not.toHaveBeenCalled();
+    expect(queryIndexerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("only calls the view function for pools the wallet actually delegates to", async () => {
+    queryIndexerMock.mockResolvedValue({
+      delegator_distinct_pool: [{pool_address: POOL_B}],
+    });
+    const view = vi.fn(async (payload: {arguments: unknown[]}) => {
+      const pool = payload.arguments[0] as string;
+      if (pool === POOL_B) {
+        // 1 APT in OCTAs across two sub-pools.
+        return ["60000000", "40000000", "0"];
+      }
+      throw new Error(`Unexpected view call for pool ${pool}`);
+    });
+    const client = {view} as unknown as AptosClient;
+
+    const result = await getBatchUserStakes(
+      USER,
+      [POOL_A, POOL_B, POOL_C],
+      client,
+      Network.MAINNET,
+    );
+
+    expect(result).toEqual([0, 1, 0]);
+    expect(view).toHaveBeenCalledTimes(1);
+    expect(view.mock.calls[0]?.[0]).toMatchObject({
+      function: "0x1::delegation_pool::get_stake",
+      arguments: [POOL_B, USER],
+    });
+  });
+
+  it("returns zeros without view calls if the indexer request fails", async () => {
+    queryIndexerMock.mockRejectedValue(new Error("indexer down"));
+    const view = vi.fn();
+    const client = {view} as unknown as AptosClient;
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await getBatchUserStakes(
+      USER,
+      [POOL_A, POOL_B],
+      client,
+      Network.MAINNET,
+    );
+
+    expect(result).toEqual([0, 0]);
+    expect(view).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("treats individual view-call failures as zero without crashing the batch", async () => {
+    queryIndexerMock.mockResolvedValue({
+      delegator_distinct_pool: [{pool_address: POOL_A}, {pool_address: POOL_B}],
+    });
+    const view = vi.fn(async (payload: {arguments: unknown[]}) => {
+      const pool = payload.arguments[0] as string;
+      if (pool === POOL_A) throw new Error("rate limited");
+      if (pool === POOL_B) return ["100000000"];
+      return ["0"];
+    });
+    const client = {view} as unknown as AptosClient;
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await getBatchUserStakes(
+      USER,
+      [POOL_A, POOL_B, POOL_C],
+      client,
+      Network.MAINNET,
+    );
+
+    expect(result).toEqual([0, 1, 0]);
+    expect(view).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
+  });
+
+  it("returns an empty array when there are no validator addresses to look up", async () => {
+    const view = vi.fn();
+    const client = {view} as unknown as AptosClient;
+
+    const result = await getBatchUserStakes(USER, [], client, Network.MAINNET);
+
+    expect(result).toEqual([]);
+    expect(view).not.toHaveBeenCalled();
+    expect(queryIndexerMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/pages/Validators/Delegation/hooks/validatorDataService.ts
+++ b/app/pages/Validators/Delegation/hooks/validatorDataService.ts
@@ -64,74 +64,130 @@ export async function getBatchDelegatorCounts(
   }
 }
 
-/**
- * Process validator addresses in batches
- */
-async function processUserStakesBatched(
-  userAddress: Types.Address,
-  validatorAddresses: Types.Address[],
-  client: AptosClient,
-  batchSize: number = 10,
-): Promise<number[]> {
-  const results: number[] = [];
-
-  for (let i = 0; i < validatorAddresses.length; i += batchSize) {
-    const batch = validatorAddresses.slice(i, i + batchSize);
-    const batchResults: number[] = [];
-
-    for (const validatorAddress of batch) {
-      try {
-        const payload = {
-          function: "0x1::delegation_pool::get_stake",
-          type_arguments: [],
-          arguments: [validatorAddress, userAddress],
-        };
-
-        const response = (await client.view(payload)) as Types.MoveValue[];
-
-        if (Array.isArray(response) && response.length > 0) {
-          let sum = 0;
-          for (const stake of response) {
-            sum += Number(stake.toString());
-          }
-          const totalStake = Math.floor(sum) / 100000000;
-          batchResults.push(totalStake);
-        } else {
-          batchResults.push(0);
-        }
-      } catch (error) {
-        console.error(
-          `Error fetching user stake for validator ${validatorAddress}:`,
-          error,
-        );
-        batchResults.push(0);
-      }
+const USER_DELEGATOR_POOLS_QUERY = `
+  query GetUserDelegatorPools($address: String!) {
+    delegator_distinct_pool(where: {delegator_address: {_eq: $address}}) {
+      pool_address
     }
-
-    results.push(...batchResults);
   }
+`;
 
-  return results;
+/**
+ * Fetch the set of pool addresses the user has any delegation position in,
+ * using the indexer. This is a single GraphQL request that lets us avoid
+ * blasting ~150 sequential `get_stake` view calls (the cause of the
+ * minute-long delay when the wallet is connected).
+ */
+async function getUserDelegatorPools(
+  userAddress: Types.Address,
+  networkName: NetworkName,
+): Promise<Set<string>> {
+  const normalizedUser = tryStandardizeAddress(userAddress) ?? userAddress;
+  const client = getCachedV2Client(networkName);
+  const data = await client.queryIndexer<{
+    delegator_distinct_pool: Array<{pool_address: string}>;
+  }>({
+    query: {
+      query: USER_DELEGATOR_POOLS_QUERY,
+      variables: {address: normalizedUser},
+    },
+  });
+
+  const pools = data?.delegator_distinct_pool ?? [];
+  const result = new Set<string>();
+  for (const pool of pools) {
+    const normalized = tryStandardizeAddress(pool.pool_address);
+    if (normalized) result.add(normalized);
+  }
+  return result;
 }
 
 /**
- * Batch fetch user stakes for multiple validators
+ * Fetch the user's stake for a single pool via the `get_stake` view function.
+ */
+async function fetchUserStakeForPool(
+  userAddress: Types.Address,
+  validatorAddress: Types.Address,
+  client: AptosClient,
+): Promise<number> {
+  try {
+    const payload = {
+      function: "0x1::delegation_pool::get_stake",
+      type_arguments: [],
+      arguments: [validatorAddress, userAddress],
+    };
+    const response = (await client.view(payload)) as Types.MoveValue[];
+    if (!Array.isArray(response) || response.length === 0) return 0;
+    let sum = 0;
+    for (const stake of response) {
+      sum += Number(stake.toString());
+    }
+    return Math.floor(sum) / 100000000;
+  } catch (error) {
+    console.error(
+      `Error fetching user stake for validator ${validatorAddress}:`,
+      error,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Batch fetch user stakes for multiple validators.
+ *
+ * Uses the indexer to first identify the (typically small) subset of pools
+ * the connected wallet has any position in, then issues one `get_stake`
+ * view call per such pool in parallel. Validators the wallet has never
+ * delegated to default to `0` without any view call.
+ *
+ * If the indexer query fails we fall back to returning zeros so the table
+ * still renders even when the wallet is connected; the per-pool data will
+ * surface on the individual validator page where view calls are scoped.
  */
 export async function getBatchUserStakes(
   userAddress: Types.Address,
   validatorAddresses: Types.Address[],
   client: AptosClient,
+  networkName: NetworkName,
 ): Promise<number[]> {
   if (!userAddress || !validatorAddresses.length) return [];
 
+  let userPools: Set<string>;
   try {
-    return await processUserStakesBatched(
-      userAddress,
-      validatorAddresses,
-      client,
-    );
+    userPools = await getUserDelegatorPools(userAddress, networkName);
   } catch (error) {
-    console.error("Error fetching user stakes:", error);
-    throw error;
+    console.error(
+      "Error fetching user delegator pools from indexer; defaulting to 0 stakes",
+      error,
+    );
+    return validatorAddresses.map(() => 0);
   }
+
+  if (userPools.size === 0) {
+    return validatorAddresses.map(() => 0);
+  }
+
+  const stakeByPool = new Map<string, number>();
+  const poolsToFetch = validatorAddresses
+    .map((addr) => ({
+      raw: addr,
+      normalized: tryStandardizeAddress(addr),
+    }))
+    .filter(
+      (entry): entry is {raw: Types.Address; normalized: string} =>
+        !!entry.normalized && userPools.has(entry.normalized),
+    );
+
+  await Promise.all(
+    poolsToFetch.map(async ({raw, normalized}) => {
+      const stake = await fetchUserStakeForPool(userAddress, raw, client);
+      stakeByPool.set(normalized, stake);
+    }),
+  );
+
+  return validatorAddresses.map((addr) => {
+    const normalized = tryStandardizeAddress(addr);
+    if (!normalized) return 0;
+    return stakeByPool.get(normalized) ?? 0;
+  });
 }

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -517,6 +517,7 @@ The app shell that wraps every page.
 | **Columns** | Status, commission, delegator count, rewards earned, delegated amount. |
 | **Wallet-aware** | "My deposit" column when wallet connected (`DEFAULT_COLUMNS` vs `COLUMNS_WITHOUT_WALLET_CONNECTION`). |
 | **Virtualization** | Uses `VirtualizedTableBody`. |
+| **Loading independence** | Table render is **not** gated on per-wallet deposit data: connecting a wallet must not delay or block the validator list. `getBatchUserStakes` first asks the indexer (`delegator_distinct_pool`) which pools the wallet has any position in, then issues `0x1::delegation_pool::get_stake` view calls only for that small subset in parallel, defaulting all other rows to `0`. If the indexer call fails, every row defaults to `0` so the list still renders. |
 
 ### FEAT-VALIDATORS-004 — Validators Map
 
@@ -1236,6 +1237,7 @@ top of the HTML site.
 | `app/pages/Account/utils/accountKeyType.test.ts` | FEAT-ACCOUNT-010 (key type extraction from latest transaction signature: Ed25519, Multi-Ed25519, Single Key, MultiKey, multi-agent / fee-payer unwrap) |
 | `app/api/hooks/useGetAccountResource.test.ts` | FEAT-MODULES-008 (`mapRegistryQueryToAccountPackages`: 404 → empty packages, not error) |
 | `app/api/hooks/useGetValidators.test.ts` | FEAT-VALIDATORS-002 (`buildValidatorsFromSources`: empty stats JSON → chain-only rows + optional operator map; merge when JSON present; patch missing/zero operator_address rows from `0x1::stake::StakePool`; `isOperatorAddressMissing` heuristic) |
+| `app/pages/Validators/Delegation/hooks/validatorDataService.test.ts` | FEAT-VALIDATORS-003 (`getBatchUserStakes`: indexer-first lookup of pools the wallet delegates to; per-row view calls only for that subset in parallel; zero-fallback when indexer fails or individual view calls error; empty-input guard) |
 | `app/api/hooks/useGetFaProperties.test.ts` | FEAT-FA-002 (FA property derivation from resources) |
 | `app/data/coinPropertyOverrides.test.ts` | FEAT-FA-002 / FEAT-COIN-002 (per-network manual overrides for FA mint/burn/freeze/dispatch chips, including mainnet PROPS) |
 | `app/api/hooks/confidentialAssetViews.test.ts` | FEAT-FA-002 / FEAT-COIN-002 / FEAT-ACCOUNT-007 (confidential-asset view response parsing) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The Delegation tab on `/validators` was taking up to a minute (and sometimes never loading without a refresh / wallet reconnect) once a wallet was connected. The moment the wallet was disconnected the full list appeared instantly.

**Root cause** — `useValidatorDelegationData` did two unfortunate things at the same time:

1. `getBatchUserStakes` fired one `0x1::delegation_pool::get_stake` view call per validator (~150 on mainnet) **sequentially** inside a `for` loop, just to populate the "My Deposit" column. With ~150 calls × ~400 ms each (plus retries when the gateway rate-limited), that comfortably hits the ~60 s the user reported.
2. The gating `isLoading` state included `userStakesLoading`, so the entire table waited for those view calls to finish. Disconnecting the wallet removed the column (and therefore the gate), which is why the list reappeared instantly.

**Fix**

- `getBatchUserStakes` now asks the indexer once (`delegator_distinct_pool`) for the small set of pools the connected wallet actually has positions in, then issues `get_stake` view calls only for that subset, in parallel. Validators the wallet has never delegated to default to `0` without any view call. If the indexer call fails — or any individual view call rate-limits / errors — the affected rows fall back to `0` instead of breaking the page.
- The validator list is no longer gated on `userStakesLoading`. The table renders immediately regardless of wallet state; the "My Deposit" column populates progressively. While pending, `userStake` is left `undefined` so `MyDepositCell` shows its neutral `-` placeholder rather than flashing `N/A` before the real number arrives.

**Behavior**

- Disconnected wallet: same as before — list shows immediately, no `My Deposit` column.
- Connected wallet with positions in N pools: list shows immediately; `N` `get_stake` view calls run in parallel; only those rows light up with values.
- Connected wallet with no positions: list shows immediately; zero view calls are issued; column is all `N/A`.
- Indexer outage: list still shows immediately; column degrades to `N/A` everywhere (the per-validator page still uses scoped view calls when you actually navigate there).

### Related Links

User-reported issue: validator list takes ~1 minute to load whenever the wallet is connected; disconnecting the wallet shows the list instantly.

### Checklist

- [x] `pnpm fmt && pnpm lint` clean (TypeScript + Biome).
- [x] `pnpm test --run` — 833 tests pass, including 5 new unit tests for `getBatchUserStakes` covering: indexer-first lookup, parallel-subset fetch, indexer failure fallback, individual-view-call failure fallback, and empty-input guard (`app/pages/Validators/Delegation/hooks/validatorDataService.test.ts`).
- [x] `docs/FEATURES_SPECIFICATION.md` updated: `FEAT-VALIDATORS-003` now documents the loading-independence contract and the indexer-first batching strategy; Appendix B lists the new test file.
- [x] `CHANGELOG.md` — entry added under `[Unreleased] → Fixed`.
- [x] No route / tab changes, so `llms.txt`, `llms-full.txt`, `sitemap.xml`, and the agent-skills index are untouched.
- [x] No Netlify Edge Functions added.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed6c5da7-d133-4957-b051-95a2f6db40bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed6c5da7-d133-4957-b051-95a2f6db40bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

