### PR TITLE
chore(ci): remove Playwright smoke tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
 
-      - name: Install Playwright Chromium
-        run: pnpm test:e2e:install
-
-      - name: Playwright smoke tests
-        run: pnpm exec playwright test
+      # Playwright smoke tests are intentionally excluded from CI — they require
+      # installing a full Chromium binary and running against a vite preview build,
+      # making them too expensive for per-PR runs. Run them locally with:
+      #   pnpm test:e2e:install && pnpm test:e2e


### PR DESCRIPTION
## Summary

- Removes the `Install Playwright Chromium` and `Playwright smoke tests` steps from the CI workflow
- Adds a comment explaining the decision and pointing to the local run commands

## Reason

Playwright requires downloading a full Chromium binary (~300MB) and running against a `vite preview` production build, making it too expensive for per-PR CI runs. E2E smoke tests should be run locally before pushing:

```
pnpm test:e2e:install && pnpm test:e2e
```

## Test plan

- [ ] Verify CI passes without the Playwright steps
- [ ] Confirm `pnpm test:e2e` still works locally