### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -7,10 +7,10 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .node-version
         cache: pnpm
@@ -21,4 +21,4 @@ runs:
       run: echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aptos-labs/*" >> "${GITHUB_ENV}"
 
     - name: Setup AikidoSec Safe Chain
-      uses: aptos-labs/actions/aikidosec-safe-chain@fdd3a3a628c840d5c35086a87e9cc3141b635505 # pin@main
+      uses: aptos-labs/actions/aikidosec-safe-chain@fdd3a3a628c840d5c35086a87e9cc3141b635505 # main (2026-05-20)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       APTOS_DEVNET_API_KEY: ${{ secrets.APTOS_DEVNET_API_KEY }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -37,7 +37,7 @@ jobs:
         run: pnpm ci:verify
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pins all third-party GitHub Actions to immutable commit SHAs instead of mutable version tags, using the latest release on each major line that is at least 3 days old (cutoff: 2026-06-29).

## Changes

| Action | Previous | Pinned SHA | Version |
|--------|----------|------------|---------|
| `actions/checkout` | `@v7` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | v7.0.0 |
| `codecov/codecov-action` | `@v7` | `fb8b3582c8e4def4969c97caa2f19720cb33a72f` | v7.0.0 |
| `pnpm/action-setup` | `@v6` | `0ebf47130e4866e96fce0953f49152a61190b271` | v6.0.9 |
| `actions/setup-node` | `@v6` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `aptos-labs/actions/aikidosec-safe-chain` | already pinned | `fdd3a3a628c840d5c35086a87e9cc3141b635505` | main (2026-05-20) |

## Files updated

- `.github/workflows/ci.yml`
- `.github/workflows/lint-and-test.yaml`
- `.github/actions/setup-node-pnpm/action.yaml`

Local composite actions (`./.github/actions/setup-node-pnpm`) are unchanged — only their upstream dependencies were pinned.

## Rationale

SHA pinning prevents tag-moving supply-chain attacks where a compromised maintainer retargets a semver tag to a malicious commit. The 3-day age gate allows recent releases to stabilize before adoption.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22a0-1f23-7f09-b747-933072170c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22a0-1f23-7f09-b747-933072170c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

