### PR TITLE
docs(env): align .env.example with VITE_APTOS_*_URL overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,21 @@
 # NETWORK CONFIGURATION
 # ============================================================================
 
-# Custom devnet URL (optional)
-# Default: https://api.devnet.staging.aptoslabs.com/v1
+# Per-network fullnode REST URL overrides (client bundle). Must be VITE_-prefixed:
+# vite.config.ts envPrefix only injects VITE_/REACT_APP_ into import.meta.env.
+# Leave unset to use the hardcoded defaults in app/lib/constants.ts.
+# Baked in at build time — restart the dev server / rebuild after changing.
+#
+# Note: API keys are still selected by network name. Overriding a URL to a
+# non-gateway host will still send that network's Authorization header to it.
+# VITE_APTOS_MAINNET_URL=https://api.mainnet.aptoslabs.com/v1
+# VITE_APTOS_TESTNET_URL=https://api.testnet.staging.aptoslabs.com/v1
+# VITE_APTOS_DEVNET_URL=https://api.devnet.staging.aptoslabs.com/v1
+# VITE_APTOS_DECIBEL_URL=https://api.netna.aptoslabs.com/v1
+# VITE_APTOS_SHELBYNET_URL=https://api.shelbynet.staging.shelby.xyz/v1
+# VITE_APTOS_LOCAL_URL=http://127.0.0.1:8080/v1
+#
+# Deprecated alias for VITE_APTOS_DEVNET_URL — never injected by Vite's envPrefix.
 # APTOS_DEVNET_URL=https://api.devnet.staging.aptoslabs.com/v1
 
 # ============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,9 +454,12 @@ Copy `.env.example` to `.env.local` and uncomment the variables you need. Common
 # APTOS_TESTNET_API_KEY=AG-...
 
 # Per-network fullnode REST URL overrides (client bundle). Must be VITE_-prefixed.
+# API keys remain keyed by network name even when the URL is overridden.
 # VITE_APTOS_MAINNET_URL=https://api.mainnet.aptoslabs.com/v1
 # VITE_APTOS_TESTNET_URL=https://api.testnet.staging.aptoslabs.com/v1
 # VITE_APTOS_DEVNET_URL=https://api.devnet.staging.aptoslabs.com/v1
+# VITE_APTOS_DECIBEL_URL=https://api.netna.aptoslabs.com/v1
+# VITE_APTOS_SHELBYNET_URL=https://api.shelbynet.staging.shelby.xyz/v1
 # VITE_APTOS_LOCAL_URL=http://127.0.0.1:8080/v1
 
 # Optional custom endpoints / analytics.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Suggestion commit for #1708: update `.env.example` (and complete the matching `AGENTS.md` examples) so they document the working `VITE_APTOS_*_URL` overrides instead of only the dead `APTOS_DEVNET_URL` alias.

## Why

PR #1708 notes that `.env.example` couldn't be edited due to a local tooling restriction. Without this, copy-paste from `.env.example` still points operators at a variable Vite never injects.

## Changes

- Replace the single `APTOS_DEVNET_URL` example with the full `VITE_APTOS_{MAINNET,TESTNET,DEVNET,DECIBEL,SHELBYNET,LOCAL}_URL` set
- Keep `APTOS_DEVNET_URL` as a commented deprecated alias
- Note that API keys remain keyed by network name when a URL is overridden (same caveat called out in #1708)
- Add missing `DECIBEL` / `SHELBYNET` URL lines in `AGENTS.md` so they match `constants.ts` / `.env.example`

## Base

Targets `fix/network-url-env-overrides` so it can be merged into #1708.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a012ba-a5d4-787a-9887-22ef940f6fdd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a012ba-a5d4-787a-9887-22ef940f6fdd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

