### PR TITLE
feat(verification): add Labs verified Near WBTC (NBTC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Labs verified token**: Near WBTC fungible asset (`NBTC`, metadata object `0x0b0b…e8e0` on mainnet) is included in the explorer manual verification list, known-address labels, and coin metadata merge so it shows the Labs verified badge and Near Intents branding where supported. Community listing still goes through the [Panora token list](https://github.com/PanoraExchange/Aptos-Tokens).
 - **Agent discovery — A2A card, auth.md, RFC 9728 PRM**: Published `/.well-known/agent-card.json` (A2A skill/capability card aligned with WebMCP tools; no JSON-RPC task endpoint), `/auth.md` (public site; no agent registration or OAuth Authorization Server), and `/.well-known/oauth-protected-resource` with empty `authorization_servers`. Homepage/SSR `Link` headers, `sitemap.xml`, and `llms*.txt` advertise the new files.
 
 - **Per-network fullnode URL overrides**: Every network in `app/lib/constants.ts` can now have its REST endpoint overridden at build time via `VITE_APTOS_<NETWORK>_URL` (`MAINNET`, `TESTNET`, `DEVNET`, `DECIBEL`, `SHELBYNET`, `LOCAL`). Previously only devnet was overridable. Trailing slashes are stripped as before.

--- a/app/components/Table/verifiedLevel.test.ts
+++ b/app/components/Table/verifiedLevel.test.ts
@@ -5,6 +5,8 @@ import {VerifiedType, verifiedLevel} from "./VerifiedCell";
 
 const USDCBL_FA =
   "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0";
+const NBTC_FA =
+  "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0";
 
 describe("FEAT-COIN-003 / FEAT-UI-002 — verifiedLevel", () => {
   it("returns NATIVE_TOKEN for APT", () => {
@@ -95,6 +97,13 @@ describe("FEAT-COIN-003 / FEAT-UI-002 — verifiedLevel", () => {
   it("returns LABS_VERIFIED for manually listed usDCBL fungible asset", () => {
     expect(manuallyVerifiedTokens[USDCBL_FA]).toBe("usDCBL");
     const result = verifiedLevel({id: USDCBL_FA, known: false}, "mainnet");
+    expect(result.level).toBe(VerifiedType.LABS_VERIFIED);
+  });
+
+  it("returns LABS_VERIFIED for manually listed Near WBTC fungible asset", () => {
+    // Covers FEAT-COIN-003 — Labs verified Near WBTC (NBTC)
+    expect(manuallyVerifiedTokens[NBTC_FA]).toBe("NBTC");
+    const result = verifiedLevel({id: NBTC_FA, known: false}, "mainnet");
     expect(result.level).toBe(VerifiedType.LABS_VERIFIED);
   });
 });

--- a/app/data/knownAddresses.test.ts
+++ b/app/data/knownAddresses.test.ts
@@ -32,6 +32,16 @@ describe("FEAT-DATA-002 — Known address system", () => {
       expect(addresses[fullAddr]).toBeDefined();
     });
 
+    it("includes Near WBTC fungible asset metadata object on mainnet", () => {
+      // Covers FEAT-DATA-002 — known address label for Labs-verified NBTC
+      const addresses = getKnownAddresses("mainnet");
+      expect(
+        addresses[
+          "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0"
+        ],
+      ).toBe("Near WBTC (NBTC)");
+    });
+
     it("falls back to mainnet data for unknown networks", () => {
       const mainnetData = getNetworkData("mainnet");
       const unknownData = getNetworkData("local");

--- a/app/data/mainnet/assets.ts
+++ b/app/data/mainnet/assets.ts
@@ -529,6 +529,30 @@ export const mainnetHardCodedCoins: Record<string, CoinDescription> = {
     usdPrice: null,
     panoraTags: ["Verified"],
   },
+  "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0": {
+    chainId: 1,
+    tokenAddress: null,
+    faAddress:
+      "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0",
+    name: "Near WBTC",
+    symbol: "NBTC",
+    decimals: 8,
+    panoraSymbol: null,
+    bridge: null,
+    logoUrl:
+      "https://coin-images.coingecko.com/coins/images/102175481/large/wbtc.png",
+    websiteUrl: "https://near-intents.org",
+    category: "Bridged",
+    isInPanoraTokenList: false,
+    isBanned: false,
+    panoraOrderIndex: 999999997,
+    panoraIndex: 999999997,
+    coinGeckoId: "near-intents-bridged-wbtc",
+    coinMarketCapId: null,
+    panoraUI: false,
+    usdPrice: null,
+    panoraTags: ["Bridged", "Verified"],
+  },
 };
 
 /**
@@ -581,6 +605,7 @@ export const mainnetVerifiedTokens: Record<string, string> = {
     "PROPS",
   "0x96401f1e3ab3245d056d5a1ba67eef066ac3edc4d5f1b16adc5d567e79a845b0":
     "usDCBL",
+  "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0": "NBTC",
 };
 
 /**

--- a/app/data/mainnet/assets.ts
+++ b/app/data/mainnet/assets.ts
@@ -541,7 +541,7 @@ export const mainnetHardCodedCoins: Record<string, CoinDescription> = {
     bridge: null,
     logoUrl:
       "https://coin-images.coingecko.com/coins/images/102175481/large/wbtc.png",
-    websiteUrl: "https://near-intents.org",
+    websiteUrl: "https://near.com",
     category: "Bridged",
     isInPanoraTokenList: false,
     isBanned: false,

--- a/app/data/mainnet/knownAddresses.ts
+++ b/app/data/mainnet/knownAddresses.ts
@@ -309,6 +309,8 @@ export const mainnetKnownAddresses: Record<string, string> = {
   "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b": "USDC",
   "0xe5c5befe31ce06bc1f2fd31210988aac08af6d821b039935557a6f14c03471be":
     "USDC contract",
+  "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0":
+    "Near WBTC (NBTC)",
 
   // Other
   "0x7e783b349d3e89cf5931af376ebeadbfab855b3fa239b7ada8f5a92fbea6b387": "Pyth", // oracle


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds Labs verification for Near WBTC (`NBTC`) on Aptos mainnet so the fungible asset shows as verified in the explorer.

On-chain metadata for [`0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0`](https://explorer.aptoslabs.com/fungible_asset/0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0/info?network=mainnet):

- Name: Near WBTC
- Symbol: NBTC
- Decimals: 8

This PR:

- Adds the FA to `mainnetVerifiedTokens` (Labs Verified badge)
- Adds hardcoded coin metadata (CoinGecko logo/id, website `https://near.com`) so branding works before Panora lists it
- Labels the metadata object in `mainnetKnownAddresses`
- Covers the lookup with unit tests

### Panora token list

Community verification is a separate PR to [PanoraExchange/Aptos-Tokens](https://github.com/PanoraExchange/Aptos-Tokens) (`submit-token-request.ts` + `logos/NBTC.png`). This agent cannot fork or open PRs in that org (GitHub 403). Payload to paste:

```ts
const requestList: SubmitTokenRequestInfo[] = [
  {
    chainId: 1,
    tokenAddress: null,
    faAddress: "0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0",
    name: "Near WBTC",
    symbol: "NBTC",
    decimals: 8,
    logoUrl: "https://raw.githubusercontent.com/PanoraExchange/Aptos-Tokens/main/logos/NBTC.png",
    websiteUrl: "https://near.com",
    coinGeckoId: "near-intents-bridged-wbtc",
    coinMarketCapId: null,
  },
]
```

Logo: copy `logos/WBTC.png` to `logos/NBTC.png` (or use the CoinGecko WBTC image). Tweet `@PanoraExchange` after opening the PR, per their README.

### Related Links

- Slack request in `#decibel-execution` (Near BTC on Aptos mainnet)
- Asset: https://explorer.aptoslabs.com/fungible_asset/0x0b0b819dcf8d9517ed14195a95adfae6a49bfdb49de33a532ca0aa7ee588e8e0/info?network=mainnet
- Verification instructions: https://explorer.aptoslabs.com/verification?network=mainnet

### Checklist

- [x] Labs verified list + hardcoded coin metadata
- [x] Known-address label
- [x] Unit tests for `verifiedLevel` / known addresses (`pnpm test --run` on those files: 21 passed)
- [ ] Panora token-list PR (blocked here; needs a fork of PanoraExchange/Aptos-Tokens)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C08AGURHMK8/p1787096164800629?thread_ts=1787096164.800629&cid=C08AGURHMK8)

<div><a href="https://cursor.com/agents/bc-b65f188e-a7f7-56df-b04e-a9ed7ac1f796?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b65f188e-a7f7-56df-b04e-a9ed7ac1f796&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

