### PR TITLE
feat(txn): load pruned transaction pages from the indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pruned transaction pages load from the indexer**: `/txn/{version}` (and per-row transaction tables / CSV export) no longer die with "not found" when the fullnode has pruned that ledger version. After REST 410/404 (the SDK still retries against the node's advertised archival endpoint first), the explorer reconstructs the transaction from indexer GraphQL (`user_transactions`, signatures, FA gas-fee activity, table items). Indexer-sourced pages show an info alert because payload arguments, events, and hashes may be missing; Balance Change still uses the existing indexer query.
+
 - **Vercel Web Analytics**: The explorer now loads `@vercel/analytics` from the root layout so production Vercel deployments report page views. Entity URLs are redacted to route templates (addresses, transaction hashes, and search text are not sent). Enable **Web Analytics** on the Vercel project (Analytics tab) after deploy — the package logs a console hint if the insights script 404s because the feature is still off. The PWA service worker does not cache `/_vercel/insights` or the debug script host.
 - **Vercel Speed Insights**: `@vercel/speed-insights` is mounted next to Web Analytics. Real-user vitals are grouped by redacted route templates (not raw account/txn IDs). Enable **Speed Insights** on the Vercel project so `/_vercel/speed-insights` is served after the next deploy.
 

--- a/app/api/client.test.ts
+++ b/app/api/client.test.ts
@@ -35,6 +35,15 @@ describe("withResponseError", () => {
     expect(emitRateLimit).not.toHaveBeenCalled();
   });
 
+  it("maps 410 Gone (pruned ledger) to NOT_FOUND", async () => {
+    const error = {status: 410, statusText: "Gone"};
+    await expect(withResponseError(Promise.reject(error))).rejects.toEqual({
+      type: ResponseErrorType.NOT_FOUND,
+      message: "Transaction has been pruned from the fullnode.",
+    });
+    expect(emitRateLimit).not.toHaveBeenCalled();
+  });
+
   it("does not emit on generic errors", async () => {
     const error = new Error("Network error");
     await expect(withResponseError(Promise.reject(error))).rejects.toEqual({

--- a/app/api/client.transaction.test.ts
+++ b/app/api/client.transaction.test.ts
@@ -1,0 +1,85 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {getTransaction} from "./client";
+import {isIndexerSourced} from "./indexerTransaction";
+
+// Covers FEAT-TXN-014 — REST prune → indexer reconstruction
+
+const indexerUserTxn = {
+  version: "685",
+  sender: "0x1",
+  sequence_number: 0,
+  max_gas_amount: 1,
+  gas_unit_price: 100,
+  expiration_timestamp_secs: "2022-10-12T21:26:49",
+  timestamp: "2022-10-12T21:26:20.299882",
+  entry_function_id_str: "0x1::coin::transfer",
+};
+
+describe("getTransaction indexer fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the fullnode transaction when REST succeeds", async () => {
+    const restTxn = {type: "user_transaction", version: "10", hash: "0xabc"};
+    const client = {
+      getTransactionByVersion: vi.fn().mockResolvedValue(restTxn),
+      queryIndexer: vi.fn(),
+    };
+
+    const result = await getTransaction("10", client as never);
+    expect(result).toEqual(restTxn);
+    expect(client.queryIndexer).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs from the indexer when REST reports the version as pruned", async () => {
+    const client = {
+      getTransactionByVersion: vi.fn().mockRejectedValue({
+        status: 410,
+        data: {error_code: "version_pruned"},
+        message: "Ledger version(685) has been pruned",
+      }),
+      queryIndexer: vi.fn().mockResolvedValue({
+        user_transactions: [indexerUserTxn],
+        fungible_asset_activities: [
+          {amount: 200, is_gas_fee: true, is_transaction_success: true},
+        ],
+      }),
+    };
+
+    const result = await getTransaction("685", client as never);
+    expect(result.type).toBe("user_transaction");
+    expect(isIndexerSourced(result)).toBe(true);
+    expect("gas_used" in result && result.gas_used).toBe("2");
+    expect(client.queryIndexer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not query the indexer for non-prune errors", async () => {
+    const client = {
+      getTransactionByVersion: vi.fn().mockRejectedValue({
+        status: 500,
+        message: "internal",
+      }),
+      queryIndexer: vi.fn(),
+    };
+
+    await expect(getTransaction("685", client as never)).rejects.toMatchObject({
+      type: "Unhandled",
+    });
+    expect(client.queryIndexer).not.toHaveBeenCalled();
+  });
+
+  it("surfaces NOT_FOUND when both REST and the indexer miss", async () => {
+    const client = {
+      getTransactionByHash: vi.fn().mockRejectedValue({status: 404}),
+      queryIndexer: vi.fn(),
+    };
+
+    await expect(
+      getTransaction("0xdead", client as never),
+    ).rejects.toMatchObject({
+      type: "Not Found",
+    });
+    expect(client.queryIndexer).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -1,5 +1,8 @@
 import type {Aptos} from "@aptos-labs/ts-sdk";
 import {emitRateLimit} from "../context/rate-limit/rateLimitEvents";
+import {getTransactionFromIndexer} from "./indexerTransaction";
+import {isPrunedOrNotFoundError} from "./prunedTransaction";
+import type {Types} from "~/types/aptos";
 
 export enum ResponseErrorType {
   NOT_FOUND = "Not Found",
@@ -26,8 +29,14 @@ export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
     // Handle Response objects (fetch API errors)
     if (typeof error === "object" && error !== null && "status" in error) {
       const response = error as Response;
-      if (response.status === 404) {
-        throw {type: ResponseErrorType.NOT_FOUND};
+      if (response.status === 404 || response.status === 410) {
+        throw {
+          type: ResponseErrorType.NOT_FOUND,
+          message:
+            response.status === 410
+              ? "Transaction has been pruned from the fullnode."
+              : undefined,
+        };
       }
       if (response.status === 429) {
         emitRateLimit();
@@ -81,19 +90,49 @@ export function isRateLimitError(error: unknown): boolean {
   return false;
 }
 
-/**
- * Fetch transaction by hash or version
- */
-export async function getTransaction(txnHashOrVersion: string, client: Aptos) {
-  // Check if it's a version (all digits) or hash
+async function fetchTransactionFromFullnode(
+  txnHashOrVersion: string,
+  client: Aptos,
+): Promise<Types.Transaction> {
   if (/^\d+$/.test(txnHashOrVersion)) {
-    return withResponseError(
-      client.getTransactionByVersion({ledgerVersion: BigInt(txnHashOrVersion)}),
-    );
+    const txn = await client.getTransactionByVersion({
+      ledgerVersion: BigInt(txnHashOrVersion),
+    });
+    return txn as unknown as Types.Transaction;
   }
-  return withResponseError(
-    client.getTransactionByHash({transactionHash: txnHashOrVersion}),
-  );
+  const txn = await client.getTransactionByHash({
+    transactionHash: txnHashOrVersion,
+  });
+  return txn as unknown as Types.Transaction;
+}
+
+/**
+ * Fetch transaction by hash or version.
+ *
+ * Confirmed txns come from the fullnode REST API (the SDK retries `410 Gone`
+ * against the node's advertised archival endpoint). When that still fails
+ * because the ledger was pruned, reconstruct from indexer GraphQL.
+ */
+export async function getTransaction(
+  txnHashOrVersion: string,
+  client: Aptos,
+): Promise<Types.Transaction> {
+  try {
+    return await fetchTransactionFromFullnode(txnHashOrVersion, client);
+  } catch (error) {
+    if (isPrunedOrNotFoundError(error)) {
+      try {
+        const indexed = await getTransactionFromIndexer(
+          client,
+          txnHashOrVersion,
+        );
+        if (indexed) return indexed;
+      } catch {
+        // Indexer failures should not hide the original REST error.
+      }
+    }
+    return withResponseError(Promise.reject(error));
+  }
 }
 
 /**

--- a/app/api/hooks/useGetObjectRefs.ts
+++ b/app/api/hooks/useGetObjectRefs.ts
@@ -1,12 +1,8 @@
 import {useQuery} from "@tanstack/react-query";
 import type {Types} from "~/types/aptos";
-import {
-  useAptosClient,
-  useNetworkValue,
-  useSdkV2Client,
-} from "../../global-config";
+import {useNetworkValue, useSdkV2Client} from "../../global-config";
 import {tryStandardizeAddress} from "../../utils";
-import {getTransaction} from "../index";
+import {getTransaction} from "../client";
 
 export interface ObjectRefs {
   hasTransferRef: boolean;
@@ -159,7 +155,6 @@ export function useGetObjectRefs(
   const enabled = options?.enabled ?? true;
   const normalizedAddress = tryStandardizeAddress(address);
   const sdkClient = useSdkV2Client();
-  const aptosClient = useAptosClient();
   const networkValue = useNetworkValue();
 
   const {
@@ -199,10 +194,7 @@ export function useGetObjectRefs(
         return NO_REFS;
       }
 
-      const tx = await getTransaction(
-        {txnHashOrVersion: creationVersion},
-        aptosClient,
-      );
+      const tx = await getTransaction(String(creationVersion), sdkClient);
       const refs = detectRefsInTransaction(tx, normalizedAddress);
 
       return {

--- a/app/api/hooks/useGetTransaction.ts
+++ b/app/api/hooks/useGetTransaction.ts
@@ -1,16 +1,16 @@
 import {useQuery} from "@tanstack/react-query";
 import type {Types} from "~/types/aptos";
-import {useAptosClient, useNetworkValue} from "../../global-config";
+import {useNetworkValue, useSdkV2Client} from "../../global-config";
 import type {ResponseError} from "../client";
-import {getTransaction} from "../index";
+import {getTransaction} from "../client";
 
 export function useGetTransaction(txnHashOrVersion: string) {
   const networkValue = useNetworkValue();
-  const aptosClient = useAptosClient();
+  const aptosClient = useSdkV2Client();
 
   return useQuery<Types.Transaction, ResponseError>({
     queryKey: ["transaction", {txnHashOrVersion}, networkValue],
-    queryFn: () => getTransaction({txnHashOrVersion}, aptosClient),
+    queryFn: () => getTransaction(txnHashOrVersion, aptosClient),
     // Transaction data is static once confirmed - cache for 1 hour
     staleTime: 60 * 60 * 1000,
     gcTime: 24 * 60 * 60 * 1000, // Keep in cache for 24 hours

--- a/app/api/indexerTransaction.test.ts
+++ b/app/api/indexerTransaction.test.ts
@@ -1,0 +1,220 @@
+import {describe, expect, it, vi} from "vitest";
+import {
+  getTransactionFromIndexer,
+  indexerTimestampToMicros,
+  indexerTimestampToUnixSeconds,
+  isIndexerSourced,
+  mapIndexerBlockMetadataTransaction,
+  mapIndexerTransactionResult,
+  mapIndexerUserTransaction,
+} from "./indexerTransaction";
+
+// Covers FEAT-TXN-014 — reconstruct pruned transactions from indexer GraphQL
+
+describe("indexerTimestampToMicros", () => {
+  it("converts indexer ISO timestamps to REST microsecond strings", () => {
+    // Mainnet user txn 685: indexer timestamp vs archival REST `timestamp`
+    expect(indexerTimestampToMicros("2022-10-12T21:26:20.299882")).toBe(
+      "1665609980299882",
+    );
+  });
+
+  it("passes through already-numeric values", () => {
+    expect(indexerTimestampToMicros("1665609980299882")).toBe(
+      "1665609980299882",
+    );
+  });
+
+  it("returns 0 for empty or invalid input", () => {
+    expect(indexerTimestampToMicros("")).toBe("0");
+    expect(indexerTimestampToMicros("not-a-date")).toBe("0");
+  });
+});
+
+describe("indexerTimestampToUnixSeconds", () => {
+  it("converts expiration timestamps to unix seconds", () => {
+    expect(indexerTimestampToUnixSeconds("2022-10-12T21:26:49")).toBe(
+      "1665610009",
+    );
+  });
+});
+
+describe("mapIndexerUserTransaction", () => {
+  const row = {
+    version: 685,
+    sender:
+      "0xfda457fe15be3102b748877e674b4b076b06e4c13e8eaf4d817b5baa77889bf9",
+    sequence_number: 0,
+    max_gas_amount: 861,
+    gas_unit_price: 100,
+    expiration_timestamp_secs: "2022-10-12T21:26:49",
+    timestamp: "2022-10-12T21:26:20.299882",
+    entry_function_id_str: "0x1::stake::update_network_and_fullnode_addresses",
+    signature: {
+      type: "ed25519_signature",
+      signer:
+        "0xfda457fe15be3102b748877e674b4b076b06e4c13e8eaf4d817b5baa77889bf9",
+      public_key:
+        "0x52c68c2ebe3fde3e479d7b04f486745245984daee3411ac1218cf123348603fd",
+      signature: "0xabc",
+      is_sender_primary: true,
+    },
+  };
+
+  it("maps user txn fields and derives gas_used from the FA gas-fee row", () => {
+    const txn = mapIndexerUserTransaction(row, {
+      activities: [
+        {
+          amount: 57400,
+          is_gas_fee: true,
+          is_transaction_success: true,
+          gas_fee_payer_address: null,
+        },
+      ],
+      tableItems: [
+        {
+          key: "0x06ab",
+          table_handle: "0x1b85",
+          decoded_key: "0x06ab",
+          decoded_value: "100",
+          write_set_change_index: 4,
+        },
+      ],
+    });
+
+    expect(txn.type).toBe("user_transaction");
+    expect(txn.version).toBe("685");
+    expect(txn.sender).toBe(row.sender);
+    expect(txn.gas_used).toBe("574");
+    expect(txn.success).toBe(true);
+    expect(txn.vm_status).toBe("Executed successfully");
+    expect(txn.timestamp).toBe("1665609980299882");
+    expect(txn.expiration_timestamp_secs).toBe("1665610009");
+    expect(txn.payload).toEqual({
+      type: "entry_function_payload",
+      function: "0x1::stake::update_network_and_fullnode_addresses",
+      type_arguments: [],
+      arguments: [],
+    });
+    expect(txn.signature?.type).toBe("ed25519_signature");
+    expect(txn.changes).toHaveLength(1);
+    expect(txn.changes[0]).toMatchObject({
+      type: "write_table_item",
+      handle: "0x1b85",
+      key: "0x06ab",
+    });
+    expect(isIndexerSourced(txn)).toBe(true);
+  });
+
+  it("records failed execution from the gas-fee activity", () => {
+    const txn = mapIndexerUserTransaction(row, {
+      activities: [
+        {
+          amount: 100,
+          is_gas_fee: true,
+          is_transaction_success: false,
+        },
+      ],
+    });
+    expect(txn.success).toBe(false);
+    expect(txn.vm_status).toBe("Execution failed");
+  });
+
+  it("uses a script payload when entry_function_id_str is missing", () => {
+    const txn = mapIndexerUserTransaction({
+      ...row,
+      entry_function_id_str: null,
+    });
+    expect(txn.payload.type).toBe("script_payload");
+  });
+});
+
+describe("mapIndexerBlockMetadataTransaction", () => {
+  it("maps block metadata rows", () => {
+    const txn = mapIndexerBlockMetadataTransaction({
+      version: 1,
+      block_height: 1,
+      id: "0x014e",
+      epoch: 1,
+      round: 2,
+      proposer: "0x94",
+      timestamp: "2022-10-12T21:22:40.857472",
+      previous_block_votes_bitvec: [0],
+      failed_proposer_indices: [],
+    });
+    expect(txn.type).toBe("block_metadata_transaction");
+    expect(txn.version).toBe("1");
+    expect(txn.proposer).toBe("0x94");
+    expect(txn.round).toBe("2");
+    expect(isIndexerSourced(txn)).toBe(true);
+  });
+});
+
+describe("mapIndexerTransactionResult", () => {
+  it("prefers user_transactions over block metadata", () => {
+    const txn = mapIndexerTransactionResult({
+      user_transactions: [
+        {
+          version: 2,
+          sender: "0x1",
+          sequence_number: 0,
+          max_gas_amount: 1,
+          gas_unit_price: 1,
+          expiration_timestamp_secs: "2022-10-12T21:26:49",
+          timestamp: "2022-10-12T21:26:20.299882",
+          entry_function_id_str: "0x1::coin::transfer",
+        },
+      ],
+      block_metadata_transactions: [
+        {
+          version: 2,
+          timestamp: "2022-10-12T21:26:20.299882",
+          proposer: "0x2",
+        },
+      ],
+    });
+    expect(txn?.type).toBe("user_transaction");
+  });
+
+  it("returns null when the indexer has no matching row", () => {
+    expect(mapIndexerTransactionResult({user_transactions: []})).toBeNull();
+    expect(mapIndexerTransactionResult(null)).toBeNull();
+  });
+});
+
+describe("getTransactionFromIndexer", () => {
+  it("returns null for hash lookups (indexer has no hash column)", async () => {
+    const queryIndexer = vi.fn();
+    const result = await getTransactionFromIndexer({queryIndexer}, "0xabc");
+    expect(result).toBeNull();
+    expect(queryIndexer).not.toHaveBeenCalled();
+  });
+
+  it("queries by version and maps the result", async () => {
+    const queryIndexer = vi.fn().mockResolvedValue({
+      user_transactions: [
+        {
+          version: "685",
+          sender: "0x1",
+          sequence_number: 0,
+          max_gas_amount: 1,
+          gas_unit_price: 100,
+          expiration_timestamp_secs: "2022-10-12T21:26:49",
+          timestamp: "2022-10-12T21:26:20.299882",
+          entry_function_id_str: "0x1::coin::transfer",
+        },
+      ],
+      fungible_asset_activities: [
+        {amount: 200, is_gas_fee: true, is_transaction_success: true},
+      ],
+    });
+
+    const txn = await getTransactionFromIndexer({queryIndexer}, "685");
+    expect(queryIndexer).toHaveBeenCalledTimes(1);
+    expect(queryIndexer.mock.calls[0][0].query.variables).toEqual({
+      version: "685",
+    });
+    expect(txn?.type).toBe("user_transaction");
+    expect(txn && "gas_used" in txn ? txn.gas_used : undefined).toBe("2");
+  });
+});

--- a/app/api/indexerTransaction.ts
+++ b/app/api/indexerTransaction.ts
@@ -1,0 +1,370 @@
+import type {Aptos} from "@aptos-labs/ts-sdk";
+import type {Types} from "~/types/aptos";
+
+/**
+ * Reconstruct a REST-shaped `Types.Transaction` from indexer GraphQL tables.
+ *
+ * The public indexer does not expose `transactions` / `events` / write-set
+ * resources, so this is a best-effort fallback for fullnode-pruned history:
+ * sender, version, function, gas, signature, success (from FA gas fee), and
+ * table-item changes. Hash, events, payload arguments, and resource changes
+ * are omitted when the indexer does not have them.
+ */
+
+const INDEXER_SOURCE = Symbol.for("aptos-explorer.indexerTransaction");
+
+export function markIndexerSourced<T extends object>(transaction: T): T {
+  Object.defineProperty(transaction, INDEXER_SOURCE, {
+    value: true,
+    enumerable: false,
+  });
+  return transaction;
+}
+
+export function isIndexerSourced(transaction: object): boolean {
+  return Boolean((transaction as Record<symbol, unknown>)[INDEXER_SOURCE]);
+}
+
+export function indexerTimestampToMicros(timestamp: string): string {
+  const trimmed = timestamp.trim();
+  if (!trimmed) return "0";
+  if (/^\d+$/.test(trimmed)) return trimmed;
+
+  const core = trimmed.replace(/(?:Z|[+-]\d{2}:?\d{2})$/i, "");
+  const [dateTime, fracRaw = ""] = core.split(".");
+  const ms = Date.parse(`${dateTime}Z`);
+  if (Number.isNaN(ms)) return "0";
+  const frac = fracRaw.replace(/\D/g, "").padEnd(6, "0").slice(0, 6);
+  return String(ms * 1000 + Number(frac));
+}
+
+export function indexerTimestampToUnixSeconds(timestamp: string): string {
+  const trimmed = timestamp.trim();
+  if (!trimmed) return "0";
+  if (/^\d+$/.test(trimmed)) return trimmed;
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(trimmed);
+  const ms = Date.parse(hasZone ? trimmed : `${trimmed}Z`);
+  if (Number.isNaN(ms)) return "0";
+  return String(Math.floor(ms / 1000));
+}
+
+function asString(value: unknown, fallback = "0"): string {
+  if (value === null || value === undefined || value === "") return fallback;
+  return String(value);
+}
+
+export type IndexerSignatureRow = {
+  type: string;
+  signer: string;
+  public_key: string;
+  signature: string;
+  is_sender_primary: boolean;
+  public_key_type?: string | null;
+  any_signature_type?: string | null;
+  function_info?: string | null;
+  threshold?: number | string | null;
+  public_key_indices?: unknown;
+};
+
+export type IndexerUserTransactionRow = {
+  version: number | string;
+  sender: string;
+  sequence_number: number | string;
+  max_gas_amount: number | string;
+  gas_unit_price: number | string;
+  expiration_timestamp_secs: string;
+  timestamp: string;
+  entry_function_id_str?: string | null;
+  block_height?: number | string | null;
+  epoch?: number | string | null;
+  parent_signature_type?: string | null;
+  signature?: IndexerSignatureRow | null;
+};
+
+export type IndexerBlockMetadataRow = {
+  version: number | string;
+  block_height?: number | string | null;
+  id?: string | null;
+  epoch?: number | string | null;
+  round?: number | string | null;
+  proposer?: string | null;
+  timestamp: string;
+  previous_block_votes_bitvec?: number[] | null;
+  failed_proposer_indices?: number[] | null;
+};
+
+export type IndexerFungibleAssetActivityRow = {
+  amount?: number | string | null;
+  is_gas_fee?: boolean | null;
+  is_transaction_success?: boolean | null;
+  gas_fee_payer_address?: string | null;
+  event_index?: number | string | null;
+};
+
+export type IndexerTableItemRow = {
+  key: string;
+  table_handle: string;
+  decoded_key?: unknown;
+  decoded_value?: unknown;
+  write_set_change_index?: number | string | null;
+};
+
+export type IndexerTransactionQueryResult = {
+  user_transactions?: IndexerUserTransactionRow[] | null;
+  block_metadata_transactions?: IndexerBlockMetadataRow[] | null;
+  signatures?: IndexerSignatureRow[] | null;
+  fungible_asset_activities?: IndexerFungibleAssetActivityRow[] | null;
+  table_items?: IndexerTableItemRow[] | null;
+};
+
+export const INDEXER_TRANSACTION_BY_VERSION_QUERY = `
+  query TransactionByVersion($version: bigint!) {
+    user_transactions(where: {version: {_eq: $version}}) {
+      version
+      sender
+      sequence_number
+      max_gas_amount
+      gas_unit_price
+      expiration_timestamp_secs
+      timestamp
+      entry_function_id_str
+      block_height
+      epoch
+      parent_signature_type
+      signature {
+        type
+        signer
+        public_key
+        signature
+        is_sender_primary
+        public_key_type
+        any_signature_type
+        function_info
+        threshold
+      }
+    }
+    block_metadata_transactions(where: {version: {_eq: $version}}) {
+      version
+      block_height
+      id
+      epoch
+      round
+      proposer
+      timestamp
+      previous_block_votes_bitvec
+      failed_proposer_indices
+    }
+    signatures(where: {transaction_version: {_eq: $version}}) {
+      type
+      signer
+      public_key
+      signature
+      is_sender_primary
+      public_key_type
+      any_signature_type
+      function_info
+      threshold
+      public_key_indices
+    }
+    fungible_asset_activities(where: {transaction_version: {_eq: $version}}) {
+      amount
+      is_gas_fee
+      is_transaction_success
+      gas_fee_payer_address
+      event_index
+    }
+    table_items(where: {transaction_version: {_eq: $version}}) {
+      key
+      table_handle
+      decoded_key
+      decoded_value
+      write_set_change_index
+    }
+  }
+`;
+
+function payloadFromEntryFunction(
+  entryFunctionId: string | null | undefined,
+): Types.TransactionPayload {
+  if (!entryFunctionId) {
+    return {
+      type: "script_payload",
+      code: {bytecode: "0x"},
+      type_arguments: [],
+      arguments: [],
+    };
+  }
+  return {
+    type: "entry_function_payload",
+    function: entryFunctionId,
+    type_arguments: [],
+    arguments: [],
+  };
+}
+
+function mapSignature(
+  row: IndexerSignatureRow | null | undefined,
+  feePayerAddress?: string | null,
+): Types.TransactionSignature | undefined {
+  if (!row) return undefined;
+  const mapped: Types.TransactionSignature = {
+    type: row.type || "ed25519_signature",
+    public_key: row.public_key,
+    signature: row.signature,
+  };
+  if (feePayerAddress) {
+    mapped.fee_payer_address = feePayerAddress;
+  }
+  return mapped;
+}
+
+function tableItemChanges(
+  rows: IndexerTableItemRow[] | null | undefined,
+): Types.WriteSetChange[] {
+  if (!rows?.length) return [];
+  const sorted = [...rows].sort(
+    (a, b) =>
+      Number(a.write_set_change_index ?? 0) -
+      Number(b.write_set_change_index ?? 0),
+  );
+  return sorted.map((row) => ({
+    type: "write_table_item" as const,
+    state_key_hash: "",
+    handle: row.table_handle,
+    key: row.key,
+    value: "",
+    data: {
+      key: row.decoded_key,
+      key_type: "",
+      value: row.decoded_value,
+      value_type: "",
+    },
+  }));
+}
+
+function gasUsedFromActivities(
+  activities: IndexerFungibleAssetActivityRow[] | null | undefined,
+  gasUnitPrice: string,
+): {gasUsed: string; success: boolean; feePayer?: string} {
+  const gasFee = activities?.find((a) => a.is_gas_fee);
+  const success = gasFee?.is_transaction_success ?? true;
+  const feePayer = gasFee?.gas_fee_payer_address || undefined;
+  const price = BigInt(gasUnitPrice || "0");
+  const feeOctas = BigInt(asString(gasFee?.amount, "0"));
+  if (price > 0n && feeOctas > 0n) {
+    return {gasUsed: (feeOctas / price).toString(), success, feePayer};
+  }
+  return {gasUsed: "0", success, feePayer};
+}
+
+export function mapIndexerUserTransaction(
+  row: IndexerUserTransactionRow,
+  extras?: {
+    signatures?: IndexerSignatureRow[] | null;
+    activities?: IndexerFungibleAssetActivityRow[] | null;
+    tableItems?: IndexerTableItemRow[] | null;
+  },
+): Types.Transaction_UserTransaction {
+  const gasUnitPrice = asString(row.gas_unit_price);
+  const {gasUsed, success, feePayer} = gasUsedFromActivities(
+    extras?.activities,
+    gasUnitPrice,
+  );
+  const primary =
+    extras?.signatures?.find((s) => s.is_sender_primary) ??
+    row.signature ??
+    extras?.signatures?.[0];
+
+  return markIndexerSourced({
+    type: "user_transaction",
+    version: asString(row.version),
+    hash: "",
+    state_change_hash: "",
+    event_root_hash: "",
+    state_checkpoint_hash: null,
+    gas_used: gasUsed,
+    success,
+    vm_status: success ? "Executed successfully" : "Execution failed",
+    accumulator_root_hash: "",
+    changes: tableItemChanges(extras?.tableItems),
+    sender: row.sender,
+    sequence_number: asString(row.sequence_number),
+    max_gas_amount: asString(row.max_gas_amount),
+    gas_unit_price: gasUnitPrice,
+    expiration_timestamp_secs: indexerTimestampToUnixSeconds(
+      asString(row.expiration_timestamp_secs, ""),
+    ),
+    payload: payloadFromEntryFunction(row.entry_function_id_str),
+    signature: mapSignature(primary, feePayer),
+    events: [],
+    timestamp: indexerTimestampToMicros(row.timestamp),
+  });
+}
+
+export function mapIndexerBlockMetadataTransaction(
+  row: IndexerBlockMetadataRow,
+): Types.Transaction_BlockMetadataTransaction {
+  return markIndexerSourced({
+    type: "block_metadata_transaction",
+    version: asString(row.version),
+    hash: "",
+    state_change_hash: "",
+    event_root_hash: "",
+    state_checkpoint_hash: null,
+    gas_used: "0",
+    success: true,
+    vm_status: "Executed successfully",
+    accumulator_root_hash: "",
+    changes: [],
+    id: row.id ?? "",
+    epoch: asString(row.epoch),
+    round: asString(row.round),
+    events: [],
+    previous_block_votes_bitvec: row.previous_block_votes_bitvec ?? [],
+    proposer: row.proposer ?? "",
+    failed_proposer_indices: row.failed_proposer_indices ?? [],
+    timestamp: indexerTimestampToMicros(row.timestamp),
+  });
+}
+
+export function mapIndexerTransactionResult(
+  data: IndexerTransactionQueryResult | null | undefined,
+): Types.Transaction | null {
+  if (!data) return null;
+  const user = data.user_transactions?.[0];
+  if (user) {
+    return mapIndexerUserTransaction(user, {
+      signatures: data.signatures,
+      activities: data.fungible_asset_activities,
+      tableItems: data.table_items,
+    });
+  }
+  const blockMeta = data.block_metadata_transactions?.[0];
+  if (blockMeta) {
+    return mapIndexerBlockMetadataTransaction(blockMeta);
+  }
+  return null;
+}
+
+export type IndexerQueryable = {
+  queryIndexer: Aptos["queryIndexer"];
+};
+
+export async function getTransactionFromIndexer(
+  client: IndexerQueryable,
+  txnHashOrVersion: string,
+): Promise<Types.Transaction | null> {
+  if (!/^\d+$/.test(txnHashOrVersion)) {
+    // The public indexer has no transaction-hash column.
+    return null;
+  }
+
+  const data = await client.queryIndexer<IndexerTransactionQueryResult>({
+    query: {
+      query: INDEXER_TRANSACTION_BY_VERSION_QUERY,
+      variables: {version: txnHashOrVersion},
+    },
+  });
+
+  return mapIndexerTransactionResult(data);
+}

--- a/app/api/legacyClient.test.ts
+++ b/app/api/legacyClient.test.ts
@@ -1,0 +1,57 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {AptosClient} from "./legacyClient";
+
+describe("AptosClient archival 410 retry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("retries pruned reads against the advertised archival endpoint", async () => {
+    const txn = {type: "user_transaction", version: "1", hash: "0x1"};
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("archive.mainnet.aptoslabs.com")) {
+        return {
+          ok: true,
+          json: async () => txn,
+        };
+      }
+      return {
+        ok: false,
+        status: 410,
+        text: async () =>
+          JSON.stringify({
+            error_code: "version_pruned",
+            archival_endpoint: "https://archive.mainnet.aptoslabs.com/v1",
+          }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AptosClient("https://api.mainnet.aptoslabs.com/v1", {
+      HEADERS: {Authorization: "Bearer test"},
+    });
+    const result = await client.getTransactionByVersion(1n);
+    expect(result).toEqual(txn);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const archivalUrl = String(fetchMock.mock.calls[1][0]);
+    expect(archivalUrl).toContain("archive.mainnet.aptoslabs.com");
+    expect(archivalUrl).toContain("/transactions/by_version/1");
+  });
+
+  it("does not retry when no archival_endpoint is advertised", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 410,
+      text: async () => JSON.stringify({error_code: "version_pruned"}),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AptosClient("https://api.mainnet.aptoslabs.com/v1");
+    await expect(client.getTransactionByVersion(1n)).rejects.toMatchObject({
+      status: 410,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/legacyClient.test.ts
+++ b/app/api/legacyClient.test.ts
@@ -1,6 +1,17 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {AptosClient} from "./legacyClient";
 
+/**
+ * Parse a fetched URL and return its hostname for exact-match dispatch.
+ * Using `new URL().hostname === "..."` avoids the "Incomplete URL substring
+ * sanitization" CodeQL pattern that `url.includes("archive.mainnet...")`
+ * triggers — `includes` would also match attacker-controlled URLs like
+ * `https://evil.example/?x=archive.mainnet.aptoslabs.com`.
+ */
+function host(url: string): string {
+  return new URL(url).hostname;
+}
+
 describe("AptosClient archival 410 retry", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -11,7 +22,7 @@ describe("AptosClient archival 410 retry", () => {
     const txn = {type: "user_transaction", version: "1", hash: "0x1"};
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes("archive.mainnet.aptoslabs.com")) {
+      if (host(url) === "archive.mainnet.aptoslabs.com") {
         return {
           ok: true,
           json: async () => txn,
@@ -35,9 +46,9 @@ describe("AptosClient archival 410 retry", () => {
     const result = await client.getTransactionByVersion(1n);
     expect(result).toEqual(txn);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const archivalUrl = String(fetchMock.mock.calls[1][0]);
-    expect(archivalUrl).toContain("archive.mainnet.aptoslabs.com");
-    expect(archivalUrl).toContain("/transactions/by_version/1");
+    const archivalUrl = new URL(String(fetchMock.mock.calls[1][0]));
+    expect(archivalUrl.hostname).toBe("archive.mainnet.aptoslabs.com");
+    expect(archivalUrl.pathname).toBe("/v1/transactions/by_version/1");
   });
 
   it("does not retry when no archival_endpoint is advertised", async () => {

--- a/app/api/legacyClient.ts
+++ b/app/api/legacyClient.ts
@@ -17,6 +17,57 @@ interface AptosClientConfig {
   HEADERS?: Record<string, string>;
 }
 
+const CREDENTIAL_HEADER_NAMES = new Set([
+  "authorization",
+  "cookie",
+  "x-api-key",
+]);
+
+function siteOf(hostname: string): string {
+  return hostname.toLowerCase().split(".").slice(-2).join(".");
+}
+
+function archivalRetryTarget(
+  originUrl: string,
+  body: unknown,
+): {url: string; forwardCredentials: boolean} | undefined {
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as {archival_endpoint?: unknown}).archival_endpoint !==
+      "string"
+  ) {
+    return undefined;
+  }
+  const advertised = (body as {archival_endpoint: string}).archival_endpoint;
+  try {
+    const archivalUrl = new URL(advertised);
+    const origin = new URL(originUrl);
+    if (archivalUrl.protocol !== "https:" && archivalUrl.protocol !== "http:") {
+      return undefined;
+    }
+    if (origin.protocol === "https:" && archivalUrl.protocol !== "https:") {
+      return undefined;
+    }
+    return {
+      url: advertised.replace(/\/+$/, ""),
+      forwardCredentials:
+        siteOf(archivalUrl.hostname) === siteOf(origin.hostname),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+class AptosApiRequestError extends Error {
+  status: number;
+  constructor(status: number, body: string) {
+    super(`Aptos API error ${status}: ${body}`);
+    this.name = "AptosApiRequestError";
+    this.status = status;
+  }
+}
+
 export class AptosClient {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
@@ -33,7 +84,11 @@ export class AptosClient {
   // ------------------------------------------------------------------
   // Helpers
   // ------------------------------------------------------------------
-  private async request<T>(path: string, options?: RequestInit): Promise<T> {
+  private async request<T>(
+    path: string,
+    options?: RequestInit,
+    archivalRetried = false,
+  ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const resp = await fetch(url, {
       ...options,
@@ -42,11 +97,32 @@ export class AptosClient {
         ...((options?.headers as Record<string, string>) ?? {}),
       },
     });
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
-      throw new Error(`Aptos API error ${resp.status}: ${body}`);
+    if (resp.ok) {
+      return resp.json() as Promise<T>;
     }
-    return resp.json() as Promise<T>;
+
+    const body = await resp.text().catch(() => "");
+    if (resp.status === 410 && !archivalRetried) {
+      let parsed: unknown;
+      try {
+        parsed = body ? JSON.parse(body) : undefined;
+      } catch {
+        parsed = undefined;
+      }
+      const target = archivalRetryTarget(url, parsed);
+      if (target) {
+        const headers = target.forwardCredentials
+          ? this.headers
+          : Object.fromEntries(
+              Object.entries(this.headers).filter(
+                ([name]) => !CREDENTIAL_HEADER_NAMES.has(name.toLowerCase()),
+              ),
+            );
+        const archivalClient = new AptosClient(target.url, {HEADERS: headers});
+        return archivalClient.request<T>(path, options, true);
+      }
+    }
+    throw new AptosApiRequestError(resp.status, body);
   }
 
   private qs(

--- a/app/api/prunedTransaction.test.ts
+++ b/app/api/prunedTransaction.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from "vitest";
+import {isPrunedOrNotFoundError} from "./prunedTransaction";
+
+// Covers FEAT-TXN-014 — detect pruned / not-found REST errors for indexer fallback
+
+describe("isPrunedOrNotFoundError", () => {
+  it("matches HTTP 410 and 404 status", () => {
+    expect(isPrunedOrNotFoundError({status: 410})).toBe(true);
+    expect(isPrunedOrNotFoundError({status: 404})).toBe(true);
+    expect(isPrunedOrNotFoundError({status: 500})).toBe(false);
+  });
+
+  it("matches ResponseError NOT_FOUND", () => {
+    expect(isPrunedOrNotFoundError({type: "Not Found"})).toBe(true);
+  });
+
+  it("matches version_pruned error_code on the body or nested data", () => {
+    expect(
+      isPrunedOrNotFoundError({
+        status: 410,
+        data: {error_code: "version_pruned"},
+      }),
+    ).toBe(true);
+    expect(isPrunedOrNotFoundError({error_code: "transaction_not_found"})).toBe(
+      true,
+    );
+  });
+
+  it("matches Aptos API error messages from the legacy REST client", () => {
+    expect(
+      isPrunedOrNotFoundError(
+        new Error(
+          'Aptos API error 410: {"error_code":"version_pruned","message":"Ledger version(1) has been pruned"}',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isPrunedOrNotFoundError(new Error("Request failed: Aptos API error 404")),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(isPrunedOrNotFoundError(new Error("Network error"))).toBe(false);
+    expect(isPrunedOrNotFoundError({status: 429})).toBe(false);
+    expect(isPrunedOrNotFoundError(null)).toBe(false);
+    expect(isPrunedOrNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/app/api/prunedTransaction.ts
+++ b/app/api/prunedTransaction.ts
@@ -1,0 +1,77 @@
+/**
+ * Detects fullnode responses for data that is missing or has been ledger-pruned.
+ * Used to decide when to reconstruct a transaction from the indexer.
+ */
+
+const PRUNED_ERROR_CODES = new Set([
+  "version_pruned",
+  "transaction_pruned",
+  "transaction_not_found",
+]);
+
+function readErrorCode(error: object): string | undefined {
+  if (
+    "data" in error &&
+    typeof (error as {data?: unknown}).data === "object" &&
+    (error as {data?: {error_code?: unknown}}).data !== null
+  ) {
+    const code = (error as {data: {error_code?: unknown}}).data.error_code;
+    if (typeof code === "string") return code;
+  }
+  if (
+    "error_code" in error &&
+    typeof (error as {error_code?: unknown}).error_code === "string"
+  ) {
+    return (error as {error_code: string}).error_code;
+  }
+  return undefined;
+}
+
+function readStatus(error: object): number | undefined {
+  if (
+    "status" in error &&
+    typeof (error as {status?: unknown}).status === "number"
+  ) {
+    return (error as {status: number}).status;
+  }
+  return undefined;
+}
+
+function readMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as {message?: unknown}).message === "string"
+  ) {
+    return (error as {message: string}).message;
+  }
+  return "";
+}
+
+/**
+ * True when a REST / SDK error means the transaction is unknown to this node
+ * or has been pruned from its ledger window (HTTP 404 / 410, or equivalent).
+ */
+export function isPrunedOrNotFoundError(error: unknown): boolean {
+  if (error == null) return false;
+
+  if (typeof error === "object") {
+    const status = readStatus(error);
+    if (status === 404 || status === 410) return true;
+
+    if ("type" in error && (error as {type?: unknown}).type === "Not Found") {
+      return true;
+    }
+
+    const code = readErrorCode(error);
+    if (code && PRUNED_ERROR_CODES.has(code)) return true;
+  }
+
+  const message = readMessage(error);
+  if (!message) return false;
+  return /410\b|404\b|version_pruned|has been pruned|transaction not found|not_found/i.test(
+    message,
+  );
+}

--- a/app/api/v2.ts
+++ b/app/api/v2.ts
@@ -1,8 +1,7 @@
 import {AccountAddress, type Aptos, type Block} from "@aptos-labs/ts-sdk";
 import type {Types} from "~/types/aptos";
-import {isNumeric} from "../pages/utils";
 import {mapWithConcurrencyLimit} from "../utils/mapWithConcurrencyLimit";
-import {withResponseError} from "./client";
+import {getTransaction, withResponseError} from "./client";
 
 /** Avoid bursting dozens of parallel `getBlockByHeight` calls (edge/CDN rate limits). */
 const DEFAULT_BLOCKS_REST_CONCURRENCY = 8;
@@ -132,28 +131,12 @@ export async function getAccountResourceV2(
 }
 
 /**
- * Get transaction using SDK v2
+ * Get transaction using SDK v2, with indexer fallback for pruned history.
  */
 export async function getTransactionV2(
   requestParameters: {txnHashOrVersion: string | number},
   aptos: Aptos,
 ): Promise<Types.Transaction> {
   const {txnHashOrVersion} = requestParameters;
-  if (typeof txnHashOrVersion === "number" || isNumeric(txnHashOrVersion)) {
-    const version =
-      typeof txnHashOrVersion === "number"
-        ? txnHashOrVersion
-        : parseInt(txnHashOrVersion, 10);
-    const txn = await withResponseError(
-      aptos.getTransactionByVersion({ledgerVersion: version}),
-    );
-    // Convert to old format for compatibility
-    return txn as unknown as Types.Transaction;
-  } else {
-    const txn = await withResponseError(
-      aptos.getTransactionByHash({transactionHash: txnHashOrVersion}),
-    );
-    // Convert to old format for compatibility
-    return txn as unknown as Types.Transaction;
-  }
+  return getTransaction(String(txnHashOrVersion), aptos);
 }

--- a/app/pages/Account/Components/AccountAllTransactions.tsx
+++ b/app/pages/Account/Components/AccountAllTransactions.tsx
@@ -10,7 +10,7 @@ import {
 import Box from "@mui/material/Box";
 import React from "react";
 import type {Types} from "~/types/aptos";
-import {getTransaction} from "../../../api";
+import {getTransaction} from "../../../api/client";
 import useFunctionFilter, {
   type FunctionFilterParams,
 } from "../../../api/hooks/useFunctionFilter";
@@ -23,10 +23,7 @@ import {
 import PageNumberPagination, {
   useCurrentPage,
 } from "../../../components/PageNumberPagination";
-import {
-  useAptosClient,
-  useSdkV2Client,
-} from "../../../global-config/GlobalConfig";
+import {useSdkV2Client} from "../../../global-config/GlobalConfig";
 import {tryStandardizeAddress} from "../../../utils";
 import FunctionFilter from "../../Transactions/Components/FunctionFilter";
 import {UserTransactionsTable} from "../../Transactions/TransactionsTable";
@@ -299,7 +296,6 @@ function CSVExportButton({
 }) {
   const [isExporting, setIsExporting] = React.useState(false);
   const [exportProgress, setExportProgress] = React.useState(0);
-  const aptosClient = useAptosClient();
   const logEvent = useLogEventWithBasic();
   const sdkV2Client = useSdkV2Client();
 
@@ -505,10 +501,7 @@ function CSVExportButton({
           try {
             return await retryWithBackoff(
               async () => {
-                return await getTransaction(
-                  {txnHashOrVersion: version},
-                  aptosClient,
-                );
+                return await getTransaction(String(version), sdkV2Client);
               },
               3,
               500,

--- a/app/pages/Transaction/Index.tsx
+++ b/app/pages/Transaction/Index.tsx
@@ -1,31 +1,20 @@
 import {Alert, Grid, Stack} from "@mui/material";
-import {useQuery} from "@tanstack/react-query";
 import {useParams} from "@tanstack/react-router";
-import type {Types} from "~/types/aptos";
-import {getTransaction} from "../../api";
-import type {ResponseError} from "../../api/client";
-import {
-  useAptosClient,
-  useNetworkValue,
-} from "../../global-config/GlobalConfig";
+import {useGetTransaction} from "../../api/hooks/useGetTransaction";
+import {isIndexerSourced} from "../../api/indexerTransaction";
 import PageHeader from "../layout/PageHeader";
 import TransactionError from "./Error";
 import TransactionTabs from "./Tabs";
 import TransactionTitle from "./Title";
 
 export default function TransactionPage() {
-  const networkValue = useNetworkValue();
-  const aptosClient = useAptosClient();
   const params = useParams({strict: false}) as {
     txnHashOrVersion?: string;
     tab?: string;
   };
   const txnHashOrVersion = params?.txnHashOrVersion ?? "";
 
-  const {isLoading, data, error} = useQuery<Types.Transaction, ResponseError>({
-    queryKey: ["transaction", {txnHashOrVersion}, networkValue],
-    queryFn: () => getTransaction({txnHashOrVersion}, aptosClient),
-  });
+  const {isLoading, data, error} = useGetTransaction(txnHashOrVersion);
 
   if (isLoading) {
     return null;
@@ -59,6 +48,14 @@ export default function TransactionPage() {
             marginTop: 2,
           }}
         >
+          {isIndexerSourced(data) && (
+            <Alert severity="info">
+              This transaction was reconstructed from indexer data because the
+              fullnode has pruned it. Payload arguments, events, hashes, and
+              some write-set changes may be missing. Balance changes still load
+              from the indexer when available.
+            </Alert>
+          )}
           <TransactionTitle
             transaction={data}
             urlTxnHashOrVersion={txnHashOrVersion}

--- a/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
+++ b/app/pages/Transaction/Tabs/UserTransactionOverviewTab.tsx
@@ -1036,21 +1036,27 @@ export default function UserTransactionOverviewTab({
           }
           tooltip={getLearnMoreTooltip("signature")}
         />
-        <ContentRow
-          title="State Change Hash:"
-          value={transactionData.state_change_hash}
-          tooltip={getLearnMoreTooltip("state_change_hash")}
-        />
-        <ContentRow
-          title="Event Root Hash:"
-          value={transactionData.event_root_hash}
-          tooltip={getLearnMoreTooltip("event_root_hash")}
-        />
-        <ContentRow
-          title="Accumulator Root Hash:"
-          value={transactionData.accumulator_root_hash}
-          tooltip={getLearnMoreTooltip("accumulator_root_hash")}
-        />
+        {transactionData.state_change_hash ? (
+          <ContentRow
+            title="State Change Hash:"
+            value={transactionData.state_change_hash}
+            tooltip={getLearnMoreTooltip("state_change_hash")}
+          />
+        ) : null}
+        {transactionData.event_root_hash ? (
+          <ContentRow
+            title="Event Root Hash:"
+            value={transactionData.event_root_hash}
+            tooltip={getLearnMoreTooltip("event_root_hash")}
+          />
+        ) : null}
+        {transactionData.accumulator_root_hash ? (
+          <ContentRow
+            title="Accumulator Root Hash:"
+            value={transactionData.accumulator_root_hash}
+            tooltip={getLearnMoreTooltip("accumulator_root_hash")}
+          />
+        ) : null}
       </ContentBox>
     </Box>
   );

--- a/app/pages/Transaction/Title.tsx
+++ b/app/pages/Transaction/Title.tsx
@@ -72,7 +72,13 @@ export default function TransactionTitle({
           />
         )}
       </Stack>
-      <TitleHashButton hash={transaction.hash} type={HashType.TRANSACTION} />
+      {transaction.hash ? (
+        <TitleHashButton hash={transaction.hash} type={HashType.TRANSACTION} />
+      ) : (
+        <Typography variant="body2" sx={{color: "text.secondary"}}>
+          Transaction hash unavailable from indexer
+        </Typography>
+      )}
       <TransactionType type={transaction.type} />
     </Stack>
   );

--- a/docs/FEATURES_SPECIFICATION.md
+++ b/docs/FEATURES_SPECIFICATION.md
@@ -6,7 +6,7 @@
 > code. Tests (unit, integration, E2E) should reference the feature IDs defined
 > here (e.g. `// Covers FEAT-SEARCH-001`).
 >
-> **Last updated**: 2026-08-25
+> **Last updated**: 2026-08-27
 
 ---
 
@@ -293,6 +293,15 @@ Both search surfaces share their input tokens (placeholder, helper text, debounc
 | **Title** | `Transaction/Title.tsx` renders the heading as **"Multisig Transaction"** with a primary outlined **"Multisig"** chip (groups icon) next to the `<h1>` when detected. |
 | **Metadata** | Page `<title>`, description, and keywords (`multisig`, `multi-signature`) reflect multisig transactions. |
 | **Function label** | `TransactionFunction.tsx` renders a styled **"Multisig Transaction"** `CodeLineBox` (groups icon) for multisig executions without an inner entry-function payload. |
+
+### FEAT-TXN-014 — Pruned Transaction Indexer Fallback
+
+| Aspect | Detail |
+|--------|--------|
+| **Trigger** | Fullnode REST `getTransactionByVersion` / `getTransactionByHash` fails with HTTP 404/410 or `version_pruned` (ledger pruning). The SDK still retries `410 Gone` against the node's advertised archival endpoint first, so complete REST-shaped data is used when archive history is available. |
+| **Indexer reconstruction** | If REST (including archival retry) still fails, `getTransaction` queries indexer GraphQL (`user_transactions`, `block_metadata_transactions`, `signatures`, `fungible_asset_activities`, `table_items`) and maps a `Types.Transaction` for `/txn/$txnHashOrVersion` pages, per-row user-transaction tables, CSV export, and object-creation scans. Hash lookup cannot use the indexer (no hash column); those URLs rely on archival REST. |
+| **Mapped fields** | Version, sender, sequence number, timestamps, max gas, gas unit price, entry function id, signature, success + `gas_used` from the FA gas-fee activity, table-item write-set rows. Events, payload arguments, resource changes, and hashes are omitted when the indexer does not store them. |
+| **UI** | Indexer-sourced pages show an info alert that some fields may be missing. Empty transaction hashes and state/event/accumulator hashes are hidden rather than shown blank. Balance Change still loads from `fungible_asset_activities` (FEAT-TXN-003). |
 
 ---
 
@@ -1337,6 +1346,10 @@ top of the HTML site.
 | `app/components/IndividualPageContent/ContentValue/CurrencyValue.test.tsx` | Currency formatting (octa → APT) |
 | `app/components/Table/verifiedLevel.test.ts` | FEAT-COIN-003 / FEAT-UI-002 (verification level determination: native, verified, banned, recognized, unverified, disabled) |
 | `app/pages/Transaction/utils.test.ts` | FEAT-TXN-002/003 (tx amounts, counterparty including decrypted encrypted payloads, balance changes), FEAT-TXN-013 (multisig transaction detection) |
+| `app/api/prunedTransaction.test.ts` | FEAT-TXN-014 (detect 404/410 / `version_pruned` REST errors) |
+| `app/api/indexerTransaction.test.ts` | FEAT-TXN-014 (indexer timestamp conversion; map user / block-metadata rows; hash lookups skipped; gas_used from FA gas fee) |
+| `app/api/client.transaction.test.ts` | FEAT-TXN-014 (`getTransaction` REST success skips indexer; prune falls back to indexer; non-prune errors do not) |
+| `app/api/legacyClient.test.ts` | FEAT-TXN-014 (legacy REST client retries 410 against `archival_endpoint`) |
 | `app/pages/Transaction/Tabs/Components/MultisigEventView.test.tsx` | FEAT-TXN-004 (multisig event detection, formatted summary/rows, v1/v2 name normalization, raw-JSON fallback, extra-field surfacing, payload decoding in execution and CreateTransaction events) |
 | `app/pages/Transaction/Tabs/Components/decodeMultisigPayload.test.ts` | FEAT-TXN-004 (BCS decoding of multisig payload bytes into an entry function; empty/invalid fallbacks) |
 | `app/pages/Transaction/Tabs/Components/decodeMoveArgument.test.ts` | FEAT-TXN-011 / FEAT-TXN-004 (ABI-typed BCS argument decoding: address, ints, bool, String, vector, Object, Option; positional alignment and invalid/leftover fallbacks) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fullnode REST prunes ledger history (mainnet `oldest_ledger_version` is ~150M versions behind the head). `/txn/{old_version}` previously died with 410 `version_pruned` because transaction detail used the legacy REST client, which did not retry the advertised archival endpoint.

This change:

1. Fetches via the SDK (`getTransactionByVersion` / `ByHash`), which already retries `410 Gone` against `archival_endpoint` (full REST-shaped JSON when archive history exists).
2. If REST still reports pruned/not found, reconstructs a `Types.Transaction` from indexer GraphQL (`user_transactions`, `block_metadata_transactions`, `signatures`, `fungible_asset_activities`, `table_items`).
3. Shows an info alert on indexer-sourced pages: payload arguments, events, and hashes may be missing. Balance Change still uses the existing indexer query.
4. Adds the same 410 archival retry to the legacy REST client for remaining call sites.

Hash URLs cannot use the indexer (no hash column) and still rely on archival REST.

Covered by `FEAT-TXN-014`.

### Related Links

Slack `#explorer`: use indexer to retrieve old transactions that are pruned for transaction pages.

### Checklist
- [x] Unit tests for prune detection, indexer mapping, REST→indexer fallback, and legacy 410 retry
- [x] `CHANGELOG.md` [Unreleased]
- [x] `docs/FEATURES_SPECIFICATION.md` (`FEAT-TXN-014`)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C040LV2NWQ4/p1787799581881769?thread_ts=1787799581.881769&cid=C040LV2NWQ4)

<div><a href="https://cursor.com/agents/bc-03b94c66-d844-5228-8972-9575150017bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b94c66-d844-5228-8972-9575150017bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

